### PR TITLE
Fix double-quoted YAML escape handling.

### DIFF
--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -255,7 +255,15 @@ module Gem
         val = val.sub(/^! /, "") if val.start_with?("! ")
 
         if val =~ /^"(.*)"$/
-          $1.gsub(/\\"/, '"').gsub(/\\n/, "\n").gsub(/\\r/, "\r").gsub(/\\t/, "\t").gsub(/\\\\/, "\\")
+          $1.gsub(/\\["nrt\\]/) do |m|
+            case m
+            when '\\"' then '"'
+            when "\\n" then "\n"
+            when "\\r" then "\r"
+            when "\\t" then "\t"
+            when "\\\\" then "\\"
+            end
+          end
         elsif val =~ /^'(.*)'$/
           $1.gsub(/''/, "'")
         elsif val == "true"

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -751,6 +751,26 @@ class TestGemSafeYAML < Gem::TestCase
     assert_equal "say\"hi\"", result["quote"]
   end
 
+  def test_load_double_quoted_backslash_before_escape_chars
+    pend "Psych mode" if Gem.use_psych?
+
+    # \\r in YAML should become literal backslash + r, not carriage return
+    result = Gem::YAMLSerializer.load('path: "D:\\\\ruby-mswin\\\\lib"')
+    assert_equal "D:\\ruby-mswin\\lib", result["path"]
+
+    # \\n should become literal backslash + n, not newline
+    result = Gem::YAMLSerializer.load('path: "C:\\\\new_folder"')
+    assert_equal "C:\\new_folder", result["path"]
+
+    # \\t should become literal backslash + t, not tab
+    result = Gem::YAMLSerializer.load('path: "C:\\\\tmp\\\\test"')
+    assert_equal "C:\\tmp\\test", result["path"]
+
+    # \\\\ should become two literal backslashes
+    result = Gem::YAMLSerializer.load('val: "a\\\\\\\\b"')
+    assert_equal "a\\\\b", result["val"]
+  end
+
   def test_load_single_quoted_escape
     pend "Psych mode" if Gem.use_psych?
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This leads installation issue of Windows.

* https://github.com/rubygems/rubygems-generate_index/actions/runs/22872629896/job/66356084420
* https://github.com/ruby/rdoc/actions/runs/22866477069/job/66334597916

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#commit-messages)
