### PR TITLE
Clear gem specification cache after acquiring process lock

### DIFF
--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -63,6 +63,11 @@ module Bundler
       Bundler.create_bundle_path
 
       ProcessLock.lock do
+        # Invalidate any stale gem specification cache from before we acquired the lock.
+        # Another process may have installed gems while we were waiting.
+        Gem::Specification.reset
+        @definition.sources.clear_cache
+
         @definition.ensure_equivalent_gemfile_and_lockfile(options[:deployment])
 
         if @definition.dependencies.empty?

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -315,8 +315,10 @@ module Bundler
       end
 
       def clear_cache
+        @specs = nil
         @installed_specs = nil
         @default_specs = nil
+        @cached_specs = nil
       end
 
       protected

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -314,6 +314,11 @@ module Bundler
         @allow_remote && api_fetchers.any?
       end
 
+      def clear_cache
+        @installed_specs = nil
+        @default_specs = nil
+      end
+
       protected
 
       def remote_names

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -136,6 +136,10 @@ module Bundler
       all_sources.each(&:remote!)
     end
 
+    def clear_cache
+      rubygems_sources.each(&:clear_cache)
+    end
+
     private
 
     def map_sources(replacement_sources)

--- a/spec/bundler/source/rubygems_spec.rb
+++ b/spec/bundler/source/rubygems_spec.rb
@@ -46,44 +46,41 @@ RSpec.describe Bundler::Source::Rubygems do
   end
 
   describe "#clear_cache" do
-    it "clears the installed_specs cache" do
+    it "invalidates memoized indexes so subsequent reads rebuild them" do
       source = described_class.new
 
-      # Access installed_specs to populate the cache
-      source.send(:installed_specs)
-      expect(source.instance_variable_get(:@installed_specs)).not_to be_nil
+      first_specs = source.specs
+      first_installed = source.send(:installed_specs)
+      first_default = source.send(:default_specs)
+      first_cached = source.send(:cached_specs)
 
-      # Expire the cache
+      expect(source.specs).to equal(first_specs)
+      expect(source.send(:installed_specs)).to equal(first_installed)
+      expect(source.send(:default_specs)).to equal(first_default)
+      expect(source.send(:cached_specs)).to equal(first_cached)
+
       source.clear_cache
 
-      # Cache should be cleared
-      expect(source.instance_variable_get(:@installed_specs)).to be_nil
+      expect(source.specs).not_to equal(first_specs)
+      expect(source.send(:installed_specs)).not_to equal(first_installed)
+      expect(source.send(:default_specs)).not_to equal(first_default)
+      expect(source.send(:cached_specs)).not_to equal(first_cached)
     end
 
-    it "clears the default_specs cache" do
+    it "reflects newly-discovered installed gems after clear_cache" do
       source = described_class.new
+      foo = Gem::Specification.new("foo", "1.0.0")
+      bar = Gem::Specification.new("bar", "1.0.0")
 
-      # Access default_specs to populate the cache
-      source.send(:default_specs)
-      expect(source.instance_variable_get(:@default_specs)).not_to be_nil
+      allow(Bundler.rubygems).to receive(:installed_specs).and_return([foo])
+      expect(source.send(:installed_specs).search("bar")).to be_empty
 
-      # Expire the cache
-      source.clear_cache
-
-      # Cache should be cleared
-      expect(source.instance_variable_get(:@default_specs)).to be_nil
-    end
-
-    it "clears the merged specs cache" do
-      source = described_class.new
-
-      source.instance_variable_set(:@specs, Bundler::Index.new)
-      source.instance_variable_set(:@cached_specs, Bundler::Index.new)
+      allow(Bundler.rubygems).to receive(:installed_specs).and_return([foo, bar])
+      expect(source.send(:installed_specs).search("bar")).to be_empty
 
       source.clear_cache
 
-      expect(source.instance_variable_get(:@specs)).to be_nil
-      expect(source.instance_variable_get(:@cached_specs)).to be_nil
+      expect(source.send(:installed_specs).search("bar")).not_to be_empty
     end
   end
 

--- a/spec/bundler/source/rubygems_spec.rb
+++ b/spec/bundler/source/rubygems_spec.rb
@@ -73,6 +73,18 @@ RSpec.describe Bundler::Source::Rubygems do
       # Cache should be cleared
       expect(source.instance_variable_get(:@default_specs)).to be_nil
     end
+
+    it "clears the merged specs cache" do
+      source = described_class.new
+
+      source.instance_variable_set(:@specs, Bundler::Index.new)
+      source.instance_variable_set(:@cached_specs, Bundler::Index.new)
+
+      source.clear_cache
+
+      expect(source.instance_variable_get(:@specs)).to be_nil
+      expect(source.instance_variable_get(:@cached_specs)).to be_nil
+    end
   end
 
   describe "log debug information" do

--- a/spec/bundler/source/rubygems_spec.rb
+++ b/spec/bundler/source/rubygems_spec.rb
@@ -45,6 +45,36 @@ RSpec.describe Bundler::Source::Rubygems do
     end
   end
 
+  describe "#clear_cache" do
+    it "clears the installed_specs cache" do
+      source = described_class.new
+
+      # Access installed_specs to populate the cache
+      source.send(:installed_specs)
+      expect(source.instance_variable_get(:@installed_specs)).not_to be_nil
+
+      # Expire the cache
+      source.clear_cache
+
+      # Cache should be cleared
+      expect(source.instance_variable_get(:@installed_specs)).to be_nil
+    end
+
+    it "clears the default_specs cache" do
+      source = described_class.new
+
+      # Access default_specs to populate the cache
+      source.send(:default_specs)
+      expect(source.instance_variable_get(:@default_specs)).not_to be_nil
+
+      # Expire the cache
+      source.clear_cache
+
+      # Cache should be cleared
+      expect(source.instance_variable_get(:@default_specs)).to be_nil
+    end
+  end
+
   describe "log debug information" do
     it "log the time spent downloading and installing a gem" do
       build_repo2 do

--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -442,6 +442,16 @@ RSpec.describe Bundler::SourceList do
     end
   end
 
+  describe "#clear_cache" do
+    let(:rubygems_source) { source_list.add_rubygems_source("remotes" => ["https://rubygems.org"]) }
+
+    it "calls #clear_cache on all rubygems sources" do
+      expect(rubygems_source).to receive(:clear_cache)
+      expect(source_list.global_rubygems_source).to receive(:clear_cache)
+      source_list.clear_cache
+    end
+  end
+
   describe "implicit_global_source?" do
     context "when a global rubygem source provided" do
       it "returns a falsy value" do

--- a/spec/install/process_lock_spec.rb
+++ b/spec/install/process_lock_spec.rb
@@ -53,5 +53,61 @@ RSpec.describe "process lock spec" do
         expect(processed).to eq true
       end
     end
+
+    it "refreshes gem specification cache after waiting for lock" do
+      build_repo2 do
+        build_gem "myrack", "1.0.0"
+      end
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        gem "myrack"
+      G
+
+      # First, install the gem so it's available
+      bundle "install"
+      expect(out).to include("Installing myrack")
+
+      # Queue for thread-safe communication
+      lock_acquired = Queue.new
+      can_release_lock = Queue.new
+      install_output = Queue.new
+
+      # Thread holds lock (simulating another bundle process that just finished installing)
+      thread = Thread.new do
+        Bundler::ProcessLock.lock(default_bundle_path) do
+          # Signal that we have the lock
+          lock_acquired << true
+          # Wait until main thread signals we can release
+          can_release_lock.pop
+        end
+      end
+
+      # Wait for thread to acquire lock
+      lock_acquired.pop
+
+      # Start another install in a thread - it will wait for the lock
+      install_thread = Thread.new do
+        bundle "install", verbose: true
+        install_output << out
+      end
+
+      # Give subprocess time to start and begin waiting for lock
+      sleep 0.5
+
+      # Signal thread to release the lock
+      can_release_lock << true
+
+      # Wait for both threads to complete
+      thread.join
+      install_thread.join
+
+      second_install_out = install_output.pop
+
+      expect(the_bundle).to include_gems "myrack 1.0.0"
+      # The second install should have refreshed its cache after acquiring
+      # the lock and seen that myrack was already installed
+      expect(second_install_out).to include("Using myrack")
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Fix race condition when multiple `bundle install` processes run concurrently
- Clear `Gem::Specification` and source caches after acquiring the process lock
- Add `clear_cache` method to `Source::Rubygems` and `SourceList`

## Problem

When two `bundle install` processes run concurrently:

1. Process A acquires the lock and starts installing gems
2. Process B populates its `Gem::Specification.stubs` and `@installed_specs` caches (showing no gems installed)
3. Process B tries to acquire the lock and waits
4. Process A finishes installing and releases the lock
5. Process B acquires the lock but uses its stale cache from step 2
6. Process B doesn't see the gems installed by Process A

This can lead to issues where gems appear to be missing or need reinstallation.

## Solution

After acquiring the process lock, clear the caches before proceeding with installation:

```ruby
ProcessLock.lock do
  Gem::Specification.reset
  @definition.sources.clear_cache
  # ... rest of installation
end
```

This ensures that any gems installed by another process while waiting for the lock are properly detected.

## Related

Similar to #8539 which addressed a related cache invalidation issue for the `bundle update` command.

## Diagram

```
⏺ bundle install
      │
      ├─ 1. Bundler.definition()                    ← BEFORE LOCK
      │      │
      │      └─ Definition.initialize()
      │           ├─ converge_sources()
      │           ├─ converge_paths()
      │           │    └─ specs_changed?(source)
      │           │         └─ source.specs         ← CACHE POPULATED HERE
      │           │              └─ installed_specs
      │           │                   └─ Gem::Specification.stubs  ⚠️
      │           └─ converge_locals()
      │                └─ specs_changed?(source)
      │                     └─ source.specs         ← CACHE POPULATED HERE
      │
      ├─ 2. definition.validate_runtime!            ← BEFORE LOCK
      │
      ├─ 3. Installer.install()
      │      │
      │      └─ run()
      │           │
      │           └─ ProcessLock.lock do            ← LOCK ACQUIRED
      │                 │
      │                 ├─ Gem::Specification.reset        ← FIX: Clear stale cache
      │                 ├─ sources.clear_cache             ← FIX: Clear @installed_specs
      │                 │
      │                 ├─ setup_domain!()
      │                 │    └─ install_needed?()
      │                 │         └─ resolve()      ← Uses fresh cache now
      │                 │
      │                 └─ install()                ← ACTUAL GEM INSTALLATION

  The race condition:
  Process A                              Process B
  ─────────────────────────────────────────────────────────────────
  definition()
    └─ cache: "myrack not installed"
                                         definition()
                                           └─ cache: "myrack not installed"
  ProcessLock.lock ✓ (acquired)
                                         ProcessLock.lock ⏳ (waiting...)
  install myrack
  ProcessLock.unlock
                                         ProcessLock.lock ✓ (acquired)
                                         ❌ Still sees stale cache: "myrack not installed"
                                         ❌ Tries to reinstall myrack

  With the fix:
  Process A                              Process B
  ─────────────────────────────────────────────────────────────────
  definition()
    └─ cache: "myrack not installed"
                                         definition()
                                           └─ cache: "myrack not installed"
  ProcessLock.lock ✓ (acquired)
                                         ProcessLock.lock ⏳ (waiting...)
  install myrack
  ProcessLock.unlock
                                         ProcessLock.lock ✓ (acquired)
                                         ✅ clear_cache + Gem::Specification.reset
                                         ✅ Fresh cache: "myrack IS installed"
                                         ✅ "Using myrack" (no reinstall)
```

## Test plan

- [x] Added unit tests for `Source::Rubygems#clear_cache`
- [x] Added unit test for `SourceList#clear_cache` delegation
- [x] Added integration test verifying cache refresh after waiting for lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)