### PR TITLE
Improve handling of paths with invalid Windows characters

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -89,6 +89,18 @@ class Gem::Package
 
   class TarInvalidError < Error; end
 
+  ##
+  # Raised when a filename contains characters that are invalid on Windows
+
+  class InvalidFileNameError < Error
+    def initialize(filename, gem_name = nil)
+      message = "The gem contains a file '#{filename}' with characters in its name that are not allowed on Windows (e.g., colons)."
+      message += " This is a problem with the '#{gem_name}' gem, not Rubygems." if gem_name
+      message += " Please report this issue to the gem author."
+      super message
+    end
+  end
+
   attr_accessor :build_time # :nodoc:
 
   ##
@@ -262,6 +274,10 @@ class Gem::Package
 
   def add_files(tar) # :nodoc:
     @spec.files.each do |file|
+      if invalid_windows_filename?(file)
+        alert_warning "filename '#{file}' contains characters that are invalid on Windows (e.g., colons). This gem may fail to install on Windows."
+      end
+
       stat = File.lstat file
 
       if stat.symlink?
@@ -431,6 +447,11 @@ EOM
 
         destination = install_location full_name, destination_dir
 
+        if invalid_windows_filename?(full_name)
+          gem_name = @spec ? @spec.full_name : "unknown"
+          raise Gem::Package::InvalidFileNameError.new(full_name, gem_name)
+        end
+
         if entry.symlink?
           link_target = entry.header.linkname
           real_destination = link_target.start_with?("/") ? link_target : File.expand_path(link_target, File.dirname(destination))
@@ -459,13 +480,18 @@ EOM
         end
 
         if entry.file?
-          File.open(destination, "wb") do |out|
-            copy_stream(tar.io, out, entry.size)
-            # Flush needs to happen before chmod because there could be data
-            # in the IO buffer that needs to be written, and that could be
-            # written after the chmod (on close) which would mess up the perms
-            out.flush
-            out.chmod file_mode(entry.header.mode) & ~File.umask
+          begin
+            File.open(destination, "wb") do |out|
+              copy_stream(tar.io, out, entry.size)
+              # Flush needs to happen before chmod because there could be data
+              # in the IO buffer that needs to be written, and that could be
+              # written after the chmod (on close) which would mess up the perms
+              out.flush
+              out.chmod file_mode(entry.header.mode) & ~File.umask
+            end
+          rescue Errno::EINVAL => e
+            gem_name = @spec ? @spec.full_name : "unknown"
+            raise Gem::Package::InvalidFileNameError.new(full_name, gem_name), e.message
           end
         end
 
@@ -536,6 +562,19 @@ EOM
     def normalize_path(pathname) # :nodoc:
       pathname
     end
+  end
+
+  ##
+  # Checks if a filename contains characters that are invalid on Windows.
+  # Windows doesn't allow: < > : " | ? * \ and control characters (0x00-0x1F).
+  # Colons are the most common issue since they're allowed on Unix.
+  # Note: Colons are only valid as drive letter separators (e.g., C:), not in filenames.
+
+  def invalid_windows_filename?(filename) # :nodoc:
+    return false unless Gem.win_platform?
+
+    basename = File.basename(filename)
+    basename.match?(/[:<>"|?*\\\x00-\x1f]/)
   end
 
   ##

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -92,7 +92,7 @@ class Gem::Package
   ##
   # Raised when a filename contains characters that are invalid on Windows
 
-  class InvalidFileNameError < Error
+  class InvalidWindowsFileNameError < Error
     def initialize(filename, gem_name = nil)
       message = "The gem contains a file '#{filename}' with characters in its name that are not allowed on Windows (e.g., colons)."
       message += " This is a problem with the '#{gem_name}' gem, not Rubygems." if gem_name
@@ -449,7 +449,7 @@ EOM
 
         if invalid_windows_filename?(full_name)
           gem_name = @spec ? @spec.full_name : "unknown"
-          raise Gem::Package::InvalidFileNameError.new(full_name, gem_name)
+          raise Gem::Package::InvalidWindowsFileNameError.new(full_name, gem_name)
         end
 
         if entry.symlink?
@@ -489,9 +489,9 @@ EOM
               out.flush
               out.chmod file_mode(entry.header.mode) & ~File.umask
             end
-          rescue Errno::EINVAL => e
+          rescue Errno::EINVAL
             gem_name = @spec ? @spec.full_name : "unknown"
-            raise Gem::Package::InvalidFileNameError.new(full_name, gem_name), e.message
+            raise Gem::Package::InvalidWindowsFileNameError.new(full_name, gem_name)
           end
         end
 

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -445,12 +445,12 @@ EOM
         full_name = entry.full_name
         next unless File.fnmatch pattern, full_name, File::FNM_DOTMATCH
 
-        destination = install_location full_name, destination_dir
-
-        if invalid_windows_filename?(full_name)
+        if Gem.win_platform? && invalid_windows_filename?(full_name)
           gem_name = @spec ? @spec.full_name : "unknown"
           raise Gem::Package::InvalidWindowsFileNameError.new(full_name, gem_name)
         end
+
+        destination = install_location full_name, destination_dir
 
         if entry.symlink?
           link_target = entry.header.linkname
@@ -480,18 +480,13 @@ EOM
         end
 
         if entry.file?
-          begin
-            File.open(destination, "wb") do |out|
-              copy_stream(tar.io, out, entry.size)
-              # Flush needs to happen before chmod because there could be data
-              # in the IO buffer that needs to be written, and that could be
-              # written after the chmod (on close) which would mess up the perms
-              out.flush
-              out.chmod file_mode(entry.header.mode) & ~File.umask
-            end
-          rescue Errno::EINVAL
-            gem_name = @spec ? @spec.full_name : "unknown"
-            raise Gem::Package::InvalidWindowsFileNameError.new(full_name, gem_name)
+          File.open(destination, "wb") do |out|
+            copy_stream(tar.io, out, entry.size)
+            # Flush needs to happen before chmod because there could be data
+            # in the IO buffer that needs to be written, and that could be
+            # written after the chmod (on close) which would mess up the perms
+            out.flush
+            out.chmod file_mode(entry.header.mode) & ~File.umask
           end
         end
 
@@ -571,10 +566,7 @@ EOM
   # Note: Colons are only valid as drive letter separators (e.g., C:), not in filenames.
 
   def invalid_windows_filename?(filename) # :nodoc:
-    return false unless Gem.win_platform?
-
-    basename = File.basename(filename)
-    basename.match?(/[:<>"|?*\\\x00-\x1f]/)
+    filename.to_s.split("/").any? { |part| part.match?(/[:<>"|?*\\\x00-\x1f]/) }
   end
 
   ##

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1357,7 +1357,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_invalid_file_name_error_message
-    error = Gem::Package::InvalidFileNameError.new("spec/internal/:memory", "crono-2.0.1")
+    error = Gem::Package::InvalidWindowsFileNameError.new("spec/internal/:memory", "crono-2.0.1")
     assert_match(%r{The gem contains a file 'spec/internal/:memory'}, error.message)
     assert_match(/characters in its name that are not allowed on Windows/, error.message)
     assert_match(/This is a problem with the 'crono-2.0.1' gem, not Rubygems/, error.message)
@@ -1376,7 +1376,7 @@ class TestGemPackage < Gem::Package::TarTestCase
       end
     end
 
-    e = assert_raise Gem::Package::InvalidFileNameError do
+    e = assert_raise Gem::Package::InvalidWindowsFileNameError do
       package.extract_tar_gz tgz_io, @destination
     end
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1344,4 +1344,44 @@ class TestGemPackage < Gem::Package::TarTestCase
 
     assert_equal %w[lib/code.rb], package.contents
   end
+
+  def test_invalid_windows_filename
+    package = Gem::Package.new @gem
+
+    if Gem.win_platform?
+      assert package.invalid_windows_filename?("spec/internal/:memory")
+      assert package.invalid_windows_filename?("file:name.rb")
+      assert package.invalid_windows_filename?("file<name.rb")
+      assert package.invalid_windows_filename?('file"name.rb')
+    end
+  end
+
+  def test_invalid_file_name_error_message
+    error = Gem::Package::InvalidFileNameError.new("spec/internal/:memory", "crono-2.0.1")
+    assert_match(%r{The gem contains a file 'spec/internal/:memory'}, error.message)
+    assert_match(/characters in its name that are not allowed on Windows/, error.message)
+    assert_match(/This is a problem with the 'crono-2.0.1' gem, not Rubygems/, error.message)
+    assert_match(/Please report this issue to the gem author/, error.message)
+  end
+
+  def test_extract_tar_gz_invalid_filename
+    pend "Windows filename validation only applies on Windows" unless Gem.win_platform?
+
+    package = Gem::Package.new @gem
+    package.verify
+
+    tgz_io = util_tar_gz do |tar|
+      tar.add_file "spec/internal/:memory", 0o644 do |io|
+        io.write "test content"
+      end
+    end
+
+    e = assert_raise Gem::Package::InvalidFileNameError do
+      package.extract_tar_gz tgz_io, @destination
+    end
+
+    assert_match(%r{The gem contains a file 'spec/internal/:memory'}, e.message)
+    assert_match(/characters in its name that are not allowed on Windows/, e.message)
+    assert_match(/This is a problem with the 'a-2' gem, not Rubygems/, e.message)
+  end
 end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1384,4 +1384,35 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_match(/characters in its name that are not allowed on Windows/, e.message)
     assert_match(/This is a problem with the 'a-2' gem, not Rubygems/, e.message)
   end
+
+  def test_build_warns_on_invalid_windows_filename
+    pend "Windows filename validation only applies on non-Windows" if Gem.win_platform?
+
+    spec = Gem::Specification.new "test_gem", "1.0"
+    spec.summary = "test"
+    spec.authors = "test"
+    spec.files = ["lib/code.rb", "lib/file:name.rb"]
+
+    FileUtils.mkdir "lib"
+
+    File.open "lib/code.rb", "w" do |io|
+      io.write "# lib/code.rb"
+    end
+
+    File.open "lib/file:name.rb", "w" do |io|
+      io.write "# lib/file:name.rb"
+    end
+
+    package = Gem::Package.new spec.file_name
+    package.spec = spec
+
+    ui = Gem::MockGemUi.new
+    use_ui ui do
+      package.build
+    end
+
+    assert_match(%r{filename 'lib/file:name\.rb' contains characters that are invalid on Windows}, ui.error)
+    assert_match(/This gem may fail to install on Windows/, ui.error)
+    assert_path_exist spec.file_name
+  end
 end


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What is your fix for the problem, implemented in this PR?

Fixes https://github.com/ruby/rubygems/issues/7681

Windows doesn't allow certain characters in filenames (e.g., colons) that are valid on Unix. When gems contain files with these characters, installation fails on Windows with cryptic `Errno::EINVAL` errors.

This PR adds validation and directs users to report issues to gem authors instead.

- Add `InvalidFileNameError` with user-friendly messages
- Validate filenames during gem extraction on Windows
- Warn developers when building gems with invalid filenames

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
