### PR TITLE
Make the build of extensions reproducible

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -40,7 +40,7 @@ class Gem::Ext::Builder
 
     destdir = '"DESTDIR=%s"' % ENV['DESTDIR']
 
-    ['clean', '', 'install'].each do |target|
+    ['clean', '', 'install', 'distclean'].each do |target|
       # Pass DESTDIR via command line to override what's in MAKEFLAGS
       cmd = [
         make_program,
@@ -50,7 +50,7 @@ class Gem::Ext::Builder
       begin
         run(cmd, results, "make #{target}".rstrip)
       rescue Gem::InstallError
-        raise unless target == 'clean' # ignore clean failure
+        raise unless %w[clean distclean].include?(target) # ignore clean and distclean failure
       end
     end
   end

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -195,7 +195,6 @@ EOF
         end
       end
 
-      write_gem_make_out results.join "\n"
     rescue => e
       results << e.message
       build_error extension_dir, results.join("\n"), $@

--- a/lib/rubygems/ext/ext_conf_builder.rb
+++ b/lib/rubygems/ext/ext_conf_builder.rb
@@ -52,7 +52,6 @@ class Gem::Ext::ExtConfBuilder < Gem::Ext::Builder
                 " the mkmf.log which can be found here:\n"
               results << "  " + File.join(dest_path, 'mkmf.log') + "\n"
             end
-            FileUtils.mv 'mkmf.log', dest_path
           end
           siteconf.unlink
         end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -115,7 +115,6 @@ install:
 
     assert_path_exists @spec.extension_dir
     assert_path_exists @spec.gem_build_complete_path
-    assert_path_exists File.join @spec.extension_dir, 'gem_make.out'
     assert_path_exists File.join @spec.extension_dir, 'a.rb'
     assert_path_exists File.join @spec.gem_dir, 'lib', 'a.rb'
     assert_path_exists File.join @spec.gem_dir, 'lib', 'a', 'b.rb'
@@ -171,7 +170,6 @@ install:
 
     assert_path_exists @spec.extension_dir
     assert_path_exists @spec.gem_build_complete_path
-    assert_path_exists File.join @spec.extension_dir, 'gem_make.out'
     assert_path_exists File.join @spec.extension_dir, 'a.rb'
     refute_path_exists File.join @spec.gem_dir, 'lib', 'a.rb'
     refute_path_exists File.join @spec.gem_dir, 'lib', 'a', 'b.rb'

--- a/test/rubygems/test_gem_ext_ext_conf_builder.rb
+++ b/test/rubygems/test_gem_ext_ext_conf_builder.rb
@@ -113,7 +113,6 @@ class TestGemExtExtConfBuilder < Gem::TestCase
     assert_match(File.join(@dest_path, 'mkmf.log'), output[4])
     assert_includes(output, "To see why this extension failed to compile, please check the mkmf.log which can be found here:\n")
 
-    assert_path_exists File.join @dest_path, 'mkmf.log'
   end
 
   def test_class_build_extconf_success_without_warning
@@ -135,7 +134,6 @@ class TestGemExtExtConfBuilder < Gem::TestCase
 
     refute_includes(output, "To see why this extension failed to compile, please check the mkmf.log which can be found here:\n")
 
-    assert_path_exists File.join @dest_path, 'mkmf.log'
   end
 
   def test_class_build_unconventional

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1176,9 +1176,6 @@ gem 'other', version
       installer.install
     end
 
-    expected_makefile = File.join Gem.user_dir, 'gems', @spec.full_name, 'Makefile'
-
-    assert_path_exists expected_makefile
     assert_path_exists expected_extension_dir
     refute_path_exists File.join expected_extension_dir, 'gem_make.out'
   end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1642,8 +1642,6 @@ dependencies: []
 
     @ext.build_extensions
 
-    gem_make_out = File.join @ext.extension_dir, 'gem_make.out'
-    assert_path_exists gem_make_out
   end
 
   def test_contains_requirable_file_eh


### PR DESCRIPTION
# Description:

When a package contains extension, the build is not reproducible due to temporary filepaths in some files which are not required at run time. This PR removes all of these files to make the build reproducible (https://reproducible-builds.org).

This PR has been tested on several gems, such as `msgpack`, `strptime`, `yajl-ruby` and all fluentd ruby dependencies.

See also the issue  https://bugs.ruby-lang.org/issues/15304.

cc @nobu 
______________

# Tasks:

- [ ] Describe the problem / feature
- [ ] Write tests
- [x] Write code to solve the problem
- [ ] Get code review from coworkers / friends

I will abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md).
