### PR TITLE
Add documentation for changelog flags

### DIFF
--- a/bundler/lib/bundler/man/bundle-gem.1.ronn
+++ b/bundler/lib/bundler/man/bundle-gem.1.ronn
@@ -41,6 +41,15 @@ configuration file using the following names:
   Do not create a `CODE_OF_CONDUCT.md` (overrides `--coc` specified in the
   global config).
 
+* `--changelog`
+  Add a `CHANGELOG.md` file to the root of the generated project. If
+  this option is unspecified, an interactive prompt will be displayed and the
+  answer will be saved in Bundler's global config for future `bundle gem` use.
+
+* `--no-changelog`:
+  Do not create a `CHANGELOG.md` (overrides `--changelog` specified in the 
+  global config) 
+
 * `--ext=c`, `--ext=rust`
   Add boilerplate for C or Rust (currently [magnus](https://docs.rs/magnus) based) extension code to the generated project. This behavior
   is disabled by default.


### PR DESCRIPTION
The --changelog and --no-changelog flags are missing from docs, this adds them in a way that matches other flags

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Was working to use `bundler gem` to generate new gems via a non-interaction shell and it was getting stuck on a interactive prompt asking ```Do you want to include a changelog?```

After checking the man page and logs these options were not documented

## What is your fix for the problem, implemented in this PR?

Expand the docs to include the --changelog and --no-changelog flags

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
