### PR TITLE
Refactor atomic file write

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -24,7 +24,7 @@ Dir.chdir __dir__
 $:.unshift File.expand_path("lib")
 require "rubygems"
 require "rubygems/gem_runner"
-require "tempfile"
+require "securerandom"
 
 Gem::CommandManager.instance.register_command :setup
 


### PR DESCRIPTION
This refactoring is based off the changes in
test/rubygems/test_gem_remote_fetcher.rb. It no longer uses tempfile as a result.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)