### PR TITLE
Prepend project bin/ to PATH in bundle exec for load-relative Ruby

### DIFF
--- a/bundler/lib/bundler/shared_helpers.rb
+++ b/bundler/lib/bundler/shared_helpers.rb
@@ -342,6 +342,9 @@ module Bundler
       validate_bundle_path
       paths = (ENV["PATH"] || "").split(File::PATH_SEPARATOR)
       paths.unshift "#{Bundler.bundle_path}/bin"
+      bin_dir = Bundler.settings[:bin] || "bin"
+      bin_path = Pathname.new(bin_dir).expand_path(Bundler.root)
+      paths.unshift bin_path.to_s if bin_path.directory?
       Bundler::SharedHelpers.set_env "PATH", paths.uniq.join(File::PATH_SEPARATOR)
     end
 

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -347,6 +347,7 @@ RSpec.describe Bundler::SharedHelpers do
       before do
         Dir.mkdir bundled_app(".bundle")
         Dir.mkdir(bundled_app("bin")) unless File.directory?(bundled_app("bin"))
+        ENV["BUNDLE_GEMFILE"] = bundled_app_gemfile.to_s
         ENV["PATH"] = "/usr/bin"
       end
 
@@ -364,6 +365,7 @@ RSpec.describe Bundler::SharedHelpers do
       before do
         Dir.mkdir bundled_app(".bundle")
         FileUtils.rm_rf(bundled_app("bin"))
+        ENV["BUNDLE_GEMFILE"] = bundled_app_gemfile.to_s
         ENV["PATH"] = "/usr/bin"
       end
 

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -343,6 +343,37 @@ RSpec.describe Bundler::SharedHelpers do
       it_behaves_like "ENV['PATH'] gets set correctly"
     end
 
+    context "when project bin/ directory exists" do
+      before do
+        Dir.mkdir bundled_app(".bundle")
+        Dir.mkdir(bundled_app("bin")) unless File.directory?(bundled_app("bin"))
+        ENV["PATH"] = "/usr/bin"
+      end
+
+      it "prepends project bin/ to ENV['PATH'] before bundle path bin" do
+        subject.set_bundle_environment
+        paths = ENV["PATH"].split(File::PATH_SEPARATOR)
+        bundle_bin_index = paths.index("#{Bundler.bundle_path}/bin")
+        project_bin_index = paths.index(bundled_app("bin").to_s)
+        expect(project_bin_index).not_to be_nil
+        expect(project_bin_index).to be < bundle_bin_index
+      end
+    end
+
+    context "when project bin/ directory does not exist" do
+      before do
+        Dir.mkdir bundled_app(".bundle")
+        FileUtils.rm_rf(bundled_app("bin"))
+        ENV["PATH"] = "/usr/bin"
+      end
+
+      it "does not prepend project bin/ to ENV['PATH']" do
+        subject.set_bundle_environment
+        paths = ENV["PATH"].split(File::PATH_SEPARATOR)
+        expect(paths).not_to include(bundled_app("bin").to_s)
+      end
+    end
+
     context "ENV['PATH'] already contains the bundle bin path" do
       let(:bundle_path) { "#{Bundler.bundle_path}/bin" }
 


### PR DESCRIPTION
## Summary

When Ruby is compiled with `--enable-load-relative` (as done by [mise](https://mise.jdx.dev/)), RubyGems generates binstubs with a `#!/bin/sh` shell wrapper that resolves `ruby` relative to the binstub directory:

```sh
bindir="${0%/*}"
exec "$bindir/ruby" "-x" "$0" "$@"
```

When `BUNDLE_PATH` is set to `vendor/bundle`, `set_path` prepends `vendor/bundle/ruby/X.Y.Z/bin` to `PATH`. `bundle exec` then finds the vendor binstub first via `Bundler.which`, but since its shebang is `#!/bin/sh` (not `#!/usr/bin/env ruby`), `ruby_shebang?` returns `false` and Bundler falls back to `kernel_exec`. The OS executes the shell wrapper, which looks for `$bindir/ruby` in the vendor bin directory — where no `ruby` binary exists — and fails:

```
vendor/bundle/ruby/3.3.0/bin/rspec: line 6: vendor/bundle/ruby/3.3.0/bin/ruby: No such file or directory
```

## Fix

This PR prepends the project `bin/` directory (where Bundler generates binstubs with `#!/usr/bin/env ruby` via `env_shebang: true`) to `PATH` **before** the vendor bin path in `SharedHelpers#set_path`. This ensures `Bundler.which` finds the correctly-shimmed project binstub first, allowing `ruby_shebang?` to return `true` and `kernel_load` to execute the command in-process.

The project `bin/` is only added when the directory actually exists, avoiding side effects for projects without binstubs.

## Root Cause Analysis

Three factors combine to produce this bug:

1. **`--enable-load-relative` Ruby** (mise builds): `LIBRUBY_RELATIVE=yes` triggers `bash_prolog_script` in `Gem::Installer#shebang`, wrapping every vendor binstub in a `#!/bin/sh` prologue
2. **`set_path` only prepends vendor bin**: `vendor/bundle/ruby/X.Y.Z/bin` is added to PATH but `bin/` is not, so the broken vendor binstub is found first
3. **`ruby_shebang?` doesn't match `#!/bin/sh`**: The shell wrapper falls through to `kernel_exec`, which executes it as a shell script that fails to find `$bindir/ruby`

## Related Issues

- Fixes https://github.com/ruby/rubygems/issues/9495
- https://github.com/ruby/rubygems/issues/8441

## Test Plan

- Added spec: project `bin/` directory is prepended to PATH before vendor bundle bin when it exists
- Added spec: project `bin/` is not added to PATH when the directory doesn't exist
- Verified manually: `bundle exec rspec` works on a project with `BUNDLE_PATH=vendor/bundle` and mise Ruby 3.3.10