### PR TITLE
Document :concurrent_downloads in gem environment config docs (follow-up to #9339)

### DIFF
--- a/lib/rubygems/commands/environment_command.rb
+++ b/lib/rubygems/commands/environment_command.rb
@@ -38,6 +38,7 @@ keys:
   :verbose: Verbosity of the gem command. false, true, and :really are the
             levels
   :update_sources: Enable/disable automatic updating of repository metadata
+  :concurrent_downloads: The number of gem downloads to perform concurrently
   :backtrace: Print backtrace when RubyGems encounters an error
   :gempath: The paths in which to look for gems
   :disable_default_gem_server: Force specification of gem server host on push

--- a/test/rubygems/test_gem_commands_environment_command.rb
+++ b/test/rubygems/test_gem_commands_environment_command.rb
@@ -164,4 +164,8 @@ class TestGemCommandsEnvironmentCommand < Gem::TestCase
     assert_equal "#{Gem.platforms.join File::PATH_SEPARATOR}\n", @ui.output
     assert_equal "", @ui.error
   end
+
+  def test_description_mentions_concurrent_downloads
+    assert_match(/:concurrent_downloads:/, @cmd.description)
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In [#9339](https://github.com/ruby/rubygems/pull/9339), `concurrent_downloads` was fixed so `.gemrc` values are honored.
However, the `.gemrc` key list shown by `gem environment` still did not mention `:concurrent_downloads`, which can make users think it is not a supported config key.

Since this text is used for command documentation (including the command reference), this needs a separate docs-focused PR.

## What is your fix for the problem, implemented in this PR?

This PR updates `Gem::Commands::EnvironmentCommand#description` to include:

- `:concurrent_downloads: The number of gem downloads to perform concurrently`

It also adds a regression test to ensure the description continues to mention this key:

- `test_description_mentions_concurrent_downloads` in `test/rubygems/test_gem_commands_environment_command.rb`

I chose this minimal approach because it directly updates the command’s canonical help text and adds test coverage to prevent future drift.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
