### PR TITLE
Fallback to copy symlinks on Windows

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
 
   push:
-    branches:
-      - master
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -41,10 +41,16 @@ jobs:
             os: { name: Ubuntu, value: ubuntu-24.04 }
             use_psych: true
 
+          - ruby: { name: no symlinks, value: 4.0.0 }
+            os: { name: Windows, value: windows-2025 }
+            symlink: off
     env:
       RUBYGEMS_USE_PSYCH: ${{ matrix.use_psych || 'false' }}
 
     steps:
+      - name: disable development mode on Windows
+        run: powershell -c "Set-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock -Name AllowDevelopmentWithoutDevLicense -Value 0"
+        if: matrix.symlink == 'off'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -55,9 +61,14 @@ jobs:
           bundler: none
       - name: Install Dependencies
         run: bin/rake setup
+      - name: Run Test with non-Admin user
+        run: |
+          gem inst win32-process --no-doc --conservative
+          ruby bin/windows_run_as_user ruby -S rake test
+        if: matrix.symlink == 'off'
       - name: Run Test
         run: bin/rake test
-        if: matrix.ruby.name != 'truffleruby' && matrix.ruby.name != 'jruby'
+        if: matrix.ruby.name != 'truffleruby' && matrix.ruby.name != 'jruby' && matrix.symlink != 'off'
       - name: Run Test isolatedly
         run: bin/rake test:isolated
         if: matrix.ruby.name == '3.4' && matrix.os.name != 'Windows'

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
 
   push:
+    branches:
+      - master
 
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
@@ -61,11 +63,6 @@ jobs:
           bundler: none
       - name: Install Dependencies
         run: bin/rake setup
-      - name: Run Test with non-Admin user
-        run: |
-          gem inst win32-process --no-doc --conservative
-          ruby bin/windows_run_as_user ruby -S rake test
-        if: matrix.symlink == 'off'
       - name: Run Test
         run: bin/rake test
         if: matrix.ruby.name != 'truffleruby' && matrix.ruby.name != 'jruby' && matrix.symlink != 'off'
@@ -78,6 +75,11 @@ jobs:
       - name: Run Test (Truffleruby)
         run: TRUFFLERUBYOPT="--experimental-options --testing-rubygems" bin/rake test
         if: matrix.ruby.name == 'truffleruby'
+      - name: Run Test with non-Admin user
+        run: |
+          gem inst win32-process --no-doc --conservative
+          ruby bin/windows_run_as_user ruby -S rake test
+        if: matrix.symlink == 'off'
 
     timeout-minutes: 60
 

--- a/bin/windows_run_as_user
+++ b/bin/windows_run_as_user
@@ -5,6 +5,7 @@ testuser = "testuser"
 testpassword = "Password123+"
 
 # Remove a previous test user if present
+# See https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/net-user
 system("net user #{testuser} /del 2>NUL")
 # Create a new non-admin user
 system("net user #{testuser} \"#{testpassword}\" /add")
@@ -26,8 +27,9 @@ IO.pipe do |stdout_read, stdout_write|
     startup_info: { stdout: stdout_write, stderr: stdout_write }
 
   stdout_write.close
-  out = stdout_read.read
-  puts out
+  stdout_read.each_line do |line|
+    puts(line)
+  end
 end
 
 # Wait for process to terminate

--- a/bin/windows_run_as_user
+++ b/bin/windows_run_as_user
@@ -1,0 +1,30 @@
+require "win32/process"
+require "rbconfig"
+
+TESTUSER = "testuser"
+
+system("net user #{TESTUSER} /del 2>NUL")
+system("net user #{TESTUSER} \"Password123+\" /add") || raise
+system("icacls . /grant #{TESTUSER}:(OI)(CI)(IO)(F)")
+
+stdout_read, stdout_write = IO.pipe
+cmd = ARGV.join(" ")
+env = {
+    "TMP" => "#{Dir.pwd}/tmp",
+    "TEMP" => "#{Dir.pwd}/tmp"
+}
+pinfo = Process.create command_line: cmd,
+    with_logon: TESTUSER,
+    password: "Password123+",
+    cwd: Dir.pwd,
+    environment: ENV.to_h.merge(env).map{|k,v| "#{k}=#{v}" },
+    startup_info: { stdout: stdout_write, stderr: stdout_write }
+
+stdout_write.close
+out = stdout_read.read
+puts out
+
+# Wait for process to terminate
+sleep 0.1 while !(ecode=Process.get_exitcode(pinfo.process_id))
+
+exit ecode

--- a/bin/windows_run_as_user
+++ b/bin/windows_run_as_user
@@ -1,30 +1,36 @@
 require "win32/process"
 require "rbconfig"
 
-TESTUSER = "testuser"
+testuser = "testuser"
+testpassword = "Password123+"
 
-system("net user #{TESTUSER} /del 2>NUL")
-system("net user #{TESTUSER} \"Password123+\" /add") || raise
-system("icacls . /grant #{TESTUSER}:(OI)(CI)(IO)(F)")
+# Remove a previous test user if present
+system("net user #{testuser} /del 2>NUL")
+# Create a new non-admin user
+system("net user #{testuser} \"#{testpassword}\" /add")
+# Give the new user full access permission on the working directory
+system("icacls . /grant #{testuser}:(OI)(CI)(IO)F")
 
-stdout_read, stdout_write = IO.pipe
-cmd = ARGV.join(" ")
-env = {
+pinfo = nil
+IO.pipe do |stdout_read, stdout_write|
+  cmd = ARGV.join(" ")
+  env = {
     "TMP" => "#{Dir.pwd}/tmp",
     "TEMP" => "#{Dir.pwd}/tmp"
-}
-pinfo = Process.create command_line: cmd,
-    with_logon: TESTUSER,
-    password: "Password123+",
+  }
+  pinfo = Process.create command_line: cmd,
+    with_logon: testuser,
+    password: testpassword,
     cwd: Dir.pwd,
     environment: ENV.to_h.merge(env).map{|k,v| "#{k}=#{v}" },
     startup_info: { stdout: stdout_write, stderr: stdout_write }
 
-stdout_write.close
-out = stdout_read.read
-puts out
+  stdout_write.close
+  out = stdout_read.read
+  puts out
+end
 
 # Wait for process to terminate
-sleep 0.1 while !(ecode=Process.get_exitcode(pinfo.process_id))
+sleep 1 while !(ecode=Process.get_exitcode(pinfo.process_id))
 
 exit ecode

--- a/bin/windows_run_as_user
+++ b/bin/windows_run_as_user
@@ -9,8 +9,6 @@ testpassword = "Password123+"
 system("net user #{testuser} /del 2>NUL")
 # Create a new non-admin user
 system("net user #{testuser} \"#{testpassword}\" /add")
-# Give the new user full access permission on the working directory
-system("icacls . /grant #{testuser}:(OI)(CI)(IO)F")
 
 pinfo = nil
 IO.pipe do |stdout_read, stdout_write|

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -470,7 +470,7 @@ EOM
 
     symlinks.each do |name, target, destination, real_destination|
       if File.exist?(real_destination)
-        File.symlink(target, destination)
+        create_symlink_safe(target, destination)
       else
         alert_warning "#{@spec.full_name} ships with a dangling symlink named #{name} pointing to missing #{target} file. Ignoring"
       end
@@ -724,6 +724,16 @@ EOM
     bytes = io.read(limit + 1)
     raise Gem::Package::FormatError, "#{name} is too big (over #{limit} bytes)" if bytes.size > limit
     bytes
+  end
+
+  # Create a symlink and fallback to copy the file or directory on Windows,
+  # where symlink creation needs special privileges in form of the Developer Mode.
+  def create_symlink_safe(old_name, new_name) # :nodoc:
+    File.symlink(old_name, new_name)
+  rescue Errno::EACCES
+    raise unless Gem.win_platform?
+    from = File.expand_path(old_name, File.dirname(new_name))
+    FileUtils.cp_r(from, new_name)
   end
 end
 

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -470,7 +470,7 @@ EOM
 
     symlinks.each do |name, target, destination, real_destination|
       if File.exist?(real_destination)
-        create_symlink_safe(target, destination)
+        create_symlink(target, destination)
       else
         alert_warning "#{@spec.full_name} ships with a dangling symlink named #{name} pointing to missing #{target} file. Ignoring"
       end
@@ -726,14 +726,19 @@ EOM
     bytes
   end
 
-  # Create a symlink and fallback to copy the file or directory on Windows,
-  # where symlink creation needs special privileges in form of the Developer Mode.
-  def create_symlink_safe(old_name, new_name) # :nodoc:
-    File.symlink(old_name, new_name)
-  rescue Errno::EACCES
-    raise unless Gem.win_platform?
-    from = File.expand_path(old_name, File.dirname(new_name))
-    FileUtils.cp_r(from, new_name)
+  if Gem.win_platform?
+    # Create a symlink and fallback to copy the file or directory on Windows,
+    # where symlink creation needs special privileges in form of the Developer Mode.
+    def create_symlink(old_name, new_name)
+      File.symlink(old_name, new_name)
+    rescue Errno::EACCES
+      from = File.expand_path(old_name, File.dirname(new_name))
+      FileUtils.cp_r(from, new_name)
+    end
+  else
+    def create_symlink(old_name, new_name)
+      File.symlink(old_name, new_name)
+    end
   end
 end
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1268,10 +1268,10 @@ Also, a list:
     if @@symlink_supported.nil?
       begin
         File.symlink(File.join(@tempdir, "a"), File.join(@tempdir, "b"))
-        File.unlink(File.join(@tempdir, "b"))
       rescue NotImplementedError, SystemCallError
         @@symlink_supported = false
       else
+        File.unlink(File.join(@tempdir, "b"))
         @@symlink_supported = true
       end
     end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1260,6 +1260,24 @@ Also, a list:
     system("nmake /? 1>NUL 2>&1")
   end
 
+  @@symlink_supported = nil
+
+  # This is needed for Windows environment without symlink support enabled (the default
+  # for non admin) to be able to skip test for features using symlinks.
+  def symlink_supported?
+    if @@symlink_supported.nil?
+      begin
+        File.symlink(File.join(@tempdir, "a"), File.join(@tempdir, "b"))
+        File.unlink(File.join(@tempdir, "b"))
+      rescue NotImplementedError, SystemCallError
+        @@symlink_supported = false
+      else
+        @@symlink_supported = true
+      end
+    end
+    @@symlink_supported
+  end
+
   # In case we're building docs in a background process, this method waits for
   # that process to exit (or if it's already been reaped, or never happened,
   # swallows the Errno::ECHILD error).

--- a/test/rubygems/installer_test_case.rb
+++ b/test/rubygems/installer_test_case.rb
@@ -237,21 +237,4 @@ class Gem::InstallerTestCase < Gem::TestCase
     assert_directory_exists non_existent_parent, "Parent directory should exist now"
     assert_directory_exists target_dir, "Target directory should exist now"
   end
-
-  @@symlink_supported = nil
-
-  # This is needed for Windows environment without symlink support enabled (the default
-  # for non admin) to be able to skip test for features using symlinks.
-  def symlink_supported?
-    if @@symlink_supported.nil?
-      begin
-        File.symlink("", "")
-      rescue Errno::ENOENT, Errno::EEXIST
-        @@symlink_supported = true
-      rescue NotImplementedError, SystemCallError
-        @@symlink_supported = false
-      end
-    end
-    @@symlink_supported
-  end
 end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -759,8 +759,12 @@ class TestGemInstaller < Gem::InstallerTestCase
 
     errors = @ui.error.split("\n")
     assert_equal "WARNING:  ascii_binder-0.1.10.1 ships with a dangling symlink named bin/ascii_binder pointing to missing bin/asciibinder file. Ignoring", errors.shift
-    assert_empty errors
-
+    if symlink_supported?
+      assert_empty errors
+    else
+      assert_match(/Unable to use symlinks, installing wrapper/i,
+                    errors.to_s)
+    end
     assert_empty @ui.output
   end
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -763,7 +763,7 @@ class TestGemInstaller < Gem::InstallerTestCase
       assert_empty errors
     else
       assert_match(/Unable to use symlinks, installing wrapper/i,
-                    errors.to_s)
+                   errors.to_s)
     end
     assert_empty @ui.output
   end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -190,7 +190,7 @@ class TestGemPackage < Gem::Package::TarTestCase
       File.symlink("../lib/code.rb", "lib/code_sym2.rb")
     rescue Errno::EACCES => e
       if Gem.win_platform?
-        pend "symlink - must be admin with no UAC on Windows"
+        pend "symlink - developer mode must be enabled on Windows"
       else
         raise e
       end
@@ -583,25 +583,45 @@ class TestGemPackage < Gem::Package::TarTestCase
       tar.add_symlink "lib/foo.rb", "../relative.rb", 0o644
     end
 
-    begin
-      package.extract_tar_gz tgz_io, @destination
-    rescue Errno::EACCES => e
-      if Gem.win_platform?
-        pend "symlink - must be admin with no UAC on Windows"
-      else
-        raise e
-      end
-    end
+    package.extract_tar_gz tgz_io, @destination
 
     extracted = File.join @destination, "lib/foo.rb"
     assert_path_exist extracted
-    assert_equal "../relative.rb",
-                 File.readlink(extracted)
+    if symlink_supported?
+      assert_equal "../relative.rb",
+                   File.readlink(extracted)
+    end
     assert_equal "hi",
+                 File.read(extracted),
+                 "should read file content either by following symlink or on Windows by reading copy"
+  end
+
+  def test_extract_tar_gz_symlink_directory
+    package = Gem::Package.new @gem
+    package.verify
+
+    tgz_io = util_tar_gz do |tar|
+      tar.add_symlink "link", "lib/orig", 0o644
+      tar.mkdir       "lib", 0o755
+      tar.mkdir       "lib/orig", 0o755
+      tar.add_file    "lib/orig/file.rb", 0o644 do |io|
+        io.write "ok"
+      end
+    end
+
+    package.extract_tar_gz tgz_io, @destination
+    extracted = File.join @destination, "link/file.rb"
+    assert_path_exist extracted
+    if symlink_supported?
+      assert_equal "lib/orig",
+                   File.readlink(File.dirname(extracted))
+    end
+    assert_equal "ok",
                  File.read(extracted)
   end
 
   def test_extract_symlink_into_symlink_dir
+    pend "Symlinks not supported or not enabled" unless symlink_supported?
     package = Gem::Package.new @gem
     tgz_io = util_tar_gz do |tar|
       tar.mkdir       "lib", 0o755
@@ -665,13 +685,9 @@ class TestGemPackage < Gem::Package::TarTestCase
     destination_subdir = File.join @destination, "subdir"
     FileUtils.mkdir_p destination_subdir
 
-    expected_exceptions = Gem.win_platform? ? [Gem::Package::SymlinkError, Errno::EACCES] : [Gem::Package::SymlinkError]
-
-    e = assert_raise(*expected_exceptions) do
+    e = assert_raise(Gem::Package::SymlinkError) do
       package.extract_tar_gz tgz_io, destination_subdir
     end
-
-    pend "symlink - must be admin with no UAC on Windows" if Errno::EACCES === e
 
     assert_equal("installing symlink 'lib/link' pointing to parent path #{@destination} of " \
                 "#{destination_subdir} is not allowed", e.message)
@@ -700,13 +716,9 @@ class TestGemPackage < Gem::Package::TarTestCase
       tar.add_symlink "link/dir", ".", 16_877
     end
 
-    expected_exceptions = Gem.win_platform? ? [Gem::Package::SymlinkError, Errno::EACCES] : [Gem::Package::SymlinkError]
-
-    e = assert_raise(*expected_exceptions) do
+    e = assert_raise(Gem::Package::SymlinkError) do
       package.extract_tar_gz tgz_io, destination_subdir
     end
-
-    pend "symlink - must be admin with no UAC on Windows" if Errno::EACCES === e
 
     assert_equal("installing symlink 'link' pointing to parent path #{destination_user_dir} of " \
                 "#{destination_subdir} is not allowed", e.message)

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -175,6 +175,9 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_add_files_symlink
+    unless symlink_supported?
+      omit("symlink - developer mode must be enabled on Windows")
+    end
     spec = Gem::Specification.new
     spec.files = %w[lib/code.rb lib/code_sym.rb lib/code_sym2.rb]
 
@@ -185,16 +188,8 @@ class TestGemPackage < Gem::Package::TarTestCase
     end
 
     # NOTE: 'code.rb' is correct, because it's relative to lib/code_sym.rb
-    begin
-      File.symlink("code.rb", "lib/code_sym.rb")
-      File.symlink("../lib/code.rb", "lib/code_sym2.rb")
-    rescue Errno::EACCES => e
-      if Gem.win_platform?
-        pend "symlink - developer mode must be enabled on Windows"
-      else
-        raise e
-      end
-    end
+    File.symlink("code.rb", "lib/code_sym.rb")
+    File.symlink("../lib/code.rb", "lib/code_sym2.rb")
 
     package = Gem::Package.new "bogus.gem"
     package.spec = spec
@@ -621,7 +616,7 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_extract_symlink_into_symlink_dir
-    pend "Symlinks not supported or not enabled" unless symlink_supported?
+    omit "Symlinks not supported or not enabled" unless symlink_supported?
     package = Gem::Package.new @gem
     tgz_io = util_tar_gz do |tar|
       tar.mkdir       "lib", 0o755


### PR DESCRIPTION
Symlinks are not permitted by default for a Windows user. To use them, a switch called "Development Mode" in the system settings has to be enabled.

## What was the end-user or developer problem that led to this PR?

Ordinary users as well as administrators are unable per default to install gems using symlinks.
One such problematical gem is `haml-rails-3.0.0`.
It uses symlinks for [files and directories](https://github.com/haml/haml-rails/tree/9f4703ddff0644ba52529c5cf41c1624829b16a7/lib/generators/haml/scaffold/templates).
The resulting error message is not very helpful:

```
$ gem inst haml-rails
Fetching haml-rails-3.0.0.gem
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the directory. (Gem::FilePermissionError)
        C:/ruby/lib/ruby/4.0.0/rubygems/installer.rb:308:in 'Gem::Installer#install'
        C:/ruby/lib/ruby/4.0.0/rubygems/resolver/specification.rb:105:in 'Gem::Resolver::Specification#install'
        C:/ruby/lib/ruby/4.0.0/rubygems/request_set.rb:192:in 'block in Gem::RequestSet#install'
        C:/ruby/lib/ruby/4.0.0/rubygems/request_set.rb:183:in 'Array#each'
        C:/ruby/lib/ruby/4.0.0/rubygems/request_set.rb:183:in 'Gem::RequestSet#install'
        C:/ruby/lib/ruby/4.0.0/rubygems/commands/install_command.rb:207:in 'Gem::Commands::InstallCommand#install_gem'
        C:/ruby/lib/ruby/4.0.0/rubygems/commands/install_command.rb:223:in 'block in Gem::Commands::InstallCommand#install_gems'
        C:/ruby/lib/ruby/4.0.0/rubygems/commands/install_command.rb:216:in 'Array#each'
        C:/ruby/lib/ruby/4.0.0/rubygems/commands/install_command.rb:216:in 'Gem::Commands::InstallCommand#install_gems'
        C:/ruby/lib/ruby/4.0.0/rubygems/commands/install_command.rb:162:in 'Gem::Commands::InstallCommand#execute'
        C:/ruby/lib/ruby/4.0.0/rubygems/command.rb:326:in 'Gem::Command#invoke_with_build_args'
        C:/ruby/lib/ruby/4.0.0/rubygems/command_manager.rb:252:in 'Gem::CommandManager#invoke_command'
        C:/ruby/lib/ruby/4.0.0/rubygems/command_manager.rb:193:in 'Gem::CommandManager#process_args'
        C:/ruby/lib/ruby/4.0.0/rubygems/command_manager.rb:151:in 'Gem::CommandManager#run'
        C:/ruby/lib/ruby/4.0.0/rubygems/gem_runner.rb:56:in 'Gem::GemRunner#run'
        C:/ruby/bin/gem.cmd:20:in '<main>'
```

## What is your fix for the problem, implemented in this PR?

Instead of working around the situation in the affected gem or to skip symlinks completely, I think the better solution would be to make copies of the files in question. This would allow Windows users to install and use the gem smoothly.

I didn't adjust the rubygems tests to support this non-developer-mode use case, because I want to ask if this approach is acceptable, first.

The switch for the "Developer Mode" is available in the Windows registry under
    `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock`
entry
    `AllowDevelopmentWithoutDevLicense`

Maybe we could add a Github Action run with `AllowDevelopmentWithoutDevLicense=0`, and adjust the tests to succeed in both cases.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
