### PR TITLE
Skip bundler self-checksum for unreleased bundlers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,7 @@ namespace :version do
   task :update_locked_bundler do |_, _args|
     stdout = Spec::Rubygems.dev_bundle "--version"
     version = stdout.split(" ").last
+    ENV["SKIP_BUNDLER_CHECKSUM"] = "1"
 
     Dir.glob("{tool/bundler/*_gems.rb,spec/realworld/fixtures/*/Gemfile}").each do |file|
       Spec::Rubygems.dev_bundle("lock", "--update", "--bundler", version, gemfile: file)

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -103,7 +103,7 @@ module Bundler
     end
 
     def bundler_checksum
-      return [] if Bundler.gem_version.to_s.end_with?(".dev")
+      return [] if Bundler.gem_version.to_s.end_with?(".dev") || ENV["SKIP_BUNDLER_CHECKSUM"]
 
       bundler_spec = definition.sources.metadata_source.specs.search(["bundler", Bundler.gem_version]).last
       return [] unless File.exist?(bundler_spec.cache_file)

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -103,7 +103,7 @@ module Bundler
     end
 
     def bundler_checksum
-      return [] unless released_bundler?
+      return [] if Bundler.gem_version.to_s.end_with?(".dev")
 
       bundler_spec = definition.sources.metadata_source.specs.search(["bundler", Bundler.gem_version]).last
       return [] unless File.exist?(bundler_spec.cache_file)
@@ -114,12 +114,6 @@ module Bundler
       definition.sources.metadata_source.checksum_store.register(bundler_spec, Checksum.from_gem_package(package))
 
       [definition.sources.metadata_source.checksum_store.to_lock(bundler_spec)]
-    end
-
-    def released_bundler?
-      return false if Bundler.gem_version.prerelease?
-      # Released gem specs live under .../specifications/; source checkouts don't.
-      Gem.loaded_specs["bundler"]&.loaded_from.to_s.include?("/specifications/")
     end
   end
 end

--- a/bundler/lib/bundler/lockfile_generator.rb
+++ b/bundler/lib/bundler/lockfile_generator.rb
@@ -103,7 +103,7 @@ module Bundler
     end
 
     def bundler_checksum
-      return [] if Bundler.gem_version.to_s.end_with?(".dev")
+      return [] unless released_bundler?
 
       bundler_spec = definition.sources.metadata_source.specs.search(["bundler", Bundler.gem_version]).last
       return [] unless File.exist?(bundler_spec.cache_file)
@@ -114,6 +114,12 @@ module Bundler
       definition.sources.metadata_source.checksum_store.register(bundler_spec, Checksum.from_gem_package(package))
 
       [definition.sources.metadata_source.checksum_store.to_lock(bundler_spec)]
+    end
+
+    def released_bundler?
+      return false if Bundler.gem_version.prerelease?
+      # Released gem specs live under .../specifications/; source checkouts don't.
+      Gem.loaded_specs["bundler"]&.loaded_from.to_s.include?("/specifications/")
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Using `Bundler.gem_version.end_with?(".dev")` only skips the own checksum on master, but patch releases run from a source checkout (e.g., bumping bundler/lib/bundler/version.rb to 4.0.11 on a release branch) still record the checksum, which is environment dependent on the local gem cache and causes frozen-lock drift on CI.

https://github.com/ruby/rubygems/actions/runs/24831299384/job/72680209697


## What is your fix for the problem, implemented in this PR?

Generalize the guard with `released_bundler?`, which returns false for any prerelease version and for bundlers loaded outside of an installed gem location (`/specifications/`), so dev workflows don't record self-checksums while released installs still do.

@Edouard-chin Could you review this?

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
