### PR TITLE
Skip bundler self-checksum on ruby-core in test fixtures

### DIFF
--- a/spec/support/checksums.rb
+++ b/spec/support/checksums.rb
@@ -58,7 +58,12 @@ module Spec
       ChecksumsBuilder.new(enabled, &block).tap do |builder|
         next if builder.bundler_registered || !bundler_checksum
 
-        next if Bundler::VERSION.to_s.end_with?(".dev")
+        # Mirror the conditions under which LockfileGenerator#bundler_checksum
+        # gives up and omits the bundler checksum from the lockfile:
+        #   - .dev: development builds have no released bundler.gem to checksum.
+        #   - ruby_core?: bundler is loaded as a default gem, so bundler.gem
+        #     is not present on disk under the test gem cache.
+        next if Bundler::VERSION.to_s.end_with?(".dev") || ruby_core?
         builder.checksum(system_gem_path, "bundler", Bundler::VERSION, Gem::Platform::RUBY, "cache")
       end
     end

--- a/spec/support/checksums.rb
+++ b/spec/support/checksums.rb
@@ -63,7 +63,7 @@ module Spec
         #   - .dev: development builds have no released bundler.gem to checksum.
         #   - ruby_core?: bundler is loaded as a default gem, so bundler.gem
         #     is not present on disk under the test gem cache.
-        next if Bundler::VERSION.to_s.end_with?(".dev") || ruby_core?
+        next if Bundler::VERSION.to_s.end_with?(".dev") || Spec::Path.ruby_core?
         builder.checksum(system_gem_path, "bundler", Bundler::VERSION, Gem::Platform::RUBY, "cache")
       end
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In ruby-core test setup, bundler is loaded as a default gem and the bundler.gem cache file is not present on disk where `LockfileGenerator#bundler_checksum` looks for it.

As a result, the generator omits the bundler checksum from the regenerated lockfile, while the test's checksums_section helper still adds it, making the "does not change the lock" expectations in setup_spec.rb fail on ruby-core CI for release branches (where Bundler::VERSION does not end in .dev).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
