### PR TITLE
Prepare RubyGems 4.0.11 and Bundler 4.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.0.11 / 2026-04-23
+
+### Enhancements:
+
+* Add commented-out rubygems_mfa_required to bundle gem template. Pull request [#9487](https://github.com/ruby/rubygems/pull/9487) by MatheusRich
+* Clarify the name and meaning of the first argument to `gem spec`. Pull request [#9476](https://github.com/ruby/rubygems/pull/9476) by eregon
+* Installs bundler 4.0.11 as a default gem.
+
 ## 4.0.10 / 2026-04-08
 
 ### Enhancements:

--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ namespace :version do
     version = stdout.split(" ").last
 
     Dir.glob("{tool/bundler/*_gems.rb,bundler/spec/realworld/fixtures/*/Gemfile}").each do |file|
-      Spec::Rubygems.dev_bundle("update", "--bundler", version, gemfile: file)
+      Spec::Rubygems.dev_bundle("lock", "--bundler", version, gemfile: file)
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -29,12 +29,12 @@ end
 
 namespace :version do
   desc "Update the locked bundler version in dev environment"
-  task update_locked_bundler: [:"bundler:install"] do |_, _args|
+  task :update_locked_bundler do |_, _args|
     stdout = Spec::Rubygems.dev_bundle "--version"
     version = stdout.split(" ").last
 
     Dir.glob("{tool/bundler/*_gems.rb,bundler/spec/realworld/fixtures/*/Gemfile}").each do |file|
-      Spec::Rubygems.dev_bundle("lock", "--bundler", version, gemfile: file)
+      Spec::Rubygems.dev_bundle("lock", "--bundler", "--bundler", version, gemfile: file)
     end
   end
 

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 4.0.11 / 2026-04-23
+
+### Enhancements:
+
+* Print a warning for a potential confusion from the indirect dependencies. Pull request [#5029](https://github.com/ruby/rubygems/pull/5029) by junaruga
+* Lock the checksum of Bundler itself in the lockfile. Pull request [#9366](https://github.com/ruby/rubygems/pull/9366) by Edouard-chin
+
+### Bug fixes:
+
+* Fix installing gems with native extensions + transitive dependencies. Pull request [#9477](https://github.com/ruby/rubygems/pull/9477) by nicholasdower
+* Fix the bundler version not being updated in dev/test lockfile. Pull request [#9463](https://github.com/ruby/rubygems/pull/9463) by Edouard-chin
+* Ensure the release CI doesn't break due to the Bundler checksum feature. Pull request [#9436](https://github.com/ruby/rubygems/pull/9436) by Edouard-chin
+
+### Documentation:
+
+* Fix formatting for BUNDLE_PREFER_PATCH variable in man page. Pull request [#9474](https://github.com/ruby/rubygems/pull/9474) by toy
+
 ## 4.0.10 / 2026-04-08
 
 ### Enhancements:

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -988,6 +988,8 @@ module Bundler
         end
       end
 
+      sources.metadata_source.checksum_store.merge!(@locked_gems.metadata_source.checksum_store) if @locked_gems
+
       changes
     end
 

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -6,7 +6,7 @@ require_relative "gem_installer"
 module Bundler
   class ParallelInstaller
     class SpecInstallation
-      attr_accessor :spec, :name, :full_name, :post_install_message, :state, :error
+      attr_accessor :spec, :name, :full_name, :post_install_message, :state, :error, :dependencies
       def initialize(spec)
         @spec = spec
         @name = spec.name
@@ -46,25 +46,11 @@ module Bundler
         !post_install_message.empty?
       end
 
-      def ignorable_dependency?(dep)
-        dep.type == :development || dep.name == @name
-      end
-
-      # Checks installed dependencies against spec's dependencies to make
-      # sure needed dependencies have been installed.
+      # Recursively checks that all dependencies (direct and transitive) have been installed.
       def dependencies_installed?(installed_specs)
-        dependencies.all? {|d| installed_specs.include? d.name }
-      end
-
-      # Represents only the non-development dependencies, the ones that are
-      # itself and are in the total list.
-      def dependencies
-        @dependencies ||= all_dependencies.reject {|dep| ignorable_dependency? dep }
-      end
-
-      # Represents all dependencies
-      def all_dependencies
-        @spec.dependencies
+        dependencies.all? do |dep|
+          installed_specs.include?(dep.name) && dep.dependencies_installed?(installed_specs)
+        end
       end
 
       def to_s
@@ -85,6 +71,12 @@ module Bundler
       @force = force
       @local = local
       @specs = all_specs.map {|s| SpecInstallation.new(s) }
+      specs_by_name = @specs.to_h {|s| [s.name, s] }
+      @specs.each do |spec_install|
+        spec_install.dependencies = spec_install.spec.dependencies.filter_map do |dep|
+          specs_by_name[dep.name] unless dep.type == :development || dep.name == spec_install.name
+        end
+      end
       @specs.each do |spec_install|
         spec_install.state = :installed if skip.include?(spec_install.name)
       end if skip

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -105,9 +105,11 @@ module Bundler
     def bundler_checksum
       return [] if Bundler.gem_version.to_s.end_with?(".dev")
 
+      bundler_spec = definition.sources.metadata_source.specs.search(["bundler", Bundler.gem_version]).last
+      return [] unless File.exist?(bundler_spec.cache_file)
+
       require "rubygems/package"
 
-      bundler_spec = definition.sources.metadata_source.specs.search(["bundler", Bundler.gem_version]).last
       package = Gem::Package.new(bundler_spec.cache_file)
       definition.sources.metadata_source.checksum_store.register(bundler_spec, Checksum.from_gem_package(package))
 

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -71,7 +71,8 @@ module Bundler
       checksums = definition.resolve.map do |spec|
         spec.source.checksum_store.to_lock(spec)
       end
-      add_section("CHECKSUMS", checksums)
+
+      add_section("CHECKSUMS", checksums + bundler_checksum)
     end
 
     def add_locked_ruby_version
@@ -99,6 +100,18 @@ module Bundler
       else
         raise ArgumentError, "#{value.inspect} can't be serialized in a lockfile"
       end
+    end
+
+    def bundler_checksum
+      return [] if Bundler.gem_version.to_s.end_with?(".dev")
+
+      require "rubygems/package"
+
+      bundler_spec = definition.sources.metadata_source.specs.search(["bundler", Bundler.gem_version]).last
+      package = Gem::Package.new(bundler_spec.cache_file)
+      definition.sources.metadata_source.checksum_store.register(bundler_spec, Checksum.from_gem_package(package))
+
+      [definition.sources.metadata_source.checksum_store.to_lock(bundler_spec)]
     end
   end
 end

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -28,6 +28,7 @@ module Bundler
 
     attr_reader(
       :sources,
+      :metadata_source,
       :dependencies,
       :specs,
       :platforms,
@@ -97,6 +98,7 @@ module Bundler
     def initialize(lockfile, strict: false)
       @platforms    = []
       @sources      = []
+      @metadata_source = Source::Metadata.new
       @dependencies = {}
       @parse_method = nil
       @specs        = {}
@@ -252,7 +254,12 @@ module Bundler
       version = Gem::Version.new(version)
       platform = platform ? Gem::Platform.new(platform) : Gem::Platform::RUBY
       full_name = Gem::NameTuple.new(name, version, platform).full_name
-      return unless spec = @specs[full_name]
+      spec = @specs[full_name]
+
+      if name == "bundler"
+        spec ||= LazySpecification.new(name, version, platform, @metadata_source)
+      end
+      return unless spec
 
       if checksums
         checksums.split(",") do |lock_checksum|

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ADD" "1" "March 2026" ""
+.TH "BUNDLE\-ADD" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-BINSTUBS" "1" "March 2026" ""
+.TH "BUNDLE\-BINSTUBS" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CACHE" "1" "March 2026" ""
+.TH "BUNDLE\-CACHE" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CHECK" "1" "March 2026" ""
+.TH "BUNDLE\-CHECK" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CLEAN" "1" "March 2026" ""
+.TH "BUNDLE\-CLEAN" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CONFIG" "1" "March 2026" ""
+.TH "BUNDLE\-CONFIG" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options
 .SH "SYNOPSIS"
@@ -172,7 +172,7 @@ Whether Bundler will install gems into the default system path (\fBGem\.dir\fR)\
 \fBplugins\fR (\fBBUNDLE_PLUGINS\fR)
 Enable Bundler's experimental plugin system\.
 .TP
-\fBprefer_patch\fR (BUNDLE_PREFER_PATCH)
+\fBprefer_patch\fR (\fBBUNDLE_PREFER_PATCH\fR)
 Prefer updating only to next patch version during updates\. Makes \fBbundle update\fR calls equivalent to \fBbundler update \-\-patch\fR\.
 .TP
 \fBredirect\fR (\fBBUNDLE_REDIRECT\fR)

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -223,7 +223,7 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Whether Bundler will install gems into the default system path (`Gem.dir`).
 * `plugins` (`BUNDLE_PLUGINS`):
    Enable Bundler's experimental plugin system.
-* `prefer_patch` (BUNDLE_PREFER_PATCH):
+* `prefer_patch` (`BUNDLE_PREFER_PATCH`):
    Prefer updating only to next patch version during updates. Makes `bundle update` calls equivalent to `bundler update --patch`.
 * `redirect` (`BUNDLE_REDIRECT`):
    The number of redirects allowed for network requests. Defaults to `5`.

--- a/bundler/lib/bundler/man/bundle-console.1
+++ b/bundler/lib/bundler/man/bundle-console.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CONSOLE" "1" "March 2026" ""
+.TH "BUNDLE\-CONSOLE" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-console\fR \- Open an IRB session with the bundle pre\-loaded
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-DOCTOR" "1" "March 2026" ""
+.TH "BUNDLE\-DOCTOR" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-env.1
+++ b/bundler/lib/bundler/man/bundle-env.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ENV" "1" "March 2026" ""
+.TH "BUNDLE\-ENV" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-env\fR \- Print information about the environment Bundler is running under
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-EXEC" "1" "March 2026" ""
+.TH "BUNDLE\-EXEC" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-fund.1
+++ b/bundler/lib/bundler/man/bundle-fund.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-FUND" "1" "March 2026" ""
+.TH "BUNDLE\-FUND" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-fund\fR \- Lists information about gems seeking funding assistance
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-GEM" "1" "March 2026" ""
+.TH "BUNDLE\-GEM" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-help.1
+++ b/bundler/lib/bundler/man/bundle-help.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-HELP" "1" "March 2026" ""
+.TH "BUNDLE\-HELP" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-help\fR \- Displays detailed help for each subcommand
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INFO" "1" "March 2026" ""
+.TH "BUNDLE\-INFO" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INIT" "1" "March 2026" ""
+.TH "BUNDLE\-INIT" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INSTALL" "1" "March 2026" ""
+.TH "BUNDLE\-INSTALL" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-issue.1
+++ b/bundler/lib/bundler/man/bundle-issue.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ISSUE" "1" "March 2026" ""
+.TH "BUNDLE\-ISSUE" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-issue\fR \- Get help reporting Bundler issues
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-licenses.1
+++ b/bundler/lib/bundler/man/bundle-licenses.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LICENSES" "1" "March 2026" ""
+.TH "BUNDLE\-LICENSES" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-licenses\fR \- Print the license of all gems in the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LIST" "1" "March 2026" ""
+.TH "BUNDLE\-LIST" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LOCK" "1" "March 2026" ""
+.TH "BUNDLE\-LOCK" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-OPEN" "1" "March 2026" ""
+.TH "BUNDLE\-OPEN" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-OUTDATED" "1" "March 2026" ""
+.TH "BUNDLE\-OUTDATED" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PLATFORM" "1" "March 2026" ""
+.TH "BUNDLE\-PLATFORM" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PLUGIN" "1" "March 2026" ""
+.TH "BUNDLE\-PLUGIN" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PRISTINE" "1" "March 2026" ""
+.TH "BUNDLE\-PRISTINE" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-REMOVE" "1" "March 2026" ""
+.TH "BUNDLE\-REMOVE" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-SHOW" "1" "March 2026" ""
+.TH "BUNDLE\-SHOW" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-UPDATE" "1" "March 2026" ""
+.TH "BUNDLE\-UPDATE" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-version.1
+++ b/bundler/lib/bundler/man/bundle-version.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-VERSION" "1" "March 2026" ""
+.TH "BUNDLE\-VERSION" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\-version\fR \- Prints Bundler version information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE" "1" "March 2026" ""
+.TH "BUNDLE" "1" "April 2026" ""
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "GEMFILE" "5" "March 2026" ""
+.TH "GEMFILE" "5" "April 2026" ""
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/source/metadata.rb
+++ b/bundler/lib/bundler/source/metadata.rb
@@ -58,6 +58,10 @@ module Bundler
       def version_message(spec)
         "#{spec.name} #{spec.version}"
       end
+
+      def checksum_store
+        @checksum_store ||= Checksum::Store.new
+      end
     end
   end
 end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -508,7 +508,7 @@ module Bundler
 
       # We are using a mutex to reaed and write from/to the hash.
       # The reason this double synchronization was added is for performance
-      # and lock the mutex for the shortest possible amount of time. Otherwise,
+      # and to lock the mutex for the shortest possible amount of time. Otherwise,
       # all threads are fighting over this mutex and when it gets acquired it gets locked
       # until a threads finishes downloading a gem, leaving the other threads waiting
       # doing nothing.

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -22,6 +22,12 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "<%= config[:changelog_uri] %>"
 <%- end -%>
 
+  # Uncomment the line below to require MFA for gem pushes.
+  # This helps protect your gem from supply chain attacks by ensuring
+  # no one can publish a new version without multi-factor authentication.
+  # See: https://guides.rubygems.org/mfa-requirement-opt-in/
+  # spec.metadata["rubygems_mfa_required"] = "true"
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   gemspec = File.basename(__FILE__)

--- a/bundler/lib/bundler/version.rb
+++ b/bundler/lib/bundler/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 module Bundler
-  VERSION = "4.0.10".freeze
+  VERSION = "4.0.11".freeze
 
   def self.bundler_major_version
     @bundler_major_version ||= gem_version.segments.first

--- a/bundler/spec/bundler/definition_spec.rb
+++ b/bundler/spec/bundler/definition_spec.rb
@@ -289,6 +289,57 @@ RSpec.describe Bundler::Definition do
     end
   end
 
+  describe "#precompute_source_requirements_for_indirect_dependencies?" do
+    before do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile) { Pathname.new("Gemfile") }
+    end
+
+    let(:sources) { Bundler::SourceList.new }
+    subject { Bundler::Definition.new(nil, [], sources, []) }
+
+    before do
+      allow(sources).to receive(:non_global_rubygems_sources).and_return(non_global_rubygems_sources)
+    end
+
+    context "when all the scoped sources implement a dependency API" do
+      let(:non_global_rubygems_sources) do
+        [
+          double("non-global-source-0", "dependency_api_available?":true, to_s:"a"),
+          double("non-global-source-1", "dependency_api_available?":true, to_s:"b"),
+        ]
+      end
+
+      it "returns true without warning" do
+        expect(subject).not_to receive(:non_dependency_api_warning)
+
+        expect(subject.send(:precompute_source_requirements_for_indirect_dependencies?)).to be_truthy
+      end
+    end
+
+    context "when some scoped sources do not implement a dependency API" do
+      let(:non_global_rubygems_sources) do
+        [
+          double("non-global-source-0", "dependency_api_available?":true, to_s:"a"),
+          double("non-global-source-1", "dependency_api_available?":false, to_s:"b"),
+          double("non-global-source-2", "dependency_api_available?":false, to_s:"c"),
+        ]
+      end
+
+      it "returns false and warns about the non-API sources" do
+        expect(Bundler.ui).to receive(:warn).with(<<-W.strip)
+Your Gemfile contains scoped sources that don't implement a dependency API, namely:
+
+  * b
+  * c
+
+Using the above gem servers may result in installing unexpected gems. To resolve this warning, make sure you use gem servers that implement dependency APIs, such as gemstash or geminabox gem servers.
+        W
+
+        expect(subject.send(:precompute_source_requirements_for_indirect_dependencies?)).to be_falsy
+      end
+    end
+  end
+
   def mock_source_list
     Class.new do
       def all_sources

--- a/bundler/spec/bundler/installer/spec_installation_spec.rb
+++ b/bundler/spec/bundler/installer/spec_installation_spec.rb
@@ -3,17 +3,16 @@
 require "bundler/installer/parallel_installer"
 
 RSpec.describe Bundler::ParallelInstaller::SpecInstallation do
-  let!(:dep) do
-    a_spec = Object.new
-    def a_spec.name
-      "I like tests"
-    end
-
-    def a_spec.full_name
-      "I really like tests"
-    end
-    a_spec
+  def build_spec(name, extensions: [])
+    spec = Object.new
+    spec.define_singleton_method(:name) { name }
+    spec.define_singleton_method(:full_name) { "#{name}-1.0" }
+    spec.define_singleton_method(:extensions) { extensions }
+    spec.define_singleton_method(:dependencies) { [] }
+    spec
   end
+
+  let!(:dep) { build_spec("I like tests") }
 
   describe "#ready_to_enqueue?" do
     context "when in enqueued state" do
@@ -39,29 +38,51 @@ RSpec.describe Bundler::ParallelInstaller::SpecInstallation do
   end
 
   describe "#dependencies_installed?" do
-    context "when all dependencies are installed" do
-      it "returns true" do
-        dependencies = []
-        dependencies << instance_double("SpecInstallation", spec: "alpha", name: "alpha", installed?: true, all_dependencies: [], type: :production)
-        dependencies << instance_double("SpecInstallation", spec: "beta", name: "beta", installed?: true, all_dependencies: [], type: :production)
-        all_specs = dependencies + [instance_double("SpecInstallation", spec: "gamma", name: "gamma", installed?: false, all_dependencies: [], type: :production)]
+    it "returns true when all dependencies are installed" do
+      alpha = described_class.new(build_spec("alpha"))
+      alpha.dependencies = []
+
+      beta = described_class.new(build_spec("beta"))
+      beta.dependencies = [alpha]
+
+      gamma = described_class.new(build_spec("gamma"))
+      gamma.dependencies = [beta]
+
+      expect(gamma.dependencies_installed?({})).to be_falsey
+      expect(gamma.dependencies_installed?({ "beta" => true })).to be_falsey
+      expect(gamma.dependencies_installed?({ "alpha" => true, "beta" => true })).to be_truthy
+    end
+  end
+
+  describe "#ready_to_install?" do
+    context "when spec has no extensions" do
+      it "returns true regardless of dependencies" do
+        beta = described_class.new(build_spec("beta"))
+        beta.dependencies = []
+
         spec = described_class.new(dep)
-        allow(spec).to receive(:all_dependencies).and_return(dependencies)
-        installed_specs = all_specs.select(&:installed?).map {|s| [s.name, true] }.to_h
-        expect(spec.dependencies_installed?(installed_specs)).to be_truthy
+        spec.state = :downloaded
+        spec.dependencies = [beta]
+
+        expect(spec.ready_to_install?({})).to be_truthy
       end
     end
 
-    context "when all dependencies are not installed" do
-      it "returns false" do
-        dependencies = []
-        dependencies << instance_double("SpecInstallation", spec: "alpha", name: "alpha", installed?: false, all_dependencies: [], type: :production)
-        dependencies << instance_double("SpecInstallation", spec: "beta", name: "beta", installed?: true, all_dependencies: [], type: :production)
-        all_specs = dependencies + [instance_double("SpecInstallation", spec: "gamma", name: "gamma", installed?: false, all_dependencies: [], type: :production)]
-        spec = described_class.new(dep)
-        allow(spec).to receive(:all_dependencies).and_return(dependencies)
-        installed_specs = all_specs.select(&:installed?).map {|s| [s.name, true] }.to_h
-        expect(spec.dependencies_installed?(installed_specs)).to be_falsey
+    context "when spec has extensions" do
+      it "returns true when all dependencies are installed" do
+        alpha = described_class.new(build_spec("alpha"))
+        alpha.dependencies = []
+
+        beta = described_class.new(build_spec("beta"))
+        beta.dependencies = [alpha]
+
+        gamma = described_class.new(build_spec("gamma", extensions: ["ext/Rakefile"]))
+        gamma.state = :downloaded
+        gamma.dependencies = [beta]
+
+        expect(gamma.ready_to_install?({})).to be_falsey
+        expect(gamma.ready_to_install?({ "beta" => true })).to be_falsey
+        expect(gamma.ready_to_install?({ "alpha" => true, "beta" => true })).to be_truthy
       end
     end
   end

--- a/bundler/spec/commands/install_spec.rb
+++ b/bundler/spec/commands/install_spec.rb
@@ -1379,6 +1379,48 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  describe "when a native extension requires a transitive dependency at build time" do
+    before do
+      build_repo4 do
+        build_gem "alpha", "1.0.0" do |s|
+          extension = "ext/alpha/extconf.rb"
+          s.extensions = extension
+          s.write(extension, <<~CODE)
+            require "mkmf"
+            sleep 1
+            create_makefile("alpha")
+          CODE
+          s.write "lib/alpha.rb", "ALPHA = '1.0.0'"
+        end
+
+        build_gem "beta", "1.0.0" do |s|
+          s.add_dependency "alpha"
+          s.write "lib/beta.rb", "require 'alpha'\nBETA = '1.0.0'"
+        end
+
+        build_gem "gamma", "1.0.0" do |s|
+          s.add_dependency "beta"
+          extension = "ext/gamma/extconf.rb"
+          s.extensions = extension
+          s.write(extension, <<~EXTCONF)
+            require "beta"
+            require "mkmf"
+            create_makefile("gamma")
+          EXTCONF
+        end
+      end
+    end
+
+    it "installs successfully" do
+      install_gemfile <<~G
+        source "https://gem.repo4"
+        gem "gamma"
+      G
+
+      expect(the_bundle).to include_gems "alpha 1.0.0", "beta 1.0.0", "gamma 1.0.0"
+    end
+  end
+
   describe "when configured path is UTF-8 and a file inside a gem package too" do
     let(:app_path) do
       path = tmp("♥")

--- a/bundler/spec/commands/lock_spec.rb
+++ b/bundler/spec/commands/lock_spec.rb
@@ -2295,6 +2295,10 @@ RSpec.describe "bundle lock" do
 
     bundle("lock --add-checksums", artifice: "endpoint")
 
+    checksums = checksums_section_when_enabled do |c|
+      c.no_checksum "warning", "18.0.0"
+    end
+
     expect(lockfile).to eq <<~L
       GEM
         remote: https://gem.repo4/
@@ -2306,10 +2310,7 @@ RSpec.describe "bundle lock" do
 
       DEPENDENCIES
         warning
-
-      CHECKSUMS
-        warning (18.0.0)
-
+      #{checksums}
       BUNDLED WITH
         #{Bundler::VERSION}
     L

--- a/bundler/spec/commands/newgem_spec.rb
+++ b/bundler/spec/commands/newgem_spec.rb
@@ -645,6 +645,15 @@ RSpec.describe "bundle gem" do
       to match(/example\.com/)
   end
 
+  it "includes a commented-out rubygems_mfa_required metadata hint" do
+    bundle "gem #{gem_name}"
+
+    gemspec_contents = bundled_app("#{gem_name}/#{gem_name}.gemspec").read
+
+    expect(gemspec_contents).to include('# spec.metadata["rubygems_mfa_required"] = "true"')
+    expect(gemspec_contents).to include("https://guides.rubygems.org/mfa-requirement-opt-in/")
+  end
+
   it "sets a minimum ruby version" do
     bundle "gem #{gem_name}"
 

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1537,6 +1537,7 @@ RSpec.describe "bundle update --bundler" do
 
     checksums = checksums_section do |c|
       c.checksum(gem_repo4, "myrack", "1.0")
+      c.checksum(gem_repo4, "bundler", "999.0.0")
     end
 
     install_gemfile <<-G
@@ -1621,6 +1622,7 @@ RSpec.describe "bundle update --bundler" do
 
     checksums = checksums_section do |c|
       c.checksum(gem_repo4, "myrack", "1.0")
+      c.checksum(gem_repo4, "bundler", "9.9.9")
     end
 
     install_gemfile <<-G
@@ -1745,6 +1747,7 @@ RSpec.describe "bundle update --bundler" do
     # Only updates properly on modern RubyGems.
     checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo4, "myrack", "1.0")
+      c.checksum(local_gem_path, "bundler", "9.0.0", Gem::Platform::RUBY, "cache")
     end
 
     expect(lockfile).to eq <<~L

--- a/bundler/spec/commands/update_spec.rb
+++ b/bundler/spec/commands/update_spec.rb
@@ -1419,9 +1419,7 @@ RSpec.describe "bundle update --ruby" do
          #{lockfile_platforms}
 
        DEPENDENCIES
-
-       CHECKSUMS
-
+       #{checksums_section_when_enabled}
        RUBY VERSION
          #{Bundler::RubyVersion.system}
 
@@ -1708,6 +1706,7 @@ RSpec.describe "bundle update --bundler" do
     checksums = checksums_section_when_enabled do |c|
       c.checksum(gem_repo4, "myrack", "1.0")
     end
+    checksums.delete("bundler")
 
     expect(lockfile).to eq <<~L
         GEM

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -478,7 +478,7 @@ RSpec.describe "bundle install with git sources" do
         update_git("foo", path: repo, tag: tag)
 
         install_gemfile <<-G
-         source "https://gem.repo1"
+          source "https://gem.repo1"
           git "#{repo}", :tag => #{tag.dump} do
             gem "foo"
           end

--- a/bundler/spec/install/gemfile/git_spec.rb
+++ b/bundler/spec/install/gemfile/git_spec.rb
@@ -1078,7 +1078,7 @@ RSpec.describe "bundle install with git sources" do
     expect(out).to eq("WIN")
   end
 
-  it "does not to a remote fetch if the revision is cached locally" do
+  it "does not do a remote fetch if the revision is cached locally" do
     build_git "foo"
 
     install_gemfile <<-G

--- a/bundler/spec/install/gems/resolving_spec.rb
+++ b/bundler/spec/install/gems/resolving_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe "bundle install with install-time dependencies" do
               #{lockfile_platforms}
 
             DEPENDENCIES
-              parallel_tests
+              rubocop
             #{checksums}
             BUNDLED WITH
               #{Bundler::VERSION}

--- a/bundler/spec/runtime/setup_spec.rb
+++ b/bundler/spec/runtime/setup_spec.rb
@@ -1329,7 +1329,7 @@ end
         gem "bar", :git => "#{lib_path("bar-1.0")}"
       G
 
-      bundle :install
+      bundle :install, env: { "BUNDLE_LOCKFILE_CHECKSUMS" => "false" }
 
       ruby <<-RUBY, artifice: nil
         require 'bundler/setup'

--- a/bundler/spec/support/checksums.rb
+++ b/bundler/spec/support/checksums.rb
@@ -3,6 +3,8 @@
 module Spec
   module Checksums
     class ChecksumsBuilder
+      attr_reader :bundler_registered
+
       def initialize(enabled = true, &block)
         @enabled = enabled
         @checksums = {}
@@ -15,6 +17,8 @@ module Spec
       end
 
       def checksum(repo, name, version, platform = Gem::Platform::RUBY, folder = "gems")
+        @bundler_registered = true if name == "bundler"
+
         name_tuple = Gem::NameTuple.new(name, version, platform)
         gem_file = File.join(repo, folder, "#{name_tuple.full_name}.gem")
         File.open(gem_file, "rb") do |f|
@@ -50,8 +54,13 @@ module Spec
       end
     end
 
-    def checksums_section(enabled = true, &block)
-      ChecksumsBuilder.new(enabled, &block)
+    def checksums_section(enabled = true, bundler_checksum: true, &block)
+      ChecksumsBuilder.new(enabled, &block).tap do |builder|
+        next if builder.bundler_registered || !bundler_checksum
+
+        next if Bundler::VERSION.to_s.end_with?(".dev")
+        builder.checksum(system_gem_path, "bundler", Bundler::VERSION, Gem::Platform::RUBY, "cache")
+      end
     end
 
     def checksums_section_when_enabled(target_lockfile = nil, &block)
@@ -64,7 +73,7 @@ module Spec
     end
 
     def checksum_to_lock(*args)
-      checksums_section do |c|
+      checksums_section(true, bundler_checksum: false) do |c|
         c.checksum(*args)
       end.to_s.sub(/^CHECKSUMS\n/, "").strip
     end

--- a/bundler/spec/support/checksums.rb
+++ b/bundler/spec/support/checksums.rb
@@ -14,9 +14,9 @@ module Spec
         @checksums = @checksums.dup
       end
 
-      def checksum(repo, name, version, platform = Gem::Platform::RUBY)
+      def checksum(repo, name, version, platform = Gem::Platform::RUBY, folder = "gems")
         name_tuple = Gem::NameTuple.new(name, version, platform)
-        gem_file = File.join(repo, "gems", "#{name_tuple.full_name}.gem")
+        gem_file = File.join(repo, folder, "#{name_tuple.full_name}.gem")
         File.open(gem_file, "rb") do |f|
           register(name_tuple, Bundler::Checksum.from_gem(f, "#{gem_file} (via ChecksumsBuilder#checksum)"))
         end

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -9,7 +9,7 @@
 require "rbconfig"
 
 module Gem
-  VERSION = "4.0.10"
+  VERSION = "4.0.11"
 end
 
 require_relative "rubygems/defaults"

--- a/lib/rubygems/commands/specification_command.rb
+++ b/lib/rubygems/commands/specification_command.rb
@@ -42,7 +42,7 @@ class Gem::Commands::SpecificationCommand < Gem::Command
 
   def arguments # :nodoc:
     <<-ARGS
-GEMFILE       name of gem to show the gemspec for
+GEM_OR_FILE   gem name or a .gem file to show the gemspec for
 FIELD         name of gemspec field to show
     ARGS
   end
@@ -68,7 +68,7 @@ Specific fields in the specification can be extracted in YAML format:
   end
 
   def usage # :nodoc:
-    "#{program_name} [GEMFILE] [FIELD]"
+    "#{program_name} [GEM_OR_FILE] [FIELD]"
   end
 
   def execute
@@ -77,7 +77,7 @@ Specific fields in the specification can be extracted in YAML format:
 
     unless gem
       raise Gem::CommandLineError,
-            "Please specify a gem name or file on the command line"
+            "Please specify a gem name or a .gem file on the command line"
     end
 
     case v = options[:version]

--- a/test/rubygems/test_gem_commands_push_command.rb
+++ b/test/rubygems/test_gem_commands_push_command.rb
@@ -148,7 +148,7 @@ class TestGemCommandsPushCommand < Gem::TestCase
       spec.metadata["allowed_push_host"] = "https://privategemserver.example"
     end
 
-    @response = "Successfully registered gem: freewill (1.0.0)"
+    @response = "Successfully registered gem: freebird (1.0.1)"
     @fetcher.data["#{@spec.metadata["allowed_push_host"]}/api/v1/gems"] = HTTPResponseFactory.create(body: @response, code: 200, msg: "OK")
     @fetcher.data["#{Gem.host}/api/v1/gems"] =
       ["fail", 500, "Internal Server Error"]

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -221,7 +221,7 @@ class TestStubSpecification < Gem::TestCase
   end
 
   def stub_with_version
-    spec = File.join @gemhome, "specifications", "stub_e-2.gemspec"
+    spec = File.join @gemhome, "specifications", "stub_v-with-version.gemspec"
     File.open spec, "w" do |io|
       io.write <<~STUB
         # -*- encoding: utf-8 -*-
@@ -244,7 +244,7 @@ class TestStubSpecification < Gem::TestCase
   end
 
   def stub_without_version
-    spec = File.join @gemhome, "specifications", "stub-2.gemspec"
+    spec = File.join @gemhome, "specifications", "stub_v-without-version.gemspec"
     File.open spec, "w" do |io|
       io.write <<~STUB
         # -*- encoding: utf-8 -*-


### PR DESCRIPTION
* Lock the checksum of Bundler itself in the lockfile [#9366](https://github.com/ruby/rubygems/pull/9366)
* Ensure the release CI doesn't break due to the Bundler checksum feature [#9436](https://github.com/ruby/rubygems/pull/9436)
* Fix inconsistent indentation in git_spec.rb [#9464](https://github.com/ruby/rubygems/pull/9464)
* Fix incorrect gem name in lockfile DEPENDENCIES section of resolving_spec.rb [#9465](https://github.com/ruby/rubygems/pull/9465)
* Fix mismatched gem name/version in test_execute_allowed_push_host response message [#9466](https://github.com/ruby/rubygems/pull/9466)
* Fix typo in test description: "does not to" → "does not do" [#9468](https://github.com/ruby/rubygems/pull/9468)
* Fix gemspec filename mismatches in stub helper methods [#9467](https://github.com/ruby/rubygems/pull/9467)
* Fix typo by copilot review findings [#9471](https://github.com/ruby/rubygems/pull/9471)
* Fix the bundler version not being updated in dev/test lockfile [#9463](https://github.com/ruby/rubygems/pull/9463)
* fix formatting for BUNDLE_PREFER_PATCH variable in man page [#9474](https://github.com/ruby/rubygems/pull/9474)
* Clarify the name and meaning of the first argument to `gem spec` [#9476](https://github.com/ruby/rubygems/pull/9476)
* Print a warning for a potential confusion from the indirect dependencies. [#5029](https://github.com/ruby/rubygems/pull/5029)
* Add commented-out rubygems_mfa_required to bundle gem template [#9487](https://github.com/ruby/rubygems/pull/9487)
* Fix installing gems with native extensions + transitive dependencies [#9477](https://github.com/ruby/rubygems/pull/9477)