### PR TITLE
Lock the checksum of Bundler itself in the lockfile

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -988,6 +988,8 @@ module Bundler
         end
       end
 
+      sources.metadata_source.checksum_store.merge!(@locked_gems.metadata_source.checksum_store) if @locked_gems
+
       changes
     end
 

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -71,7 +71,8 @@ module Bundler
       checksums = definition.resolve.map do |spec|
         spec.source.checksum_store.to_lock(spec)
       end
-      add_section("CHECKSUMS", checksums)
+
+      add_section("CHECKSUMS", checksums + bundler_checksum)
     end
 
     def add_locked_ruby_version
@@ -99,6 +100,18 @@ module Bundler
       else
         raise ArgumentError, "#{value.inspect} can't be serialized in a lockfile"
       end
+    end
+
+    def bundler_checksum
+      return [] if Bundler.gem_version.to_s.end_with?(".dev")
+
+      require "rubygems/package"
+
+      bundler_spec = definition.sources.metadata_source.specs.search(["bundler", Bundler.gem_version]).last
+      package = Gem::Package.new(bundler_spec.cache_file)
+      definition.sources.metadata_source.checksum_store.register(bundler_spec, Checksum.from_gem_package(package))
+
+      [definition.sources.metadata_source.checksum_store.to_lock(bundler_spec)]
     end
   end
 end

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -28,6 +28,7 @@ module Bundler
 
     attr_reader(
       :sources,
+      :metadata_source,
       :dependencies,
       :specs,
       :platforms,
@@ -97,6 +98,7 @@ module Bundler
     def initialize(lockfile, strict: false)
       @platforms    = []
       @sources      = []
+      @metadata_source = Source::Metadata.new
       @dependencies = {}
       @parse_method = nil
       @specs        = {}
@@ -252,7 +254,12 @@ module Bundler
       version = Gem::Version.new(version)
       platform = platform ? Gem::Platform.new(platform) : Gem::Platform::RUBY
       full_name = Gem::NameTuple.new(name, version, platform).full_name
-      return unless spec = @specs[full_name]
+      spec = @specs[full_name]
+
+      if name == "bundler"
+        spec ||= LazySpecification.new(name, version, platform, @metadata_source)
+      end
+      return unless spec
 
       if checksums
         checksums.split(",") do |lock_checksum|

--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -58,6 +58,10 @@ module Bundler
       def version_message(spec)
         "#{spec.name} #{spec.version}"
       end
+
+      def checksum_store
+        @checksum_store ||= Checksum::Store.new
+      end
     end
   end
 end

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1537,6 +1537,7 @@ RSpec.describe "bundle update --bundler" do
 
     checksums = checksums_section do |c|
       c.checksum(gem_repo4, "myrack", "1.0")
+      c.checksum(gem_repo4, "bundler", "999.0.0")
     end
 
     install_gemfile <<-G
@@ -1621,6 +1622,7 @@ RSpec.describe "bundle update --bundler" do
 
     checksums = checksums_section do |c|
       c.checksum(gem_repo4, "myrack", "1.0")
+      c.checksum(gem_repo4, "bundler", "9.9.9")
     end
 
     install_gemfile <<-G
@@ -1745,6 +1747,7 @@ RSpec.describe "bundle update --bundler" do
     # Only updates properly on modern RubyGems.
     checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo4, "myrack", "1.0")
+      c.checksum(local_gem_path, "bundler", "9.0.0", Gem::Platform::RUBY, "cache")
     end
 
     expect(lockfile).to eq <<~L

--- a/bundler/spec/support/checksums.rb
+++ b/bundler/spec/support/checksums.rb
@@ -14,9 +14,9 @@ module Spec
         @checksums = @checksums.dup
       end
 
-      def checksum(repo, name, version, platform = Gem::Platform::RUBY)
+      def checksum(repo, name, version, platform = Gem::Platform::RUBY, folder = "gems")
         name_tuple = Gem::NameTuple.new(name, version, platform)
-        gem_file = File.join(repo, "gems", "#{name_tuple.full_name}.gem")
+        gem_file = File.join(repo, folder, "#{name_tuple.full_name}.gem")
         File.open(gem_file, "rb") do |f|
           register(name_tuple, Bundler::Checksum.from_gem(f, "#{gem_file} (via ChecksumsBuilder#checksum)"))
         end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I'd like to be able to lock the checksum of the `bundler` gem itself. I find strange that all gems get their checksum locked, but bundler itself (which is the only gem that *every application* will need to install due to the auto-switch feature) isn't getting locked.
I think this is a security vulnerability and I'd like to fix this.

With this patch, the lockfile will look like this:

```
GEM
  remote: https://rubygems.org/
  specs:
    warning (1.5.0)

PLATFORMS
  arm64-darwin-25
  ruby

DEPENDENCIES
  warning

CHECKSUMS
  bundler (9.9.9) sha256=fe2e521b3e2897f24b59cdc682b10ffb2a43677c183fc619911716aa3f203237 <----- This is new
  warning (1.5.0) sha256=0f12c49fea0c06757778eefdcc7771e4fd99308901e3d55c504d87afdd718c53

BUNDLED WITH
  9.9.9
```

## What is your fix for the problem, implemented in this PR?

### Details

I'd like to introduce this change into two separate changes for easier reviews. The first (this commit) only produce the checksum in the lockfile, nothings consumes it or verify it yet.

The second patch will make sure that whenever the Bundler auto-install kicks in, Bundler will verify that the locked checksum matches the Bundler version being downloaded and installed.

Though, please let me know if you'd prefer me doing the whole thing in just one PR.

### Solution

Overall the solution here is similar to how checksums are already generated for other gems. However, the `bundler` gem comes from a different source (the `Bundler::Source::Metadata`) and so it needs to be handled slightly differently.

A big part ot the change is test related. Instead of having to modify all tests that assert the state of the lockfile (which will be broken now, since the lockfile includes the Bundler checksum), I opted to automatically include the checksum whenever the helper metod `checksums_section` is called.

I'll add a few comments on the code directly for parts that may not be obvious.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
