### PR TITLE
Deprecate parsing non-lockfile content in LockfileParser

### DIFF
--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -116,7 +116,7 @@ module Bundler
       end
 
       @valid = lockfile.strip.empty? ||
-        lockfile.split(/(?:\r?\n)+/).any? {|l| KNOWN_SECTIONS.include?(l) }
+               lockfile.split(/(?:\r?\n)+/).any? {|l| KNOWN_SECTIONS.include?(l) }
 
       unless @valid
         SharedHelpers.feature_deprecated!(

--- a/bundler/lib/bundler/lockfile_parser.rb
+++ b/bundler/lib/bundler/lockfile_parser.rb
@@ -115,6 +115,17 @@ module Bundler
           "Run `git checkout HEAD -- #{@lockfile_path}` first to get a clean lock."
       end
 
+      @valid = lockfile.strip.empty? ||
+        lockfile.split(/(?:\r?\n)+/).any? {|l| KNOWN_SECTIONS.include?(l) }
+
+      unless @valid
+        SharedHelpers.feature_deprecated!(
+          "Your #{@lockfile_path} does not appear to be a valid lockfile. " \
+          "Run `rm #{@lockfile_path}` and then `bundle install` to generate a new lockfile. " \
+          "This will raise a LockfileError in a future version of Bundler."
+        )
+      end
+
       lockfile.split(/((?:\r?\n)+)/) do |line|
         # split alternates between the line and the following whitespace
         next @pos.advance!(line) if line.match?(/^\s*$/)
@@ -162,6 +173,10 @@ module Bundler
 
     def may_include_redundant_platform_specific_gems?
       bundler_version.nil? || bundler_version < Gem::Version.new("1.16.2")
+    end
+
+    def valid?
+      @valid
     end
 
     private

--- a/spec/bundler/lockfile_parser_spec.rb
+++ b/spec/bundler/lockfile_parser_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe Bundler::LockfileParser do
 
     shared_examples_for "parsing" do
       it "parses correctly" do
+        expect(subject.valid?).to be(true)
         expect(subject.sources).to eq sources
         expect(subject.dependencies).to eq dependencies
         expect(subject.specs).to eq specs
@@ -189,6 +190,66 @@ RSpec.describe Bundler::LockfileParser do
       end
       let(:rake_checksums) { [rake_sha256_checksum, rake_sha512_checksum] }
       include_examples "parsing"
+    end
+
+    context "when the content does not contain any recognized lockfile sections" do
+      let(:lockfile_contents) { "hello world\nlorem ipsum\n" }
+
+      it "does not raise, is not valid, and deprecates" do
+        expect(Bundler::SharedHelpers).to receive(:feature_deprecated!).with(
+          /does not appear to be a valid lockfile.*future version of Bundler/m
+        )
+        parser = described_class.new(lockfile_contents)
+        expect(parser.valid?).to be(false)
+        expect(parser.specs).to eq([])
+        expect(parser.dependencies).to eq({})
+      end
+
+      it "does not raise when strict: true, and still deprecates" do
+        expect(Bundler::SharedHelpers).to receive(:feature_deprecated!).with(
+          /does not appear to be a valid lockfile.*future version of Bundler/m
+        )
+        parser = described_class.new(lockfile_contents, strict: true)
+        expect(parser.valid?).to be(false)
+        expect(parser.specs).to eq([])
+        expect(parser.dependencies).to eq({})
+      end
+    end
+
+    context "when the content looks like a Gemfile DSL" do
+      let(:lockfile_contents) { <<~G }
+        source "https://rubygems.org"
+        gem "rake"
+      G
+
+      it "does not raise, is not valid, and deprecates" do
+        expect(Bundler::SharedHelpers).to receive(:feature_deprecated!).with(
+          /does not appear to be a valid lockfile.*future version of Bundler/m
+        )
+        parser = described_class.new(lockfile_contents)
+        expect(parser.valid?).to be(false)
+        expect(parser.specs).to eq([])
+        expect(parser.dependencies).to eq({})
+      end
+
+      it "does not raise when strict: true, and still deprecates" do
+        expect(Bundler::SharedHelpers).to receive(:feature_deprecated!).with(
+          /does not appear to be a valid lockfile.*future version of Bundler/m
+        )
+        parser = described_class.new(lockfile_contents, strict: true)
+        expect(parser.valid?).to be(false)
+        expect(parser.specs).to eq([])
+        expect(parser.dependencies).to eq({})
+      end
+    end
+
+    context "when the content is empty" do
+      let(:lockfile_contents) { "" }
+
+      it "does not raise and is valid" do
+        expect { subject }.not_to raise_error
+        expect(subject.valid?).to be(true)
+      end
     end
 
     context "when CHECKSUMS has duplicate checksums in the lockfile that don't match" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`Bundler::LockfileParser#initialize` silently accepts any string input — including Gemfiles, READMEs, or arbitrary text — producing an empty parser with no indication that the input was invalid. Downstream tooling such as [bundler-audit](https://github.com/rubysec/bundler-audit) (via its `--gemfile-lock FILE` option) has no way to confirm that the file it was handed is actually a lockfile. See #8932.

## What is your fix for the problem, implemented in this PR?

Detect non-lockfile content at parse time by checking for any of the known section headers (`GEM`, `GIT`, `PATH`, `PLATFORMS`, `DEPENDENCIES`, etc.). Empty input is left untouched for backward compatibility.

Instead of raising immediately — which would be a hard break for anyone unknowingly relying on the old silent-accept behavior — the parser now:

- emits a deprecation warning via `SharedHelpers.feature_deprecated!` announcing that a future Bundler version will raise `LockfileError`;
- exposes a new `LockfileParser#valid?` predicate so callers can branch on the result without string-matching the deprecation message.

Specs cover both default and `strict: true` cases, for non-lockfile text and a Gemfile-as-lockfile regression.

Fixes #8932.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write tests for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the current code style and write meaningful commit messages without tags