### PR TITLE
Workaround for directly loading `Gem::Version`

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -150,6 +150,9 @@
 # For the last example, single-digit versions are automatically extended with
 # a zero to give a sensible result.
 
+# Workaround for directly loading Gem::Version in some cases
+module Gem; end
+
 class Gem::Version
   include Comparable
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

If we use `rubygems/version` directlry without `rubygems`, we faced `uninitialized constant Gem (NameError)` error.

## What is your fix for the problem, implemented in this PR?

Pick https://github.com/ruby/ruby/commit/e410d938fa1b8474fd4763b9b8383defa7f1db3f

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
