### PR TITLE
Remove myself from MAINTAINERS.txt, because Ruby Central revoked everyone's commit access

### DIFF
--- a/doc/MAINTAINERS.txt
+++ b/doc/MAINTAINERS.txt
@@ -1,6 +1,5 @@
 Luis Sagastume <lsagastume1990@gmail.com> (@bronzdoc)
 Daniel Berger <djberg96@gmail.com> (@djberg96)
-Ellen Marie Dash <me@duckie.co> (@duckinator)
 Evan Phoenix <evan@phx.io> (@evanphx)
 SHIBATA Hiroshi <hsbt@ruby-lang.org> (@hsbt)
 André Arko <andre@arko.net> (@indirect)


### PR DESCRIPTION
Ruby Central [forcefully took control of the RubyGems GitHub organization.](https://pup-e.com/goodbye-rubygems.pdf)

They then, among other things, revoked my commit access against the wishes of the entire team.

**If I can't push a commit to the repository, I am not a maintainer.**

You don't get to use my name anymore.