### PR TITLE
Fix bundle config gemfile unset behavior

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -61,14 +61,18 @@ module Bundler
 
       current_cmd = args.last[:current_command].name
 
-      Bundler.configure_custom_gemfile(options[:gemfile])
+      # `bundle config` manages stored settings, so avoid promoting settings
+      # like `gemfile` or `lockfile` to environment variables before it runs.
+      unless current_cmd == "config"
+        Bundler.configure_custom_gemfile(options[:gemfile])
 
-      # lock --lockfile works differently than install --lockfile
-      unless current_cmd == "lock"
-        custom_lockfile = options[:lockfile] || ENV["BUNDLE_LOCKFILE"] || Bundler.settings[:lockfile]
-        if custom_lockfile && !custom_lockfile.empty?
-          Bundler::SharedHelpers.set_env "BUNDLE_LOCKFILE", File.expand_path(custom_lockfile)
-          reset_settings = true
+        # lock --lockfile works differently than install --lockfile
+        unless current_cmd == "lock"
+          custom_lockfile = options[:lockfile] || ENV["BUNDLE_LOCKFILE"] || Bundler.settings[:lockfile]
+          if custom_lockfile && !custom_lockfile.empty?
+            Bundler::SharedHelpers.set_env "BUNDLE_LOCKFILE", File.expand_path(custom_lockfile)
+            reset_settings = true
+          end
         end
       end
 

--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -577,6 +577,36 @@ E
 end
 
 RSpec.describe "setting gemfile via config" do
+  context "when a default Gemfile exists" do
+    before do
+      gemfile <<-G
+        source "https://gem.repo1"
+      G
+
+      gemfile bundled_app("foo/bar_gemfile"), <<-G
+        source "https://gem.repo1"
+      G
+    end
+
+    it "reports the local gemfile setting without promoting it to the environment" do
+      bundle "config set gemfile foo/bar_gemfile"
+
+      bundle "config list"
+      expect(out).to include("Set for your local app (#{bundled_app(".bundle/config")}): \"foo/bar_gemfile\"")
+      expect(out).not_to include("Set via BUNDLE_GEMFILE")
+    end
+
+    it "unsets the local gemfile setting from the app config" do
+      bundle "config set gemfile foo/bar_gemfile"
+
+      bundle "config unset gemfile"
+      bundle "config get gemfile"
+
+      expect(out).to include("You have not configured a value for `gemfile`")
+      expect(File.read(bundled_app(".bundle/config"))).not_to include("BUNDLE_GEMFILE")
+    end
+  end
+
   context "when only the non-default Gemfile exists" do
     it "persists the gemfile location to .bundle/config" do
       gemfile bundled_app("NotGemfile"), <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

After setting a custom Gemfile with `bundle config set gemfile foo/bar_gemfile`, later `bundle config` commands reported the value as coming from `BUNDLE_GEMFILE` instead of the local `.bundle/config` file.

That also meant `bundle config unset gemfile` did not remove the local setting, leaving users unable to clear the configured Gemfile without manually editing `.bundle/config`.

Fixes #5925.

## What is your fix for the problem, implemented in this PR?

The CLI initializer was promoting the configured `gemfile` setting into `ENV["BUNDLE_GEMFILE"]` before the `config` subcommand ran. That made `bundle config list` display the value as environment-derived and made `bundle config unset gemfile` miss the stored local setting.

This PR skips that promotion for `bundle config`, since that command is responsible for reading and editing stored settings directly. Other commands continue to resolve configured custom Gemfiles as before.

Regression specs cover both listing the local `gemfile` setting and unsetting it from `.bundle/config`.

Validation run:

- `bin/rspec spec/commands/config_spec.rb`
- `bin/rake rubocop`

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
