### PR TITLE
Add bundler before/after eval hooks for plugins

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -35,7 +35,10 @@ module Bundler
 
       raise GemfileNotFound, "#{gemfile} not found" unless gemfile.file?
 
-      Dsl.evaluate(gemfile, lockfile, unlock)
+      Plugin.hook(Plugin::Events::GEM_BEFORE_EVAL, gemfile, lockfile, unlock)
+      Dsl.evaluate(gemfile, lockfile, unlock).tap do |definition|
+        Plugin.hook(Plugin::Events::GEM_AFTER_EVAL, definition)
+      end
     end
 
     #

--- a/bundler/lib/bundler/plugin/events.rb
+++ b/bundler/lib/bundler/plugin/events.rb
@@ -56,6 +56,18 @@ module Bundler
       #   Includes an Array of Bundler::Dependency objects
       #   GEM_AFTER_INSTALL_ALL = "after-install-all"
       define :GEM_AFTER_INSTALL_ALL,  "after-install-all"
+
+      # @!parse
+      #   A hook called before the Gemfile is evaluated
+      #   Includes the Gemfile name, the Lockfile name, and the unlock options
+      #   GEM_BEFORE_EVAL = "before-eval"
+      define :GEM_BEFORE_EVAL, "before-eval"
+
+      # @!parse
+      #   A hook called after the Gemfile is evaluated
+      #   Includes a Bundler::Definition
+      #   GEM_AFTER_EVAL = "after-eval"
+      define :GEM_AFTER_EVAL, "after-eval"
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

My plugin would have a much cleaner implementation if it could hook both before and after the Gemfile is evaluated (the former to easily add additional DSL methods, the latter to do verification that the new methods were properly used).

## What is your fix for the problem, implemented in this PR?

Add the hooks and call them from `Definition.build` (not `Dsl#evaluate` or `Dsl#eval_gemfile`, so as not to interfere with the plugin-parsing pass of the Gemfile).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
