### PR TITLE
Gracefully handle missing checksums in Compact Index

### DIFF
--- a/bundler/lib/bundler/compact_index_client/parser.rb
+++ b/bundler/lib/bundler/compact_index_client/parser.rb
@@ -71,7 +71,10 @@ module Bundler
       # This method gets called at least once for every gem when parsing versions.
       def parse_version_checksum(line, checksums)
         return unless (name_end = line.index(" ")) # Artifactory bug causes blank lines in artifactor index files
-        return unless (checksum_start = line.index(" ", name_end + 1) + 1)
+        checksum_start = line.index(" ", name_end + 1)
+        return unless checksum_start
+        checksum_start += 1
+
         checksum_end = line.size - checksum_start
 
         line.freeze # allows slicing into the string to not allocate a copy of the line

--- a/spec/bundler/compact_index_client/parser_spec.rb
+++ b/spec/bundler/compact_index_client/parser_spec.rb
@@ -233,5 +233,17 @@ RSpec.describe Bundler::CompactIndexClient::Parser do
       VERSIONS
       expect(parser.info("a")).to eq(a_result)
     end
+
+    it "handles lines without a checksum" do
+      compact_index.versions = <<~VERSIONS
+        created_at: 2024-05-01T00:00:04Z
+        ---
+        a 1.0.0,1.0.1,1.1.0 aaa111
+        b 2.0.0,2.0.0-java
+        c 3.0.0,3.0.3,3.3.3 ccc333
+      VERSIONS
+
+      expect(parser.info("a")).to eq(a_result)
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes #9491.

## What is your fix for the problem, implemented in this PR?

I've changed `CompactIndexClient::Parser#parse_version_checksum` to fail gracefully in the way it looks like @martinemde  originally intended, by placing the nil check before any addition.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
