### PR TITLE
Remove `verify_gz`

### DIFF
--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -858,7 +858,7 @@ class TestGemPackage < Gem::Package::TarTestCase
                  "#{@destination} is not allowed", e.message)
   end
 
-  def test_load_spec
+  def test_load_spec_from_metadata
     entry = StringIO.new Gem::Util.gzip @spec.to_yaml
     def entry.full_name
       "metadata.gz"
@@ -866,7 +866,7 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     package = Gem::Package.new "nonexistent.gem"
 
-    spec = package.load_spec entry
+    spec = package.load_spec_from_metadata entry
 
     assert_equal @spec, spec
   end


### PR DESCRIPTION
This PR removes the `#verify_gz` method because it is redunant and unnecessary.

Previously the `data.tar.gz` would get read twice for every file - once in `verify_gz` and once in `extract_files`. The `extract_files` method verifies the `data.tar.gz` when it reads it, and raises an error if unzipping it fails.

The `verify_gz` code can be seen in some profiles as a hotspot - although not major - as it accounts for between 9% and 17% of time, but only when the installation thread doesn't have native extensions or plugins.

<img width="1192" height="457" alt="Screenshot 2025-11-17 at 4 51 23 PM" src="https://github.com/user-attachments/assets/6569ac93-e59b-480c-94ff-9f587c47a428" />

Note: to create this profile I actually split the fetching and installing into two steps so I could profile just installing all the gems. I then profiled just the install code.

## What was the end-user or developer problem that led to this PR?

I was looking at profiles for bundler and noticed we spend time in `verify_gz` but that method is redundant.

## What is your fix for the problem, implemented in this PR?

See commit message

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)

cc/ @tenderlove @Edouard-chin 
