### PR TITLE
Make `bundle config get` return status 1 when the value is not set

### DIFF
--- a/bundler/lib/bundler/cli/config.rb
+++ b/bundler/lib/bundler/cli/config.rb
@@ -87,23 +87,17 @@ module Bundler
 
         if value.nil?
           warn_unused_scope "Ignoring --#{scope} since no value to set was given"
-
-          configured = Bundler.settings.locations(name).any?
+          current_value = Bundler.settings[name]
 
           if options[:parseable]
             if value = Bundler.settings[name]
               Bundler.ui.info("#{name}=#{value}")
             end
-            if configured
-              return
-            else
-              exit 1
-            end
+          else
+            confirm(name)
           end
 
-          confirm(name)
-
-          if configured
+          if current_value
             return
           else
             exit 1

--- a/bundler/lib/bundler/cli/config.rb
+++ b/bundler/lib/bundler/cli/config.rb
@@ -97,10 +97,10 @@ module Bundler
             confirm(name)
           end
 
-          if current_value
-            return
-          else
+          if current_value.nil?
             exit 1
+          else
+            return
           end
         end
 

--- a/bundler/lib/bundler/cli/config.rb
+++ b/bundler/lib/bundler/cli/config.rb
@@ -88,15 +88,26 @@ module Bundler
         if value.nil?
           warn_unused_scope "Ignoring --#{scope} since no value to set was given"
 
+          configured = Bundler.settings.locations(name).any?
+
           if options[:parseable]
             if value = Bundler.settings[name]
               Bundler.ui.info("#{name}=#{value}")
             end
-            return
+            if configured
+              return
+            else
+              exit 1
+            end
           end
 
           confirm(name)
-          return
+
+          if configured
+            return
+          else
+            exit 1
+          end
         end
 
         Bundler.ui.info(message) if message

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -251,8 +251,10 @@ To update to the most recent version, run `bundle update --bundler`
 
       context "running a parseable command" do
         it "prints no warning" do
+          bundle "config set foo value", env: { "BUNDLER_VERSION" => bundler_version }
           bundle "config get --parseable foo", env: { "BUNDLER_VERSION" => bundler_version }
-          expect(stdboth).to eq ""
+          expect(out).to eq "foo=value"
+          expect(err).to eq ""
 
           bundle "platform --ruby", env: { "BUNDLER_VERSION" => bundler_version }, raise_on_error: false
           expect(stdboth).to eq "Could not locate Gemfile"

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -313,9 +313,10 @@ RSpec.describe ".bundle/config" do
 
   describe "parseable option" do
     it "prints an empty string" do
-      bundle "config get foo --parseable"
+      bundle "config get foo --parseable", raise_on_error: false
 
       expect(out).to eq ""
+      expect(last_command).to be_failure
     end
 
     it "only prints the value of the config" do
@@ -501,8 +502,9 @@ E
     it "get" do
       ENV["BUNDLE_BAR"] = "bar_val"
 
-      bundle "config get foo"
+      bundle "config get foo", raise_on_error: false
       expect(out).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
+      expect(last_command).to be_failure
 
       ENV["BUNDLE_FOO"] = "foo_val"
 
@@ -547,7 +549,8 @@ E
 
       bundle "config unset foo"
       expect(out).to eq ""
-      expect(bundle("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
+      expect(bundle("config get foo", raise_on_error: false)).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
+      expect(last_command).to be_failure
 
       bundle "config set --local foo 1"
       bundle "config set --global foo 2"
@@ -557,7 +560,8 @@ E
       expect(bundle("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nSet for the current user (#{home(".bundle/config")}): \"2\""
       bundle "config unset foo --global"
       expect(out).to eq ""
-      expect(bundle("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
+      expect(bundle("config get foo", raise_on_error: false)).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
+      expect(last_command).to be_failure
 
       bundle "config set --local foo 1"
       bundle "config set --global foo 2"
@@ -567,7 +571,8 @@ E
       expect(bundle("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nSet for your local app (#{bundled_app(".bundle/config")}): \"1\""
       bundle "config unset foo --local"
       expect(out).to eq ""
-      expect(bundle("config get foo")).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
+      expect(bundle("config get foo", raise_on_error: false)).to eq "Settings for `foo` in order of priority. The top value will be used\nYou have not configured a value for `foo`"
+      expect(last_command).to be_failure
 
       bundle "config unset foo --local --global", raise_on_error: false
       expect(last_command).to be_failure

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe "major deprecations" do
 
     describe "old get interface" do
       before do
-        bundle "config waka"
+        bundle "config waka", raise_on_error: false
       end
 
       it "warns", bundler: "4" do


### PR DESCRIPTION
Fix #3215

Change the exit status to 1 when trying to `get` a config key that does not exist, as shown below.

```sh
$ bundle config get foo

Settings for `foo` in order of priority. The top value will be used

You have not configured a value for `foo`

$ echo $?
1
```

It seems that showing “Settings for `foo` in order of priority. The top value will be used” when the key does not exist is not very meaningful, but for now I have left the behavior unchanged except for the exit status.

In the tests, some existing cases try to `get` a missing config without `raise_on_error: false`, so set the value in advance or add `raise_on_error: false` to handle them.
