### PR TITLE
New plugin hooks around fetching gems and git sources

### DIFF
--- a/bundler/lib/bundler/plugin/events.rb
+++ b/bundler/lib/bundler/plugin/events.rb
@@ -46,6 +46,30 @@ module Bundler
       define :GEM_AFTER_INSTALL,  "after-install"
 
       # @!parse
+      #   A hook called before each individual gem is fetched for installation.
+      #   Includes a Bundler::ParallelInstaller::SpecInstallation and a source reference.
+      #   GEM_BEFORE_FETCH = "before-fetch"
+      define :GEM_BEFORE_FETCH, "before-fetch"
+
+      # @!parse
+      #   A hook called after each individual gem is fetched for installation.
+      #   Includes a Bundler::ParallelInstaller::SpecInstallation and a source reference.
+      #   GEM_AFTER_FETCH = "after-fetch"
+      define :GEM_AFTER_FETCH, "after-fetch"
+
+      # @!parse
+      #   A hook called before a git source is fetched.
+      #   Includes a Bundler::Source::Git reference.
+      #   GIT_GEM_BEFORE_FETCH = "git-before-fetch"
+      define :GIT_BEFORE_FETCH, "git-before-fetch"
+
+      # @!parse
+      #   A hook called after a git source is fetched.
+      #   Includes a Bundler::Source::Git reference.
+      #   GEM_AFTER_FETCH = "git-after-fetch"
+      define :GIT_AFTER_FETCH, "git-after-fetch"
+
+      # @!parse
       #   A hook called before any gems install
       #   Includes an Array of Bundler::Dependency objects
       #   GEM_BEFORE_INSTALL_ALL = "before-install-all"

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -191,8 +191,10 @@ module Bundler
         set_cache_path!(app_cache_path) if use_app_cache?
 
         if requires_checkout? && !@copied
+          Plugin.hook(Plugin::Events::GIT_BEFORE_FETCH, self)
           fetch unless use_app_cache?
           checkout
+          Plugin.hook(Plugin::Events::GIT_AFTER_FETCH, self)
         end
 
         local_specs
@@ -205,7 +207,9 @@ module Bundler
         print_using_message "Using #{version_message(spec, options[:previous_spec])} from #{self}"
 
         if (requires_checkout? && !@copied) || force
+          Plugin.hook(Plugin::Events::GEM_BEFORE_FETCH, spec, self)
           checkout
+          Plugin.hook(Plugin::Events::GEM_AFTER_FETCH, spec, self)
         end
 
         generate_bin_options = { disable_extensions: !spec.missing_extensions?, build_args: options[:build_args] }

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -431,11 +431,14 @@ module Bundler
       end
 
       def fetch_gem_if_possible(spec, previous_spec = nil)
-        if spec.remote
+        Plugin.hook(Plugin::Events::GEM_BEFORE_FETCH, spec, self)
+        gem_path = if spec.remote
           fetch_gem(spec, previous_spec)
         else
           cached_gem(spec)
         end
+        Plugin.hook(Plugin::Events::GEM_AFTER_FETCH, spec, self)
+        gem_path
       end
 
       def fetch_gem(spec, previous_spec = nil)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?
During bundler install runs, most prominently as part of a CI / container building pipeline, I was wondering which of our (many) gems where having the most impact on runtime. For a larger-ish project with some hundred+ gems a typical bundler install run can take multiple minutes. As of right now, there was no good way (that we knew of) to dissect which individual gems take the majority of time.
Native extensions are an obvious culprit and so are network download times.

We've been hacking [a small plugin called Bundler-Timing](https://github.com/MrMarvin/bundler-timing/tree/main), which gives per-gem install timing statistics. However this approach was lacking more detailed events to determine:
* How long a gem source took to download, as part of the overall installation
* How expensive was the git checkout operation

## What is your fix for the problem, implemented in this PR?
Introduce two new sets of plugin events:

* `GEM_BEFORE_FETCH` and `GEM_AFTER_FETCH`
* `GIT_BEFORE_FETCH` and `GIT_AFTER_FETCH`

Please feel free to see the above mentioned plugin for an [example implementing ](https://github.com/MrMarvin/bundler-timing/blob/main/lib/bundler/timing.rb#L125-L147)the hooks.

**If introducing new hooks is generally acceptable for this project and there is no concerns moving forward, I'll add some specs as well. Right now I'm happy with interactively experimenting using our timing plugin.**

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
