### PR TITLE
Add plugin hooks for Gemfile evaluation and source fetching

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -38,7 +38,10 @@ module Bundler
 
       raise GemfileNotFound, "#{gemfile} not found" unless gemfile.file?
 
-      Dsl.evaluate(gemfile, lockfile, unlock)
+      Plugin.hook(Plugin::Events::GEM_BEFORE_EVAL, gemfile, lockfile)
+      Dsl.evaluate(gemfile, lockfile, unlock).tap do |definition|
+        Plugin.hook(Plugin::Events::GEM_AFTER_EVAL, definition)
+      end
     end
 
     #

--- a/bundler/lib/bundler/plugin/events.rb
+++ b/bundler/lib/bundler/plugin/events.rb
@@ -46,6 +46,30 @@ module Bundler
       define :GEM_AFTER_INSTALL,  "after-install"
 
       # @!parse
+      #   A hook called before each individual gem is downloaded from a remote source.
+      #   Includes a Gem::Specification. Does not fire on cache hits.
+      #   GEM_BEFORE_FETCH = "before-fetch"
+      define :GEM_BEFORE_FETCH, "before-fetch"
+
+      # @!parse
+      #   A hook called after each individual gem is downloaded from a remote source.
+      #   Includes a Gem::Specification. Does not fire on cache hits.
+      #   GEM_AFTER_FETCH = "after-fetch"
+      define :GEM_AFTER_FETCH, "after-fetch"
+
+      # @!parse
+      #   A hook called before a git source is fetched.
+      #   Includes a Bundler::Source::Git reference.
+      #   GIT_BEFORE_FETCH = "before-git-fetch"
+      define :GIT_BEFORE_FETCH, "before-git-fetch"
+
+      # @!parse
+      #   A hook called after a git source is fetched.
+      #   Includes a Bundler::Source::Git reference.
+      #   GIT_AFTER_FETCH = "after-git-fetch"
+      define :GIT_AFTER_FETCH, "after-git-fetch"
+
+      # @!parse
       #   A hook called before any gems install
       #   Includes an Array of Bundler::Dependency objects
       #   GEM_BEFORE_INSTALL_ALL = "before-install-all"

--- a/bundler/lib/bundler/plugin/events.rb
+++ b/bundler/lib/bundler/plugin/events.rb
@@ -80,6 +80,18 @@ module Bundler
       #   Includes an Array of Bundler::Dependency objects.
       #   GEM_AFTER_REQUIRE_ALL = "after-require-all"
       define :GEM_AFTER_REQUIRE_ALL,  "after-require-all"
+
+      # @!parse
+      #   A hook called before the Gemfile is evaluated
+      #   Includes the Gemfile path and the Lockfile path
+      #   GEM_BEFORE_EVAL = "before-eval"
+      define :GEM_BEFORE_EVAL, "before-eval"
+
+      # @!parse
+      #   A hook called after the Gemfile is evaluated
+      #   Includes a Bundler::Definition
+      #   GEM_AFTER_EVAL = "after-eval"
+      define :GEM_AFTER_EVAL, "after-eval"
     end
   end
 end

--- a/bundler/lib/bundler/plugin/events.rb
+++ b/bundler/lib/bundler/plugin/events.rb
@@ -50,13 +50,19 @@ module Bundler
 
       # @!parse
       #   A hook called before each individual gem is downloaded from a remote source.
-      #   Includes a Gem::Specification. Does not fire on cache hits.
+      #   Includes a spec-like object responding to the Gem::Specification API
+      #   (for example, a Bundler spec proxy such as Bundler::EndpointSpecification
+      #   or Bundler::RemoteSpecification). Does not fire when the gem is already
+      #   present at the initial download-cache check.
       #   GEM_BEFORE_FETCH = "before-fetch"
       define :GEM_BEFORE_FETCH, "before-fetch"
 
       # @!parse
       #   A hook called after each individual gem is downloaded from a remote source.
-      #   Includes a Gem::Specification. Does not fire on cache hits.
+      #   Includes a spec-like object responding to the Gem::Specification API
+      #   (for example, a Bundler spec proxy such as Bundler::EndpointSpecification
+      #   or Bundler::RemoteSpecification). Does not fire when the gem is already
+      #   present at the initial download-cache check.
       #   GEM_AFTER_FETCH = "after-fetch"
       define :GEM_AFTER_FETCH, "after-fetch"
 

--- a/bundler/lib/bundler/plugin/events.rb
+++ b/bundler/lib/bundler/plugin/events.rb
@@ -31,6 +31,48 @@ module Bundler
       end
 
       # @!parse
+      #   A hook called before the Gemfile is evaluated
+      #   Includes the Gemfile path and the Lockfile path
+      #   GEM_BEFORE_EVAL = "before-eval"
+      define :GEM_BEFORE_EVAL, "before-eval"
+
+      # @!parse
+      #   A hook called after the Gemfile is evaluated
+      #   Includes a Bundler::Definition
+      #   GEM_AFTER_EVAL = "after-eval"
+      define :GEM_AFTER_EVAL, "after-eval"
+
+      # @!parse
+      #   A hook called before any gems install
+      #   Includes an Array of Bundler::Dependency objects
+      #   GEM_BEFORE_INSTALL_ALL = "before-install-all"
+      define :GEM_BEFORE_INSTALL_ALL, "before-install-all"
+
+      # @!parse
+      #   A hook called before each individual gem is downloaded from a remote source.
+      #   Includes a Gem::Specification. Does not fire on cache hits.
+      #   GEM_BEFORE_FETCH = "before-fetch"
+      define :GEM_BEFORE_FETCH, "before-fetch"
+
+      # @!parse
+      #   A hook called after each individual gem is downloaded from a remote source.
+      #   Includes a Gem::Specification. Does not fire on cache hits.
+      #   GEM_AFTER_FETCH = "after-fetch"
+      define :GEM_AFTER_FETCH, "after-fetch"
+
+      # @!parse
+      #   A hook called before a git source is fetched or checked out.
+      #   Includes a Bundler::Source::Git reference.
+      #   GIT_BEFORE_FETCH = "before-git-fetch"
+      define :GIT_BEFORE_FETCH, "before-git-fetch"
+
+      # @!parse
+      #   A hook called after a git source is fetched or checked out.
+      #   Includes a Bundler::Source::Git reference.
+      #   GIT_AFTER_FETCH = "after-git-fetch"
+      define :GIT_AFTER_FETCH, "after-git-fetch"
+
+      # @!parse
       #   A hook called before each individual gem is installed
       #   Includes a Bundler::ParallelInstaller::SpecInstallation.
       #   No state, error, post_install_message will be present as nothing has installed yet
@@ -46,40 +88,16 @@ module Bundler
       define :GEM_AFTER_INSTALL,  "after-install"
 
       # @!parse
-      #   A hook called before each individual gem is downloaded from a remote source.
-      #   Includes a Gem::Specification. Does not fire on cache hits.
-      #   GEM_BEFORE_FETCH = "before-fetch"
-      define :GEM_BEFORE_FETCH, "before-fetch"
-
-      # @!parse
-      #   A hook called after each individual gem is downloaded from a remote source.
-      #   Includes a Gem::Specification. Does not fire on cache hits.
-      #   GEM_AFTER_FETCH = "after-fetch"
-      define :GEM_AFTER_FETCH, "after-fetch"
-
-      # @!parse
-      #   A hook called before a git source is fetched.
-      #   Includes a Bundler::Source::Git reference.
-      #   GIT_BEFORE_FETCH = "before-git-fetch"
-      define :GIT_BEFORE_FETCH, "before-git-fetch"
-
-      # @!parse
-      #   A hook called after a git source is fetched.
-      #   Includes a Bundler::Source::Git reference.
-      #   GIT_AFTER_FETCH = "after-git-fetch"
-      define :GIT_AFTER_FETCH, "after-git-fetch"
-
-      # @!parse
-      #   A hook called before any gems install
-      #   Includes an Array of Bundler::Dependency objects
-      #   GEM_BEFORE_INSTALL_ALL = "before-install-all"
-      define :GEM_BEFORE_INSTALL_ALL, "before-install-all"
-
-      # @!parse
       #   A hook called after any gems install
       #   Includes an Array of Bundler::Dependency objects
       #   GEM_AFTER_INSTALL_ALL = "after-install-all"
       define :GEM_AFTER_INSTALL_ALL,  "after-install-all"
+
+      # @!parse
+      #   A hook called before any gems require
+      #   Includes an Array of Bundler::Dependency objects.
+      #   GEM_BEFORE_REQUIRE_ALL = "before-require-all"
+      define :GEM_BEFORE_REQUIRE_ALL, "before-require-all"
 
       # @!parse
       #   A hook called before each individual gem is required
@@ -94,28 +112,10 @@ module Bundler
       define :GEM_AFTER_REQUIRE,  "after-require"
 
       # @!parse
-      #   A hook called before any gems require
-      #   Includes an Array of Bundler::Dependency objects.
-      #   GEM_BEFORE_REQUIRE_ALL = "before-require-all"
-      define :GEM_BEFORE_REQUIRE_ALL, "before-require-all"
-
-      # @!parse
       #   A hook called after all gems required
       #   Includes an Array of Bundler::Dependency objects.
       #   GEM_AFTER_REQUIRE_ALL = "after-require-all"
-      define :GEM_AFTER_REQUIRE_ALL,  "after-require-all"
-
-      # @!parse
-      #   A hook called before the Gemfile is evaluated
-      #   Includes the Gemfile path and the Lockfile path
-      #   GEM_BEFORE_EVAL = "before-eval"
-      define :GEM_BEFORE_EVAL, "before-eval"
-
-      # @!parse
-      #   A hook called after the Gemfile is evaluated
-      #   Includes a Bundler::Definition
-      #   GEM_AFTER_EVAL = "after-eval"
-      define :GEM_AFTER_EVAL, "after-eval"
+      define :GEM_AFTER_REQUIRE_ALL, "after-require-all"
     end
   end
 end

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -191,8 +191,10 @@ module Bundler
         set_cache_path!(app_cache_path) if use_app_cache?
 
         if requires_checkout? && !@copied
+          Plugin.hook(Plugin::Events::GIT_BEFORE_FETCH, self)
           fetch unless use_app_cache?
           checkout
+          Plugin.hook(Plugin::Events::GIT_AFTER_FETCH, self)
         end
 
         local_specs

--- a/bundler/lib/bundler/source/git.rb
+++ b/bundler/lib/bundler/source/git.rb
@@ -192,9 +192,12 @@ module Bundler
 
         if requires_checkout? && !@copied
           Plugin.hook(Plugin::Events::GIT_BEFORE_FETCH, self)
-          fetch unless use_app_cache?
-          checkout
-          Plugin.hook(Plugin::Events::GIT_AFTER_FETCH, self)
+          begin
+            fetch unless use_app_cache?
+            checkout
+          ensure
+            Plugin.hook(Plugin::Events::GIT_AFTER_FETCH, self)
+          end
         end
 
         local_specs

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -478,10 +478,13 @@ module Bundler
         gem_remote_fetcher = remote_fetchers.fetch(spec.remote).gem_remote_fetcher
 
         Plugin.hook(Plugin::Events::GEM_BEFORE_FETCH, spec)
-        Gem.time("Downloaded #{spec.name} in", 0, true) do
-          Bundler.rubygems.download_gem(spec, uri, download_cache_path, gem_remote_fetcher)
+        begin
+          Gem.time("Downloaded #{spec.name} in", 0, true) do
+            Bundler.rubygems.download_gem(spec, uri, download_cache_path, gem_remote_fetcher)
+          end
+        ensure
+          Plugin.hook(Plugin::Events::GEM_AFTER_FETCH, spec)
         end
-        Plugin.hook(Plugin::Events::GEM_AFTER_FETCH, spec)
       end
 
       # Returns the global cache path of the calling Rubygems::Source object.

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -477,9 +477,11 @@ module Bundler
         Bundler.ui.confirm("Fetching #{version_message(spec, previous_spec)}")
         gem_remote_fetcher = remote_fetchers.fetch(spec.remote).gem_remote_fetcher
 
+        Plugin.hook(Plugin::Events::GEM_BEFORE_FETCH, spec)
         Gem.time("Downloaded #{spec.name} in", 0, true) do
           Bundler.rubygems.download_gem(spec, uri, download_cache_path, gem_remote_fetcher)
         end
+        Plugin.hook(Plugin::Events::GEM_AFTER_FETCH, spec)
       end
 
       # Returns the global cache path of the calling Rubygems::Source object.

--- a/spec/commands/doctor_spec.rb
+++ b/spec/commands/doctor_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe "bundle doctor" do
       allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       allow(Find).to receive(:find).with(Bundler.bundle_path.to_s) { [unwritable_file] }
       allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:writable?).and_call_original
+      allow(File).to receive(:readable?).and_call_original
       allow(File).to receive(:exist?).with(unwritable_file).and_return(true)
       allow(File).to receive(:stat).with(unwritable_file) { stat }
       allow(stat).to receive(:uid) { Process.uid }
@@ -108,6 +110,8 @@ RSpec.describe "bundle doctor" do
       allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       allow(Find).to receive(:find).with(Bundler.bundle_path.to_s) { [@unwritable_file] }
       allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:writable?).and_call_original
+      allow(File).to receive(:readable?).and_call_original
       allow(File).to receive(:exist?).with(@unwritable_file) { true }
       allow(File).to receive(:stat).with(@unwritable_file) { @stat }
     end

--- a/spec/plugins/hook_spec.rb
+++ b/spec/plugins/hook_spec.rb
@@ -193,6 +193,57 @@ RSpec.describe "hook plugins" do
     end
   end
 
+  context "before-eval hook" do
+    before do
+      build_repo2 do
+        build_plugin "before-eval-plugin" do |s|
+          s.write "plugins.rb", <<-RUBY
+            Bundler::Plugin::API.hook Bundler::Plugin::Events::GEM_BEFORE_EVAL do |gemfile, lockfile|
+              puts "hooked eval start of \#{File.basename(gemfile)} to \#{File.basename(lockfile)}"
+            end
+          RUBY
+        end
+      end
+
+      bundle "plugin install before-eval-plugin --source https://gem.repo2"
+    end
+
+    it "runs before the Gemfile is evaluated" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "rake"
+      G
+
+      expect(out).to include "hooked eval start of Gemfile to Gemfile.lock"
+    end
+  end
+
+  context "after-eval hook" do
+    before do
+      build_repo2 do
+        build_plugin "after-eval-plugin" do |s|
+          s.write "plugins.rb", <<-RUBY
+            Bundler::Plugin::API.hook Bundler::Plugin::Events::GEM_AFTER_EVAL do |defn|
+              puts "hooked eval after with gems \#{defn.dependencies.map(&:name).join(", ")}"
+            end
+          RUBY
+        end
+      end
+
+      bundle "plugin install after-eval-plugin --source https://gem.repo2"
+    end
+
+    it "runs after the Gemfile is evaluated" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack"
+        gem "rake"
+      G
+
+      expect(out).to include "hooked eval after with gems myrack, rake"
+    end
+  end
+
   def install_gemfile_and_bundler_require
     install_gemfile <<-G
       source "https://gem.repo1"

--- a/spec/plugins/hook_spec.rb
+++ b/spec/plugins/hook_spec.rb
@@ -244,6 +244,78 @@ RSpec.describe "hook plugins" do
     end
   end
 
+  context "before-fetch and after-fetch hooks" do
+    before do
+      build_repo2 do
+        build_plugin "fetch-timing-plugin" do |s|
+          s.write "plugins.rb", <<-RUBY
+            @timing_start = nil
+            Bundler::Plugin::API.hook Bundler::Plugin::Events::GEM_BEFORE_FETCH do |spec|
+              @timing_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              puts "gem \#{spec.name} started fetch at \#{@timing_start}"
+            end
+            Bundler::Plugin::API.hook Bundler::Plugin::Events::GEM_AFTER_FETCH do |spec|
+              timing_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              puts "gem \#{spec.name} took \#{timing_end - @timing_start} to fetch"
+              @timing_start = nil
+            end
+          RUBY
+        end
+      end
+
+      bundle "plugin install fetch-timing-plugin --source https://gem.repo2"
+    end
+
+    it "runs around each gem download" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "rake"
+        gem "myrack"
+      G
+
+      expect(out).to include "gem rake started fetch at"
+      expect(out).to match(/gem rake took \d+\.\d+ to fetch/)
+      expect(out).to include "gem myrack started fetch at"
+      expect(out).to match(/gem myrack took \d+\.\d+ to fetch/)
+    end
+  end
+
+  context "before-git-fetch and after-git-fetch hooks" do
+    before do
+      build_repo2 do
+        build_plugin "git-fetch-timing-plugin" do |s|
+          s.write "plugins.rb", <<-RUBY
+            @timing_start = nil
+            Bundler::Plugin::API.hook Bundler::Plugin::Events::GIT_BEFORE_FETCH do |source|
+              @timing_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              puts "git source \#{source.name} started fetch at \#{@timing_start}"
+            end
+            Bundler::Plugin::API.hook Bundler::Plugin::Events::GIT_AFTER_FETCH do |source|
+              timing_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              puts "git source \#{source.name} took \#{timing_end - @timing_start} to fetch"
+              @timing_start = nil
+            end
+          RUBY
+        end
+      end
+
+      bundle "plugin install git-fetch-timing-plugin --source https://gem.repo2"
+    end
+
+    it "runs around each git source fetch" do
+      build_git "foo", "1.0", path: lib_path("foo")
+
+      relative_path = lib_path("foo").relative_path_from(bundled_app)
+      install_gemfile <<-G, verbose: true
+        source "https://gem.repo1"
+        gem "foo", :git => "#{relative_path}"
+      G
+
+      expect(out).to include "git source foo started fetch at"
+      expect(out).to match(/git source foo took \d+\.\d+ to fetch/)
+    end
+  end
+
   def install_gemfile_and_bundler_require
     install_gemfile <<-G
       source "https://gem.repo1"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler's plugin hook mechanism only covers install and require operations. PR #6961 proposed eval hooks and PR #8162 proposed fetch hooks, but both have been open for years without a conclusion.

## What is your fix for the problem, implemented in this PR?

Rebases #6961 and #8162 onto the current codebase and consolidates them into one cohesive set of hook points, with the following adjustments after review.

For eval hooks, the `unlock` argument was removed from `before-eval` since it exposes internal state that plugins should not depend on.

For fetch hooks, the hook position was moved from `fetch_gem_if_possible` to `Source::Rubygems#download_gem` so the hooks fire only on actual network downloads, not on cache hits or `bundle cache` runs. The `source` argument was dropped because `spec.source` already provides it. The hook invocations are wrapped in `begin`/`ensure` so the `after` hook fires even when the download raises, matching the behavior of the existing `GEM_AFTER_INSTALL` hook.

For git fetch hooks, the event names were renamed from `git-before-fetch` / `git-after-fetch` to `before-git-fetch` / `after-git-fetch` for consistency with the existing `before-*` / `after-*` naming pattern. The redundant `GEM_BEFORE_FETCH` / `GEM_AFTER_FETCH` invocations in `Source::Git#install` were removed since using gem fetch events for git sources is semantically inconsistent. As with the gem fetch hooks, the invocations are wrapped in `begin`/`ensure`.

Closes https://github.com/ruby/rubygems/pull/6961
Closes https://github.com/ruby/rubygems/pull/8162

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
