### PR TITLE
Don't wrap non-ruby executables and explicit no-wrap requests. 

### DIFF
--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -524,6 +524,40 @@ gem 'other', version
                  'real executable overwritten'
   end
 
+  def test_no_wrap_non_ruby_executables
+    skip "Symlinks not supported or not enabled" unless symlink_supported?
+
+    installer = setup_base_installer
+
+    installer.wrappers = true
+    util_make_exec @spec, "#!/usr/bin/env bash"
+    installer.gem_dir = @spec.gem_dir
+
+    installer.generate_bin
+    assert_directory_exists util_inst_bindir
+    installed_exec = File.join util_inst_bindir, 'executable'
+    assert_equal true, File.symlink?(installed_exec)
+    assert_equal(File.join(@spec.gem_dir, 'bin', 'executable'),
+                 File.readlink(installed_exec))
+  end
+
+  def test_no_wrap_explicit_rubygems_no_wrap
+    skip "Symlinks not supported or not enabled" unless symlink_supported?
+
+    installer = setup_base_installer
+
+    installer.wrappers = true
+    util_make_exec @spec, ":: rubygems: no-wrap" # a batch file would likely look like this
+    installer.gem_dir = @spec.gem_dir
+
+    installer.generate_bin
+    assert_directory_exists util_inst_bindir
+    installed_exec = File.join util_inst_bindir, 'executable'
+    assert_equal true, File.symlink?(installed_exec)
+    assert_equal(File.join(@spec.gem_dir, 'bin', 'executable'),
+                 File.readlink(installed_exec))
+  end
+
   def test_generate_bin_symlink
     skip "Symlinks not supported or not enabled" unless symlink_supported?
 


### PR DESCRIPTION
This is still a draft. The functionality is in, but docs are not updated.

## What was the end-user or developer problem that led to this PR?

This is the result of the discussion in #88

In short: apart from checking `@wrappers` the installer performs an additional check before deciding whether to wrap executables:

* Check if the first line is a shebang: 
    * if it is, check if it contains the string 'ruby', 
    * if it doesn't, assume this is not a ruby executable and don't wrap
* If it's not a shebang, check if it contains the magic string 'rubygems: no-wrap'
    * if it does, don't wrap as well. This will be the way to deploy windows batch files
    * if it doesn't contain the magic string, assume it's a shebang-less ruby executable and wrap away

This doesn't break any of the existing tests. I find it highly unlikely that any existing gem will be affected by this

Future gems will be able to provide shell scripts as non-wrapped executables, without requesting the users to explicitly use `--no-wrappers` when installing

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
