### PR TITLE
Fix RubyGems not able to require the right gem:

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -193,11 +193,12 @@ module Gem
     begin
       spec.activate
     rescue Gem::LoadError => e # this could fail due to gem dep collisions, go lax
-      spec_by_name = Gem::Specification.find_by_name(spec.name)
-      if spec_by_name.nil?
+      spec = Gem::Specification.find_unloaded_by_path(path)
+      spec ||= Gem::Specification.find_by_name(spec.name)
+      if spec.nil?
         raise e
       else
-        spec_by_name.activate
+        spec.activate
       end
     end
 

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -960,6 +960,15 @@ class Gem::Specification < Gem::BasicSpecification
 
   ##
   # Return the best specification that contains the file matching +path+
+  # amongst the specs that are not loaded. This method is different than
+  # +find_inactive_by_path+ as it will filter out loaded specs by their name.
+
+  def self.find_unloaded_by_path(path)
+    specification_record.find_unloaded_by_path(path)
+  end
+
+  ##
+  # Return the best specification that contains the file matching +path+
   # amongst the specs that are not activated.
 
   def self.find_inactive_by_path(path)

--- a/lib/rubygems/specification_record.rb
+++ b/lib/rubygems/specification_record.rb
@@ -155,6 +155,19 @@ module Gem
     end
 
     ##
+    # Return the best specification that contains the file matching +path+
+    # amongst the specs that are not loaded. This method is different than
+    # +find_inactive_by_path+ as it will filter out loaded specs by their name.
+
+    def find_unloaded_by_path(path)
+      stub = stubs.find do |s|
+        next if Gem.loaded_specs[s.name]
+        s.contains_requirable_file? path
+      end
+      stub&.to_spec
+    end
+
+    ##
     # Return the best specification in the record that contains the file
     # matching +path+ amongst the specs that are not activated.
 

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -431,6 +431,22 @@ class TestGemRequire < Gem::TestCase
     assert_equal %w[default-2.0.0.0], loaded_spec_names
   end
 
+  def test_multiple_gems_with_the_same_path_the_non_activated_spec_is_chosen
+    a1 = util_spec "a", "1", nil, "lib/ib.rb"
+    a2 = util_spec "a", "2", nil, "lib/foo.rb"
+    b1 = util_spec "b", "1", nil, "lib/ib.rb"
+
+    install_specs a1, a2, b1
+
+    a2.activate
+
+    assert_equal %w[a-2], loaded_spec_names
+    assert_empty unresolved_names
+
+    assert_require "ib"
+    assert_equal %w[a-2 b-1], loaded_spec_names
+  end
+
   def test_default_gem_require_activates_just_once
     default_gem_spec = new_default_spec("default", "2.0.0.0",
                                         nil, "default/gem.rb")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fix https://github.com/ruby/rubygems/issues/9238

This is an issue that bites gem maintainers from time to time, with the most recent one in https://github.com/minitest/minitest/issues/1040#issuecomment-3679370619

The issue is summarized as follow:

1) A gem "X" has a feature in "lib/feature.rb"
2) Maintainer wants to extract this feature into its own gem "Y"
3) Maintainer cut a release of X without that new feature.
4) Users install the new version of X and also install the new gem "Y" since the feature is now extracted.
5) When a call to "require 'feature'" is encountered, RG will fail to load the right gem, resulting in a `LoadError`.

## What is your fix for the problem, implemented in this PR?

#### Details

Now that we have two gems (old version of X and new gem Y) with the same path, RubyGems will detect that `feature.rb` can be loaded from the old version of X, but if the new version of X had already been loaded, then RubyGems will raise due to versions conflicting.

```ruby
require 'x' # Loads the new version of X without the feature which was extracted. 
require 'feature' # Rubygems see that the old version of X include that file and tries to activate the old X spec, resulting in a version conflict.
```

#### Solution

I propose that RubyGems fallback to a spec that's not yet loaded. We try to find a spec by its path and filter it out in case a spec with the same name has already been loaded.

Its worth to note that RubyGems already has a `find_inactive_by_path` but we can't use it. This method only checks if the spec object is active and doesn't look if other spec with the same name have been loaded. The new method we are introducing verifies this.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
