### PR TITLE
Respect Gemfile bundler setting in `Bundler.setup`

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -156,6 +156,7 @@ module Bundler
       # Return if all groups are already loaded
       return @setup if defined?(@setup) && @setup
 
+      configure_custom_gemfile
       definition.validate_runtime!
 
       SharedHelpers.print_major_deprecations!
@@ -584,6 +585,15 @@ module Bundler
       configure_gem_path
       configure_gem_home(path)
       Bundler.rubygems.clear_paths
+    end
+
+    def configure_custom_gemfile(custom_gemfile = nil)
+      custom_gemfile ||= Bundler.settings[:gemfile]
+
+      if custom_gemfile && !custom_gemfile.empty?
+        Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", File.expand_path(custom_gemfile)
+        reset_settings_and_root!
+      end
     end
 
     def self_manager

--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -61,11 +61,7 @@ module Bundler
 
       current_cmd = args.last[:current_command].name
 
-      custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
-      if custom_gemfile && !custom_gemfile.empty?
-        Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", File.expand_path(custom_gemfile)
-        reset_settings = true
-      end
+      Bundler.configure_custom_gemfile(options[:gemfile])
 
       # lock --lockfile works differently than install --lockfile
       unless current_cmd == "lock"

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -303,6 +303,25 @@ RSpec.describe "Bundler.setup" do
         expect(out).to eq("WIN")
       end
     end
+
+    context "user sets it via `config set --local gemfile`" do
+      it "uses the value in the config" do
+        gemfile <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem "rack"
+        G
+
+        gemfile bundled_app("gemfake"), <<-G
+          source "#{file_uri_for(gem_repo1)}"
+          gem "activesupport", "2.3.5"
+        G
+
+        bundle "config set --local gemfile #{bundled_app("gemfake")}"
+        bundle "install"
+
+        expect(the_bundle).to include_gems "activesupport 2.3.5"
+      end
+    end
   end
 
   it "prioritizes gems in BUNDLE_PATH over gems in GEM_HOME" do

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -307,19 +307,26 @@ RSpec.describe "Bundler.setup" do
     context "user sets it via `config set --local gemfile`" do
       it "uses the value in the config" do
         gemfile <<-G
-          source "#{file_uri_for(gem_repo1)}"
-          gem "rack"
+          source "https://gem.repo1"
+          gem "myrack"
         G
 
-        gemfile bundled_app("gemfake"), <<-G
-          source "#{file_uri_for(gem_repo1)}"
+        gemfile bundled_app("CustomGemfile"), <<-G
+          source "https://gem.repo1"
           gem "activesupport", "2.3.5"
         G
 
-        bundle "config set --local gemfile #{bundled_app("gemfake")}"
+        bundle "config set --local gemfile #{bundled_app("CustomGemfile")}"
         bundle "install"
 
-        expect(the_bundle).to include_gems "activesupport 2.3.5"
+        ruby <<-R
+          require 'bundler'
+          Bundler.setup
+          require 'activesupport'
+          puts ACTIVESUPPORT
+        R
+
+        expect(out).to eq("2.3.5")
       end
     end
   end


### PR DESCRIPTION
When we run `bundle exec` it'll look at `Bundler.settings[:gemfile]`
and respect the Gemfile setting. However, when we just require
`bundler/setup` or run `Bundle.setup`, it'll not look through that.

This should make this behaviour consistent.

More details can be found at:
https://gitlab.com/gitlab-org/gitlab/-/issues/339939#note_667461354

## What was the end-user or developer problem that led to this PR?

Try the following scenario:

* `bundler config set --local gemfile Something`
* Put something in `Something` but not `Gemfile`
* Notice that `bundle exec` will look for `Something` as expected, but `ruby -rbundler/setup` will not

## What is your fix for the problem, implemented in this PR?

I found in `bundler/lib/bundler/cli.rb` there's a snippet:

``` ruby
custom_gemfile = options[:gemfile] || Bundler.settings[:gemfile]
if custom_gemfile && !custom_gemfile.empty?
  Bundler::SharedHelpers.set_env "BUNDLE_GEMFILE", File.expand_path(custom_gemfile)
  Bundler.reset_settings_and_root!
end
```

This does not run when we run `Bundler.setup` causing this inconsistency.

In order to fix it, make sure we also run this in `Bundler.setup`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
