### PR TITLE
Print a warning for a potential confusion from the indirect dependencies.

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -777,8 +777,6 @@ module Bundler
     end
 
     def precompute_source_requirements_for_indirect_dependencies?
-      return false unless @remote && !sources.aggregate_global_source?
-
       if sources.non_global_rubygems_sources.all?(&:dependency_api_available?)
         true
       else

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -777,7 +777,27 @@ module Bundler
     end
 
     def precompute_source_requirements_for_indirect_dependencies?
-      sources.non_global_rubygems_sources.all?(&:dependency_api_available?)
+      return false unless @remote && !sources.aggregate_global_source?
+
+      if sources.non_global_rubygems_sources.all?(&:dependency_api_available?)
+        true
+      else
+        non_dependency_api_warning
+        false
+      end
+    end
+
+    def non_dependency_api_warning
+      non_api_sources = sources.non_global_rubygems_sources.reject(&:dependency_api_available?)
+      non_api_source_names = non_api_sources.map {|d| "  * #{d}" }.join("\n")
+
+      msg = String.new
+      msg << "Your Gemfile contains scoped sources that don't implement a dependency API, namely:\n\n"
+      msg << non_api_source_names
+      msg << "\n\nUsing the above gem servers may result in installing unexpected gems. " \
+        "To resolve this warning, make sure you use gem servers that implement dependency APIs, " \
+        "such as gemstash or geminabox gem servers."
+      Bundler.ui.warn msg
     end
 
     def current_platform_locked?

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -304,8 +304,8 @@ RSpec.describe Bundler::Definition do
     context "when all the scoped sources implement a dependency API" do
       let(:non_global_rubygems_sources) do
         [
-          double("non-global-source-0", :dependency_api_available? => true, :to_s => "a"),
-          double("non-global-source-1", :dependency_api_available? => true, :to_s => "b"),
+          double("non-global-source-0", "dependency_api_available?":true, to_s:"a"),
+          double("non-global-source-1", "dependency_api_available?":true, to_s:"b"),
         ]
       end
 
@@ -319,9 +319,9 @@ RSpec.describe Bundler::Definition do
     context "when some scoped sources do not implement a dependency API" do
       let(:non_global_rubygems_sources) do
         [
-          double("non-global-source-0", :dependency_api_available? => true, :to_s => "a"),
-          double("non-global-source-1", :dependency_api_available? => false, :to_s => "b"),
-          double("non-global-source-2", :dependency_api_available? => false, :to_s => "c"),
+          double("non-global-source-0", "dependency_api_available?":true, to_s:"a"),
+          double("non-global-source-1", "dependency_api_available?":false, to_s:"b"),
+          double("non-global-source-2", "dependency_api_available?":false, to_s:"c"),
         ]
       end
 

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -289,6 +289,61 @@ RSpec.describe Bundler::Definition do
     end
   end
 
+  describe "#precompute_source_requirements_for_indirect_dependencies?" do
+    before do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile) { Pathname.new("Gemfile") }
+    end
+
+    let(:sources) { Bundler::SourceList.new }
+    subject { Bundler::Definition.new(nil, [], sources, []) }
+
+    context "when remote and does not have multiple global sources" do
+      before do
+        subject.instance_variable_set(:@remote, true)
+        allow(sources).to receive(:aggregate_global_source?).and_return(false)
+        allow(sources).to receive(:non_global_rubygems_sources).and_return(non_global_rubygems_sources)
+      end
+
+      context "when all the scoped sources contain a dependency API" do
+        let(:non_global_rubygems_sources) do
+          [
+            double("non-global-source-0", :dependency_api_available? => true, :to_s => "a"),
+            double("non-global-source-1", :dependency_api_available? => true, :to_s => "b"),
+          ]
+        end
+
+        it "will not raise a warning" do
+          expect(subject).not_to receive(:non_dependency_api_warning)
+
+          expect(subject.send(:precompute_source_requirements_for_indirect_dependencies?)).to be_truthy
+        end
+      end
+
+      context "when scoped sources do not contain a dependency API" do
+        let(:non_global_rubygems_sources) do
+          [
+            double("non-global-source-0", :dependency_api_available? => true, :to_s => "a"),
+            double("non-global-source-1", :dependency_api_available? => false, :to_s => "b"),
+            double("non-global-source-2", :dependency_api_available? => false, :to_s => "c"),
+          ]
+        end
+
+        it "will raise a warning" do
+          expect(Bundler.ui).to receive(:warn).with(<<-W.strip)
+Your Gemfile contains scoped sources that don't implement a dependency API, namely:
+
+  * b
+  * c
+
+Using the above gem servers may result in installing unexpected gems. To resolve this warning, make sure you use gem servers that implement dependency APIs, such as gemstash or geminabox gem servers.
+          W
+
+          expect(subject.send(:precompute_source_requirements_for_indirect_dependencies?)).to be_falsy
+        end
+      end
+    end
+  end
+
   def mock_source_list
     Class.new do
       def all_sources

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -297,49 +297,45 @@ RSpec.describe Bundler::Definition do
     let(:sources) { Bundler::SourceList.new }
     subject { Bundler::Definition.new(nil, [], sources, []) }
 
-    context "when remote and does not have multiple global sources" do
-      before do
-        subject.instance_variable_set(:@remote, true)
-        allow(sources).to receive(:aggregate_global_source?).and_return(false)
-        allow(sources).to receive(:non_global_rubygems_sources).and_return(non_global_rubygems_sources)
+    before do
+      allow(sources).to receive(:non_global_rubygems_sources).and_return(non_global_rubygems_sources)
+    end
+
+    context "when all the scoped sources implement a dependency API" do
+      let(:non_global_rubygems_sources) do
+        [
+          double("non-global-source-0", :dependency_api_available? => true, :to_s => "a"),
+          double("non-global-source-1", :dependency_api_available? => true, :to_s => "b"),
+        ]
       end
 
-      context "when all the scoped sources contain a dependency API" do
-        let(:non_global_rubygems_sources) do
-          [
-            double("non-global-source-0", :dependency_api_available? => true, :to_s => "a"),
-            double("non-global-source-1", :dependency_api_available? => true, :to_s => "b"),
-          ]
-        end
+      it "returns true without warning" do
+        expect(subject).not_to receive(:non_dependency_api_warning)
 
-        it "will not raise a warning" do
-          expect(subject).not_to receive(:non_dependency_api_warning)
+        expect(subject.send(:precompute_source_requirements_for_indirect_dependencies?)).to be_truthy
+      end
+    end
 
-          expect(subject.send(:precompute_source_requirements_for_indirect_dependencies?)).to be_truthy
-        end
+    context "when some scoped sources do not implement a dependency API" do
+      let(:non_global_rubygems_sources) do
+        [
+          double("non-global-source-0", :dependency_api_available? => true, :to_s => "a"),
+          double("non-global-source-1", :dependency_api_available? => false, :to_s => "b"),
+          double("non-global-source-2", :dependency_api_available? => false, :to_s => "c"),
+        ]
       end
 
-      context "when scoped sources do not contain a dependency API" do
-        let(:non_global_rubygems_sources) do
-          [
-            double("non-global-source-0", :dependency_api_available? => true, :to_s => "a"),
-            double("non-global-source-1", :dependency_api_available? => false, :to_s => "b"),
-            double("non-global-source-2", :dependency_api_available? => false, :to_s => "c"),
-          ]
-        end
-
-        it "will raise a warning" do
-          expect(Bundler.ui).to receive(:warn).with(<<-W.strip)
+      it "returns false and warns about the non-API sources" do
+        expect(Bundler.ui).to receive(:warn).with(<<-W.strip)
 Your Gemfile contains scoped sources that don't implement a dependency API, namely:
 
   * b
   * c
 
 Using the above gem servers may result in installing unexpected gems. To resolve this warning, make sure you use gem servers that implement dependency APIs, such as gemstash or geminabox gem servers.
-          W
+        W
 
-          expect(subject.send(:precompute_source_requirements_for_indirect_dependencies?)).to be_falsy
-        end
+        expect(subject.send(:precompute_source_requirements_for_indirect_dependencies?)).to be_falsy
       end
     end
   end


### PR DESCRIPTION
Print warning when a confusion by the indirect dependencies can happen.

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

This PR is a fix for the https://github.com/rubygems/rubygems/issues/4694#issuecomment-871371684 (a possible dependency confusion from indirect dependencies to print a warning message.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I added the logic to print a warning in the case.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)

This PR is working in progress. I will prepare the reproducer using `gem server` (non dependency API) soon. I have some questions before writing the tests.

### Q1

I have not implemented the following logic to check the size of the index. Could you tell me how to check the size?

> I guess this is not too bad if the index is small, so we could allow that and fix the issue up to a certain index size, and print a warning otherwise?

### Q2

What do you think about adding the following code to raise an error as a default, and print a warning if the `bundle config` key `allow_dependency_confusion` (`BUNDLE_ALLOW_DEPENDENCY_CONFUSION` environment variable) is available as a compatibility?  Because maybe we want to stop the use case that triggers [the security issue](https://bundler.io/blog/2021/02/15/a-more-secure-bundler-we-fixed-our-source-priorities.html).

```
$ diff --git a/bundler/lib/bundler/definition.rb b/bundler/lib/bundler/definition.rb
index 7414a5e7d4..d8dddb9f59 100644
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -537,6 +537,9 @@ def precompute_source_requirements_for_indirect_dependencies?
         msg << "Your bundle cannot resolve indirect dependencies because "
         msg << reasons.join(" and ")
         msg << "."
+
+        raise ProductionError, msg unless Bundler.settings[:allow_dependency_confusion]
+
         Bundler.ui.warn msg
       end
```

### Q3

The added logic is
in `lib/bundler/definition.rb#precompute_source_requirements_for_indirect_dependencies?`
in `lib/bundler/definition.rb#source_requirements`
in `lib/bundler/definition.rb#resolve`
in `lib/bundler/definition.rb#resolve_remotely!`

However technically after running `sources.remote!` in `resolve_remotely!`, the Bundler is ready to print the warning (or raise an error) referring the `sources` object. So, I wondered if we could add the new logic to print the warning after `sources.remote!` in the `resolve_remotely!` instead of `source_requirements`. And I think the logic is the remote flow specific (`@remote == true` ). What do you think?

```
    def resolve_remotely!
      @remote = true
      sources.remote!

      # Add a new logic here? 

      resolve
    end
```
