### PR TITLE
Replace #9506 with a targeted :ruby_repo skip

### DIFF
--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -1309,7 +1309,12 @@ end
     end
 
     context "is not present" do
-      it "does not change the lock" do
+      # Skipped on ruby-core because `ruby "require 'bundler/setup'"` does not
+      # activate bundler as a gem there, so Source::Metadata falls back to a
+      # synthetic spec whose cache_file does not exist on disk and
+      # LockfileGenerator#bundler_checksum drops the bundler checksum, while
+      # the on-disk lockfile still has it.
+      it "does not change the lock", :ruby_repo do
         expect { ruby "require 'bundler/setup'" }.not_to change { lockfile }
       end
     end

--- a/spec/support/checksums.rb
+++ b/spec/support/checksums.rb
@@ -58,12 +58,7 @@ module Spec
       ChecksumsBuilder.new(enabled, &block).tap do |builder|
         next if builder.bundler_registered || !bundler_checksum
 
-        # Mirror the conditions under which LockfileGenerator#bundler_checksum
-        # gives up and omits the bundler checksum from the lockfile:
-        #   - .dev: development builds have no released bundler.gem to checksum.
-        #   - ruby_core?: bundler is loaded as a default gem, so bundler.gem
-        #     is not present on disk under the test gem cache.
-        next if Bundler::VERSION.to_s.end_with?(".dev") || Spec::Path.ruby_core?
+        next if Bundler::VERSION.to_s.end_with?(".dev")
         builder.checksum(system_gem_path, "bundler", Bundler::VERSION, Gem::Platform::RUBY, "cache")
       end
     end


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

The blanket skip in checksums_section from #9506 caused ruby-core test failures whose lockfile expectations legitimately include the bundler checksum (paths that go through `bundle install` where bundler is activated as a gem).

Revert that change and instead tag only the affected setup_spec example with :ruby_repo, since its `ruby "require 'bundler/setup'"` invocation is the one case where bundler is loaded from $LOAD_PATH and Source::Metadata's synthetic bundler spec has no cache_file on disk.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
