### PR TITLE
Add `ignore_ruby_upper_bounds` and `ignore_rubygems_upper_bounds` settings

### DIFF
--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -142,6 +142,12 @@ When set, no funding requests will be printed\.
 \fBignore_messages\fR (\fBBUNDLE_IGNORE_MESSAGES\fR)
 When set, no post install messages will be printed\. To silence a single gem, use dot notation like \fBignore_messages\.httparty true\fR\.
 .TP
+\fBignore_ruby_upper_bounds\fR (\fBBUNDLE_IGNORE_RUBY_UPPER_BOUNDS\fR)
+When set, Bundler ignores upper bound constraints (\fB<\fR and \fB<=\fR) on \fBrequired_ruby_version\fR in gem metadata\. Useful when gems haven't updated their gemspecs for newer Ruby versions but still work fine\.
+.TP
+\fBignore_rubygems_upper_bounds\fR (\fBBUNDLE_IGNORE_RUBYGEMS_UPPER_BOUNDS\fR)
+When set, Bundler ignores upper bound constraints (\fB<\fR and \fB<=\fR) on \fBrequired_rubygems_version\fR in gem metadata\. Useful when gems haven't updated their gemspecs for newer RubyGems versions but still work fine\.
+.TP
 \fBinit_gems_rb\fR (\fBBUNDLE_INIT_GEMS_RB\fR)
 Generate a \fBgems\.rb\fR instead of a \fBGemfile\fR when running \fBbundle init\fR\.
 .TP

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -189,6 +189,14 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `ignore_messages` (`BUNDLE_IGNORE_MESSAGES`):
    When set, no post install messages will be printed. To silence a single gem,
    use dot notation like `ignore_messages.httparty true`.
+* `ignore_ruby_upper_bounds` (`BUNDLE_IGNORE_RUBY_UPPER_BOUNDS`):
+   When set, Bundler ignores upper bound constraints (`<` and `<=`) on
+   `required_ruby_version` in gem metadata. Useful when gems haven't updated
+   their gemspecs for newer Ruby versions but still work fine.
+* `ignore_rubygems_upper_bounds` (`BUNDLE_IGNORE_RUBYGEMS_UPPER_BOUNDS`):
+   When set, Bundler ignores upper bound constraints (`<` and `<=`) on
+   `required_rubygems_version` in gem metadata. Useful when gems haven't
+   updated their gemspecs for newer RubyGems versions but still work fine.
 * `init_gems_rb` (`BUNDLE_INIT_GEMS_RB`):
    Generate a `gems.rb` instead of a `Gemfile` when running `bundle init`.
 * `jobs` (`BUNDLE_JOBS`):

--- a/bundler/lib/bundler/match_metadata.rb
+++ b/bundler/lib/bundler/match_metadata.rb
@@ -7,7 +7,12 @@ module Bundler
     end
 
     def matches_current_ruby?
-      @required_ruby_version.satisfied_by?(Gem.ruby_version)
+      requirement = if Bundler.settings[:ignore_ruby_upper_bounds]
+        remove_upper_bounds(@required_ruby_version)
+      else
+        @required_ruby_version
+      end
+      requirement.satisfied_by?(Gem.ruby_version)
     end
 
     def matches_current_rubygems?
@@ -25,12 +30,22 @@ module Bundler
       return if requirement.nil? || requirement.none?
 
       if name == "Ruby" && Bundler.settings[:ignore_ruby_upper_bounds]
-        reqs = requirement.requirements.reject { |op, _| op == "<" || op == "<=" }
-        return if reqs.empty?
-        requirement = Gem::Requirement.new(reqs.map { |op, v| "#{op} #{v}" })
+        requirement = remove_upper_bounds(requirement)
+        return if requirement.none?
       end
 
       Gem::Dependency.new("#{name}\0", requirement)
+    end
+
+    private
+
+    def remove_upper_bounds(requirement)
+      filtered = requirement.requirements.reject {|op, _| op == "<" || op == "<=" }
+      if filtered.empty?
+        Gem::Requirement.default
+      else
+        Gem::Requirement.new(filtered.map {|op, v| "#{op} #{v}" })
+      end
     end
   end
 end

--- a/bundler/lib/bundler/match_metadata.rb
+++ b/bundler/lib/bundler/match_metadata.rb
@@ -24,6 +24,12 @@ module Bundler
     def metadata_dependency(name, requirement)
       return if requirement.nil? || requirement.none?
 
+      if name == "Ruby" && Bundler.settings[:ignore_ruby_upper_bounds]
+        reqs = requirement.requirements.reject { |op, _| op == "<" || op == "<=" }
+        return if reqs.empty?
+        requirement = Gem::Requirement.new(reqs.map { |op, v| "#{op} #{v}" })
+      end
+
       Gem::Dependency.new("#{name}\0", requirement)
     end
   end

--- a/bundler/lib/bundler/match_metadata.rb
+++ b/bundler/lib/bundler/match_metadata.rb
@@ -16,7 +16,12 @@ module Bundler
     end
 
     def matches_current_rubygems?
-      @required_rubygems_version.satisfied_by?(Gem.rubygems_version)
+      requirement = if Bundler.settings[:ignore_rubygems_upper_bounds]
+        remove_upper_bounds(@required_rubygems_version)
+      else
+        @required_rubygems_version
+      end
+      requirement.satisfied_by?(Gem.rubygems_version)
     end
 
     def expanded_dependencies
@@ -29,7 +34,8 @@ module Bundler
     def metadata_dependency(name, requirement)
       return if requirement.nil? || requirement.none?
 
-      if name == "Ruby" && Bundler.settings[:ignore_ruby_upper_bounds]
+      if (name == "Ruby" && Bundler.settings[:ignore_ruby_upper_bounds]) ||
+         (name == "RubyGems" && Bundler.settings[:ignore_rubygems_upper_bounds])
         requirement = remove_upper_bounds(requirement)
         return if requirement.none?
       end
@@ -40,7 +46,7 @@ module Bundler
     private
 
     def remove_upper_bounds(requirement)
-      filtered = requirement.requirements.reject {|op, _| op == "<" || op == "<=" }
+      filtered = requirement.requirements.reject {|op, _| ["<", "<="].include?(op) }
       if filtered.empty?
         Gem::Requirement.default
       else

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -28,6 +28,7 @@ module Bundler
       global_gem_cache
       ignore_messages
       ignore_ruby_upper_bounds
+      ignore_rubygems_upper_bounds
       init_gems_rb
       inline
       lockfile_checksums

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -27,6 +27,7 @@ module Bundler
       git.allow_insecure
       global_gem_cache
       ignore_messages
+      ignore_ruby_upper_bounds
       init_gems_rb
       inline
       lockfile_checksums

--- a/spec/bundler/match_metadata_spec.rb
+++ b/spec/bundler/match_metadata_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::MatchMetadata do
+  let(:klass) do
+    Class.new do
+      include Bundler::MatchMetadata
+
+      attr_accessor :required_ruby_version, :required_rubygems_version, :dependencies
+
+      def initialize(ruby_version, rubygems_version)
+        @required_ruby_version = ruby_version
+        @required_rubygems_version = rubygems_version
+        @dependencies = []
+      end
+
+      alias_method :runtime_dependencies, :dependencies
+    end
+  end
+
+  describe "#matches_current_ruby?" do
+    context "when the ruby version has an upper bound that excludes the current ruby" do
+      let(:spec) { klass.new(Gem::Requirement.new(">= 3.0", "< 3.1"), Gem::Requirement.default) }
+
+      it "returns false by default" do
+        expect(spec.matches_current_ruby?).to be false
+      end
+
+      it "returns true when ignore_ruby_upper_bounds is set" do
+        bundle "config set ignore_ruby_upper_bounds true"
+        expect(spec.matches_current_ruby?).to be true
+      end
+    end
+
+    context "when the ruby version has only a lower bound" do
+      let(:spec) { klass.new(Gem::Requirement.new(">= 2.0"), Gem::Requirement.default) }
+
+      it "returns true regardless of setting" do
+        expect(spec.matches_current_ruby?).to be true
+
+        bundle "config set ignore_ruby_upper_bounds true"
+        expect(spec.matches_current_ruby?).to be true
+      end
+    end
+
+    context "when the ruby version has only an upper bound" do
+      let(:spec) { klass.new(Gem::Requirement.new("< 3.1"), Gem::Requirement.default) }
+
+      it "returns false by default" do
+        expect(spec.matches_current_ruby?).to be false
+      end
+
+      it "returns true when ignore_ruby_upper_bounds is set (upper bound removed, defaults to >= 0)" do
+        bundle "config set ignore_ruby_upper_bounds true"
+        expect(spec.matches_current_ruby?).to be true
+      end
+    end
+  end
+
+  describe "#metadata_dependency" do
+    context "when ignore_ruby_upper_bounds is set" do
+      before { bundle "config set ignore_ruby_upper_bounds true" }
+
+      it "removes upper bounds from Ruby dependency" do
+        spec = klass.new(Gem::Requirement.new(">= 3.0", "< 3.1"), Gem::Requirement.default)
+        dep = spec.send(:metadata_dependency, "Ruby", spec.required_ruby_version)
+        expect(dep.requirement).to eq(Gem::Requirement.new(">= 3.0"))
+      end
+
+      it "returns nil when only upper bounds exist" do
+        spec = klass.new(Gem::Requirement.new("< 3.1"), Gem::Requirement.default)
+        dep = spec.send(:metadata_dependency, "Ruby", spec.required_ruby_version)
+        expect(dep).to be_nil
+      end
+
+      it "does not affect RubyGems dependency" do
+        spec = klass.new(Gem::Requirement.default, Gem::Requirement.new(">= 3.0", "< 4.0"))
+        dep = spec.send(:metadata_dependency, "RubyGems", spec.required_rubygems_version)
+        expect(dep.requirement).to eq(Gem::Requirement.new(">= 3.0", "< 4.0"))
+      end
+    end
+  end
+end

--- a/spec/bundler/match_metadata_spec.rb
+++ b/spec/bundler/match_metadata_spec.rb
@@ -56,6 +56,32 @@ RSpec.describe Bundler::MatchMetadata do
     end
   end
 
+  describe "#matches_current_rubygems?" do
+    context "when the rubygems version has an upper bound that excludes the current rubygems" do
+      let(:spec) { klass.new(Gem::Requirement.default, Gem::Requirement.new(">= 3.0", "< 3.1")) }
+
+      it "returns false by default" do
+        expect(spec.matches_current_rubygems?).to be false
+      end
+
+      it "returns true when ignore_rubygems_upper_bounds is set" do
+        bundle "config set ignore_rubygems_upper_bounds true"
+        expect(spec.matches_current_rubygems?).to be true
+      end
+    end
+
+    context "when the rubygems version has only a lower bound" do
+      let(:spec) { klass.new(Gem::Requirement.default, Gem::Requirement.new(">= 2.0")) }
+
+      it "returns true regardless of setting" do
+        expect(spec.matches_current_rubygems?).to be true
+
+        bundle "config set ignore_rubygems_upper_bounds true"
+        expect(spec.matches_current_rubygems?).to be true
+      end
+    end
+  end
+
   describe "#metadata_dependency" do
     context "when ignore_ruby_upper_bounds is set" do
       before { bundle "config set ignore_ruby_upper_bounds true" }
@@ -76,6 +102,22 @@ RSpec.describe Bundler::MatchMetadata do
         spec = klass.new(Gem::Requirement.default, Gem::Requirement.new(">= 3.0", "< 4.0"))
         dep = spec.send(:metadata_dependency, "RubyGems", spec.required_rubygems_version)
         expect(dep.requirement).to eq(Gem::Requirement.new(">= 3.0", "< 4.0"))
+      end
+    end
+
+    context "when ignore_rubygems_upper_bounds is set" do
+      before { bundle "config set ignore_rubygems_upper_bounds true" }
+
+      it "removes upper bounds from RubyGems dependency" do
+        spec = klass.new(Gem::Requirement.default, Gem::Requirement.new(">= 3.0", "< 4.0"))
+        dep = spec.send(:metadata_dependency, "RubyGems", spec.required_rubygems_version)
+        expect(dep.requirement).to eq(Gem::Requirement.new(">= 3.0"))
+      end
+
+      it "does not affect Ruby dependency" do
+        spec = klass.new(Gem::Requirement.new(">= 3.0", "< 3.1"), Gem::Requirement.default)
+        dep = spec.send(:metadata_dependency, "Ruby", spec.required_ruby_version)
+        expect(dep.requirement).to eq(Gem::Requirement.new(">= 3.0", "< 3.1"))
       end
     end
   end


### PR DESCRIPTION
## Summary

While reviewing #9316, I found tobi's `ignore_ruby_upper_bounds` commit and extended it to also cover `matches_current_ruby?`, and then applied the same pattern to add `ignore_rubygems_upper_bounds` — since `required_rubygems_version` constraints cause the same problem.

When using a new version of Ruby or RubyGems, many gems fail to install because their gemspecs contain upper bound constraints like `required_ruby_version = ">= 3.0", "< 4.0"` that haven't been updated yet.

In most cases the gem works fine — the constraint is just stale. This is especially painful right after a new Ruby release, where developers have to wait for every gem author to update their gemspec before they can run `bundle install`.

This PR adds two opt-in settings that strip `<` and `<=` constraints from gem metadata:

- `BUNDLE_IGNORE_RUBY_UPPER_BOUNDS=true` removes upper bounds from `required_ruby_version`
- `BUNDLE_IGNORE_RUBYGEMS_UPPER_BOUNDS=true` removes upper bounds from `required_rubygems_version`

As a side effect, removing these constraints also reduces resolver backtracking. In a synthetic benchmark with many constrained gem versions, resolution is approximately 2.8x faster with the settings enabled.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
