### PR TITLE
Always show install times during bundle install

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -211,11 +211,9 @@ module Bundler
         message += " with native extensions" if spec.extensions.any?
         Bundler.ui.confirm message
 
-        installed_spec = nil
-
-        Gem.time("Installed #{spec.name} in", 0, true) do
-          installed_spec = installer.install
-        end
+        start_time = Time.now
+        installed_spec = installer.install
+        Bundler.ui.confirm "Installed #{spec.name} in: #{format("%.3f", Time.now - start_time)}s"
 
         spec.full_gem_path = installed_spec.full_gem_path
         spec.loaded_from = installed_spec.loaded_from
@@ -483,9 +481,9 @@ module Bundler
         Bundler.ui.confirm("Fetching #{version_message(spec, previous_spec)}")
         gem_remote_fetcher = remote_fetchers.fetch(spec.remote).gem_remote_fetcher
 
-        Gem.time("Downloaded #{spec.name} in", 0, true) do
-          Bundler.rubygems.download_gem(spec, uri, download_cache_path, gem_remote_fetcher)
-        end
+        start_time = Time.now
+        Bundler.rubygems.download_gem(spec, uri, download_cache_path, gem_remote_fetcher)
+        Bundler.ui.confirm "Downloaded #{spec.name} in: #{format("%.3f", Time.now - start_time)}s"
       end
 
       # Returns the global cache path of the calling Rubygems::Source object.

--- a/bundler/spec/bundler/source/rubygems_spec.rb
+++ b/bundler/spec/bundler/source/rubygems_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Bundler::Source::Rubygems do
     end
   end
 
-  describe "log debug information" do
+  describe "log timing information" do
     it "log the time spent downloading and installing a gem" do
       build_repo2 do
         build_gem "warning"
@@ -56,7 +56,7 @@ RSpec.describe Bundler::Source::Rubygems do
         gem "warning"
       G
 
-      stdout = install_gemfile(gemfile_content, env: { "DEBUG" => "1" })
+      stdout = install_gemfile(gemfile_content)
 
       expect(stdout).to match(/Downloaded warning in: \d+\.\d+s/)
       expect(stdout).to match(/Installed warning in: \d+\.\d+s/)

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -981,7 +981,7 @@ RSpec.describe "bundle update" do
     end
 
     bundle "update", all: true
-    expect(out.sub("Removing foo (1.0)\n", "")).to match(/Resolving dependencies\.\.\.\.*\nFetching foo 2\.0 \(was 1\.0\)\nInstalling foo 2\.0 \(was 1\.0\)\nBundle updated/)
+    expect(out.sub("Removing foo (1.0)\n", "")).to match(/Resolving dependencies\.\.\.\.*\nFetching foo 2\.0 \(was 1\.0\)\nDownloaded foo in:.*\nInstalling foo 2\.0 \(was 1\.0\)\nInstalled foo in:.*\nBundle updated/)
   end
 
   it "shows error message when Gemfile.lock is not preset and gem is specified" do

--- a/bundler/spec/runtime/inline_spec.rb
+++ b/bundler/spec/runtime/inline_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "bundler/inline#gemfile" do
       end
     RUBY
 
-    expect(out).to eq("CONFIRMED!\nCONFIRMED!")
+    expect(out).to eq("CONFIRMED!\nCONFIRMED!\nCONFIRMED!\nCONFIRMED!")
   end
 
   it "has an option for quiet installation" do


### PR DESCRIPTION
The [recently-added](https://github.com/ruby/rubygems/pull/9066) "Installed in" and "Downloaded in" timing outputs are much appreciated 🙏 

I'd like to suggest we enable them by default, rather than only when DEBUG=true.

It's very common to:

- Run `bundle install` during deploys or CI
- Have `--jobs` > 1
- Have some gems take a very long time to install. E.g. ones with native extensions.

When `--jobs` > 1, it's impossible to tell which gems are slow, unless "Installed In" is displayed.

`DEBUG=true` is **very** verbose, and seems like too much for this common need. This feels like a common enough case to output the new timings by default.

We had some discussion of this previously in https://github.com/ruby/rubygems/pull/7622 and had decided on always displaying the timings.

Or, if we don't want to enable the output by default, would we be ok with adding an `--timing` option, to allow outputing even when `DEBUG=true` is not set?

i.e. like:
```ruby
if Bundler.settings[:timing]
  Bundler.ui.confirm "Installed #{spec.name} in: #{format("%.3f", Time.now - start_time)}s"
end
```
?

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
