### PR TITLE
Changelogs for RubyGems 4.0.11 and Bundler 4.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.0.11 / 2026-04-30
+
+### Enhancements:
+
+* Add commented-out rubygems_mfa_required to bundle gem template. Pull request [#9487](https://github.com/ruby/rubygems/pull/9487) by MatheusRich
+* Clarify the name and meaning of the first argument to `gem spec`. Pull request [#9476](https://github.com/ruby/rubygems/pull/9476) by eregon
+* Installs bundler 4.0.11 as a default gem.
+
 ## 4.0.10 / 2026-04-08
 
 ### Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 4.0.11 / 2026-04-30
+
+### Enhancements:
+
+* Update gem creation guide URL to rubygems.org. Pull request [#9500](https://github.com/ruby/rubygems/pull/9500) by nissyi-gh
+* Lock the checksum of Bundler itself in the lockfile. Pull request [#9366](https://github.com/ruby/rubygems/pull/9366) by Edouard-chin
+
+### Bug fixes:
+
+* Skip bundler self-checksum on ruby-core in test fixtures. Pull request [#9506](https://github.com/ruby/rubygems/pull/9506) by hsbt
+* Skip bundler self-checksum for unreleased bundlers. Pull request [#9501](https://github.com/ruby/rubygems/pull/9501) by hsbt
+* Fix installing gems with native extensions + transitive dependencies. Pull request [#9477](https://github.com/ruby/rubygems/pull/9477) by nicholasdower
+* Fix the bundler version not being updated in dev/test lockfile. Pull request [#9463](https://github.com/ruby/rubygems/pull/9463) by Edouard-chin
+* Ensure the release CI doesn't break due to the Bundler checksum feature. Pull request [#9436](https://github.com/ruby/rubygems/pull/9436) by Edouard-chin
+
+### Documentation:
+
+* Fix formatting for BUNDLE_PREFER_PATCH variable in man page. Pull request [#9474](https://github.com/ruby/rubygems/pull/9474) by toy
+
 ## 4.0.10 / 2026-04-08
 
 ### Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 4.0.11 and Bundler 4.0.11 into master.