### PR TITLE
Add Gemfile `override` DSL for version constraints (Phase 1)

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -156,6 +156,7 @@ bundler/lib/bundler/match_platform.rb
 bundler/lib/bundler/match_remote_metadata.rb
 bundler/lib/bundler/materialization.rb
 bundler/lib/bundler/mirror.rb
+bundler/lib/bundler/override.rb
 bundler/lib/bundler/plugin.rb
 bundler/lib/bundler/plugin/api.rb
 bundler/lib/bundler/plugin/api/source.rb

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -62,6 +62,7 @@ module Bundler
   autoload :MatchRemoteMetadata,    File.expand_path("bundler/match_remote_metadata", __dir__)
   autoload :Materialization,        File.expand_path("bundler/materialization", __dir__)
   autoload :NULL,                   File.expand_path("bundler/constants", __dir__)
+  autoload :Override,               File.expand_path("bundler/override", __dir__)
   autoload :ProcessLock,            File.expand_path("bundler/process_lock", __dir__)
   autoload :RemoteSpecification,    File.expand_path("bundler/remote_specification", __dir__)
   autoload :Resolver,               File.expand_path("bundler/resolver", __dir__)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -10,13 +10,14 @@ module Bundler
       attr_accessor :no_lock
     end
 
-    attr_writer :lockfile
+    attr_writer :lockfile, :overrides
 
     attr_reader(
       :dependencies,
       :locked_checksums,
       :locked_deps,
       :locked_gems,
+      :overrides,
       :platforms,
       :ruby_version,
       :lockfile,
@@ -88,6 +89,7 @@ module Bundler
       @specs           = nil
       @ruby_version    = ruby_version
       @gemfiles        = gemfiles
+      @overrides       = []
 
       @lockfile               = lockfile
       @lockfile_contents      = String.new

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -635,7 +635,20 @@ module Bundler
     end
 
     def expanded_dependencies
-      dependencies_with_bundler + metadata_dependencies
+      apply_overrides_to(dependencies_with_bundler) + metadata_dependencies
+    end
+
+    def apply_overrides_to(deps)
+      return deps if @overrides.empty?
+      deps.map {|dep| apply_override_to(dep) }
+    end
+
+    def apply_override_to(dep)
+      override = @overrides.find {|o| o.target == dep.name && o.field == :version }
+      return dep unless override
+      new_dep = dep.dup
+      new_dep.instance_variable_set(:@requirement, override.apply_to(dep.requirement))
+      new_dep
     end
 
     def dependencies_with_bundler

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1054,7 +1054,23 @@ module Bundler
         @changed_dependencies << name if dep_changed
       end
 
+      converge_overrides_outside_dependencies
+
       @changed_dependencies.any?
+    end
+
+    def converge_overrides_outside_dependencies
+      @overrides.each do |override|
+        next unless override.target.is_a?(String)
+
+        name = override.target
+        next if @changed_dependencies.include?(name)
+        next if @dependencies.any? {|d| d.name == name }
+        next if @originally_locked_specs[name].empty?
+
+        @gems_to_unlock << name
+        @changed_dependencies << name
+      end
     end
 
     # Remove elements from the locked specs that are expired. This will most

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1275,7 +1275,7 @@ module Bundler
 
     def new_resolution_base(last_resolve:, unlock:)
       new_resolution_platforms = @current_platform_missing ? @new_platforms + [Bundler.local_platform] : @new_platforms
-      Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, locked_specs: @originally_locked_specs, unlock: unlock, prerelease: gem_version_promoter.pre?, prefer_local: @prefer_local, new_platforms: new_resolution_platforms)
+      Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, locked_specs: @originally_locked_specs, unlock: unlock, prerelease: gem_version_promoter.pre?, prefer_local: @prefer_local, new_platforms: new_resolution_platforms, overrides: @overrides)
     end
 
     def new_resolver(base)

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -59,7 +59,7 @@ module Bundler
     #   to be updated or true if all gems should be updated
     # @param ruby_version [Bundler::RubyVersion, nil] Requested Ruby Version
     # @param optional_groups [Array(String)] A list of optional groups
-    def initialize(lockfile, dependencies, sources, unlock, ruby_version = nil, optional_groups = [], gemfiles = [])
+    def initialize(lockfile, dependencies, sources, unlock, ruby_version = nil, optional_groups = [], gemfiles = [], overrides = [])
       unlock ||= {}
 
       if unlock == true
@@ -89,7 +89,7 @@ module Bundler
       @specs           = nil
       @ruby_version    = ruby_version
       @gemfiles        = gemfiles
-      @overrides       = []
+      @overrides       = overrides
 
       @lockfile               = lockfile
       @lockfile_contents      = String.new
@@ -1044,7 +1044,7 @@ module Bundler
               @locked_specs.delete(locked_specs.select {|s| s.source != dep.source })
             end
 
-            unless dep.matches_spec?(locked_specs.first)
+            unless apply_override_to(dep).matches_spec?(locked_specs.first)
               @gems_to_unlock << name
               dep_changed = true
             end

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -198,6 +198,7 @@ module Bundler
       operations.each do |field, operation|
         validate_override_field!(field)
         validate_override_operation!(operation)
+        validate_override_uniqueness!(target, field)
       end
 
       operations.each do |field, operation|
@@ -288,6 +289,11 @@ module Bundler
       else
         raise ArgumentError, "override operation must be a String, Symbol, or nil, got #{operation.inspect}"
       end
+    end
+
+    def validate_override_uniqueness!(target, field)
+      return unless @overrides.any? {|o| o.target == target && o.field == field }
+      raise ArgumentError, "duplicate override for #{target.inspect} `#{field}:`"
     end
 
     def add_dependency(name, version = nil, options = {})

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -209,9 +209,7 @@ module Bundler
     def to_definition(lockfile, unlock)
       check_primary_source_safety
       lockfile = @lockfile unless @lockfile.nil?
-      definition = Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups, @gemfiles)
-      definition.overrides = @overrides
-      definition
+      Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups, @gemfiles, @overrides)
     end
 
     def group(*args, &blk)

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -185,9 +185,19 @@ module Bundler
       with_source(git_source) { yield }
     end
 
+    SUPPORTED_OVERRIDE_FIELDS = [:version].freeze
+    SUPPORTED_OVERRIDE_SYMBOL_OPERATIONS = [:ignore_upper].freeze
+
     def override(target, **operations)
+      validate_override_target!(target)
+
       if target == :all && operations.key?(:version)
         raise ArgumentError, "`override :all, version:` is not allowed; version requirements are per-gem"
+      end
+
+      operations.each do |field, operation|
+        validate_override_field!(field)
+        validate_override_operation!(operation)
       end
 
       operations.each do |field, operation|
@@ -256,6 +266,29 @@ module Bundler
     end
 
     private
+
+    def validate_override_target!(target)
+      return if target == :all
+      return if target.is_a?(String)
+      raise ArgumentError, "override target must be :all or a gem name string, got #{target.inspect}"
+    end
+
+    def validate_override_field!(field)
+      return if SUPPORTED_OVERRIDE_FIELDS.include?(field)
+      raise ArgumentError, "unsupported override field `#{field}:`; only `version:` is currently supported"
+    end
+
+    def validate_override_operation!(operation)
+      case operation
+      when String, nil
+        # ok
+      when Symbol
+        return if SUPPORTED_OVERRIDE_SYMBOL_OPERATIONS.include?(operation)
+        raise ArgumentError, "unsupported override operation: #{operation.inspect}"
+      else
+        raise ArgumentError, "override operation must be a String, Symbol, or nil, got #{operation.inspect}"
+      end
+    end
 
     def add_dependency(name, version = nil, options = {})
       options["gemfile"] = @gemfile

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -186,6 +186,10 @@ module Bundler
     end
 
     def override(target, **operations)
+      if target == :all && operations.key?(:version)
+        raise ArgumentError, "`override :all, version:` is not allowed; version requirements are per-gem"
+      end
+
       operations.each do |field, operation|
         @overrides << Override.new(target, field, operation)
       end

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -22,7 +22,7 @@ module Bundler
     GITHUB_PULL_REQUEST_URL = %r{\Ahttps://github\.com/([A-Za-z0-9_\-\.]+/[A-Za-z0-9_\-\.]+)/pull/(\d+)\z}
     GITLAB_MERGE_REQUEST_URL = %r{\Ahttps://gitlab\.com/([A-Za-z0-9_\-\./]+)/-/merge_requests/(\d+)\z}
 
-    attr_reader :gemspecs, :gemfile
+    attr_reader :gemspecs, :gemfile, :overrides
     attr_accessor :dependencies
 
     def initialize
@@ -40,6 +40,7 @@ module Bundler
       @gemfile              = nil
       @gemfiles             = []
       @lockfile             = nil
+      @overrides            = []
       add_git_sources
     end
 
@@ -184,10 +185,18 @@ module Bundler
       with_source(git_source) { yield }
     end
 
+    def override(target, **operations)
+      operations.each do |field, operation|
+        @overrides << Override.new(target, field, operation)
+      end
+    end
+
     def to_definition(lockfile, unlock)
       check_primary_source_safety
       lockfile = @lockfile unless @lockfile.nil?
-      Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups, @gemfiles)
+      definition = Definition.new(lockfile, @dependencies, @sources, unlock, @ruby_version, @optional_groups, @gemfiles)
+      definition.overrides = @overrides
+      definition
     end
 
     def group(*args, &blk)

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ADD" "1" "April 2026" ""
+.TH "BUNDLE\-ADD" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-binstubs.1
+++ b/bundler/lib/bundler/man/bundle-binstubs.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-BINSTUBS" "1" "April 2026" ""
+.TH "BUNDLE\-BINSTUBS" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-binstubs\fR \- Install the binstubs of the listed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-cache.1
+++ b/bundler/lib/bundler/man/bundle-cache.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CACHE" "1" "April 2026" ""
+.TH "BUNDLE\-CACHE" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-cache\fR \- Package your needed \fB\.gem\fR files into your application
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-check.1
+++ b/bundler/lib/bundler/man/bundle-check.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CHECK" "1" "April 2026" ""
+.TH "BUNDLE\-CHECK" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-check\fR \- Verifies if dependencies are satisfied by installed gems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-clean.1
+++ b/bundler/lib/bundler/man/bundle-clean.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CLEAN" "1" "April 2026" ""
+.TH "BUNDLE\-CLEAN" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-clean\fR \- Cleans up unused gems in your bundler directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CONFIG" "1" "April 2026" ""
+.TH "BUNDLE\-CONFIG" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-config\fR \- Set bundler configuration options
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-console.1
+++ b/bundler/lib/bundler/man/bundle-console.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-CONSOLE" "1" "April 2026" ""
+.TH "BUNDLE\-CONSOLE" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-console\fR \- Open an IRB session with the bundle pre\-loaded
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-doctor.1
+++ b/bundler/lib/bundler/man/bundle-doctor.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-DOCTOR" "1" "April 2026" ""
+.TH "BUNDLE\-DOCTOR" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-doctor\fR \- Checks the bundle for common problems
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-env.1
+++ b/bundler/lib/bundler/man/bundle-env.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ENV" "1" "April 2026" ""
+.TH "BUNDLE\-ENV" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-env\fR \- Print information about the environment Bundler is running under
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-exec.1
+++ b/bundler/lib/bundler/man/bundle-exec.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-EXEC" "1" "April 2026" ""
+.TH "BUNDLE\-EXEC" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-exec\fR \- Execute a command in the context of the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-fund.1
+++ b/bundler/lib/bundler/man/bundle-fund.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-FUND" "1" "April 2026" ""
+.TH "BUNDLE\-FUND" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-fund\fR \- Lists information about gems seeking funding assistance
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-GEM" "1" "April 2026" ""
+.TH "BUNDLE\-GEM" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-gem\fR \- Generate a project skeleton for creating a rubygem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-help.1
+++ b/bundler/lib/bundler/man/bundle-help.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-HELP" "1" "April 2026" ""
+.TH "BUNDLE\-HELP" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-help\fR \- Displays detailed help for each subcommand
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-info.1
+++ b/bundler/lib/bundler/man/bundle-info.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INFO" "1" "April 2026" ""
+.TH "BUNDLE\-INFO" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-info\fR \- Show information for the given gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-init.1
+++ b/bundler/lib/bundler/man/bundle-init.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INIT" "1" "April 2026" ""
+.TH "BUNDLE\-INIT" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-init\fR \- Generates a Gemfile into the current working directory
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-INSTALL" "1" "April 2026" ""
+.TH "BUNDLE\-INSTALL" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-issue.1
+++ b/bundler/lib/bundler/man/bundle-issue.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-ISSUE" "1" "April 2026" ""
+.TH "BUNDLE\-ISSUE" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-issue\fR \- Get help reporting Bundler issues
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-licenses.1
+++ b/bundler/lib/bundler/man/bundle-licenses.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LICENSES" "1" "April 2026" ""
+.TH "BUNDLE\-LICENSES" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-licenses\fR \- Print the license of all gems in the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-list.1
+++ b/bundler/lib/bundler/man/bundle-list.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LIST" "1" "April 2026" ""
+.TH "BUNDLE\-LIST" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-list\fR \- List all the gems in the bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-lock.1
+++ b/bundler/lib/bundler/man/bundle-lock.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-LOCK" "1" "April 2026" ""
+.TH "BUNDLE\-LOCK" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-lock\fR \- Creates / Updates a lockfile without installing
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-open.1
+++ b/bundler/lib/bundler/man/bundle-open.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-OPEN" "1" "April 2026" ""
+.TH "BUNDLE\-OPEN" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-open\fR \- Opens the source directory for a gem in your bundle
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-OUTDATED" "1" "April 2026" ""
+.TH "BUNDLE\-OUTDATED" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-platform.1
+++ b/bundler/lib/bundler/man/bundle-platform.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PLATFORM" "1" "April 2026" ""
+.TH "BUNDLE\-PLATFORM" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-platform\fR \- Displays platform compatibility information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-plugin.1
+++ b/bundler/lib/bundler/man/bundle-plugin.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PLUGIN" "1" "April 2026" ""
+.TH "BUNDLE\-PLUGIN" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-plugin\fR \- Manage Bundler plugins
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-pristine.1
+++ b/bundler/lib/bundler/man/bundle-pristine.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-PRISTINE" "1" "April 2026" ""
+.TH "BUNDLE\-PRISTINE" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-pristine\fR \- Restores installed gems to their pristine condition
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-remove.1
+++ b/bundler/lib/bundler/man/bundle-remove.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-REMOVE" "1" "April 2026" ""
+.TH "BUNDLE\-REMOVE" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-remove\fR \- Removes gems from the Gemfile
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-show.1
+++ b/bundler/lib/bundler/man/bundle-show.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-SHOW" "1" "April 2026" ""
+.TH "BUNDLE\-SHOW" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-show\fR \- Shows all the gems in your bundle, or the path to a gem
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-UPDATE" "1" "April 2026" ""
+.TH "BUNDLE\-UPDATE" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle-version.1
+++ b/bundler/lib/bundler/man/bundle-version.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE\-VERSION" "1" "April 2026" ""
+.TH "BUNDLE\-VERSION" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\-version\fR \- Prints Bundler version information
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/bundle.1
+++ b/bundler/lib/bundler/man/bundle.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "BUNDLE" "1" "April 2026" ""
+.TH "BUNDLE" "1" "May 2026" ""
 .SH "NAME"
 \fBbundle\fR \- Ruby Dependency Management
 .SH "SYNOPSIS"

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "GEMFILE" "5" "April 2026" ""
+.TH "GEMFILE" "5" "May 2026" ""
 .SH "NAME"
 \fBGemfile\fR \- A format for describing gem dependencies for Ruby programs
 .SH "SYNOPSIS"
@@ -460,6 +460,42 @@ The \fBgemspec\fR method adds any runtime dependencies as gem requirements in th
 The \fBgemspec\fR method supports optional \fB:path\fR, \fB:glob\fR, \fB:name\fR, and \fB:development_group\fR options, which control where bundler looks for the \fB\.gemspec\fR, the glob it uses to look for the gemspec (defaults to: \fB{,*,*/*}\.gemspec\fR), what named \fB\.gemspec\fR it uses (if more than one is present), and which group development dependencies are included in\.
 .P
 When a \fBgemspec\fR dependency encounters version conflicts during resolution, the local version under development will always be selected \-\- even if there are remote versions that better match other requirements for the \fBgemspec\fR gem\.
+.SH "OVERRIDE"
+The \fBoverride\fR directive rewrites the version requirement on another gem before resolution runs\. It targets the common case where an upstream gem's published metadata is too narrow on the current project's machine \-\- a stale upper bound, an unwanted floor, or a transitive pin that has to be lifted\.
+.IP "" 4
+.nf
+override <target>, <field>: <operation>
+.fi
+.IP "" 0
+.P
+\fB<target>\fR is a gem name string\. \fB<field>\fR is \fBversion:\fR\. \fB<operation>\fR is one of:
+.IP "\(bu" 4
+a version requirement string (e\.g\. \fB">= 8\.0"\fR), which \fBreplaces\fR the target's version requirement absolutely\. The original requirement, both direct and transitive, is discarded in favour of the override\.
+.IP "\(bu" 4
+\fB:ignore_upper\fR, which removes upper\-bound operators (\fB<\fR and \fB<=\fR) from the existing requirement and folds \fB~>\fR into its lower bound (\fB~> 1\.5\fR becomes \fB>= 1\.5\fR)\. Other operators, including \fB!=\fR, are preserved\.
+.IP "\(bu" 4
+\fBnil\fR, which collapses the requirement to \fB>= 0\fR (no constraint at all)\.
+.IP "" 0
+.P
+Multiple \fBoverride\fR calls for distinct targets are allowed; declaring the same \fBtarget\fR and \fBfield\fR twice is an error\.
+.IP "" 4
+.nf
+source "https://rubygems\.org"
+
+# Force every reference to "rails" \-\- direct or transitive \-\- to >= 8\.0\.
+override "rails", version: ">= 8\.0"
+
+# Strip the upper bound on nokogiri\.
+override "nokogiri", version: :ignore_upper
+
+# Drop the version pin on legacy entirely\.
+override "legacy", version: nil
+
+gem "rails", "~> 7\.0"
+.fi
+.IP "" 0
+.P
+The override only affects resolution; \fBGemfile\.lock\fR continues to reflect the resolved versions, not the rewritten requirements\.
 .SH "SOURCE PRIORITY"
 When attempting to locate a gem to satisfy a gem requirement, bundler uses the following priority order:
 .IP "1." 4

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -541,6 +541,45 @@ When a `gemspec` dependency encounters version conflicts during resolution, the
 local version under development will always be selected -- even if there are
 remote versions that better match other requirements for the `gemspec` gem.
 
+## OVERRIDE
+
+The `override` directive rewrites the version requirement on another gem
+before resolution runs. It targets the common case where an upstream gem's
+published metadata is too narrow on the current project's machine -- a stale
+upper bound, an unwanted floor, or a transitive pin that has to be lifted.
+
+    override <target>, <field>: <operation>
+
+`<target>` is a gem name string. `<field>` is `version:`. `<operation>` is
+one of:
+
+  * a version requirement string (e.g. `">= 8.0"`), which **replaces** the
+    target's version requirement absolutely. The original requirement, both
+    direct and transitive, is discarded in favour of the override.
+  * `:ignore_upper`, which removes upper-bound operators (`<` and `<=`) from
+    the existing requirement and folds `~>` into its lower bound (`~> 1.5`
+    becomes `>= 1.5`). Other operators, including `!=`, are preserved.
+  * `nil`, which collapses the requirement to `>= 0` (no constraint at all).
+
+Multiple `override` calls for distinct targets are allowed; declaring the
+same `target` and `field` twice is an error.
+
+    source "https://rubygems.org"
+
+    # Force every reference to "rails" -- direct or transitive -- to >= 8.0.
+    override "rails", version: ">= 8.0"
+
+    # Strip the upper bound on nokogiri.
+    override "nokogiri", version: :ignore_upper
+
+    # Drop the version pin on legacy entirely.
+    override "legacy", version: nil
+
+    gem "rails", "~> 7.0"
+
+The override only affects resolution; `Gemfile.lock` continues to reflect
+the resolved versions, not the rewritten requirements.
+
 ## SOURCE PRIORITY
 
 When attempting to locate a gem to satisfy a gem requirement,

--- a/bundler/lib/bundler/override.rb
+++ b/bundler/lib/bundler/override.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Bundler
+  class Override
+    LOWER_BOUND_OPERATORS = [">=", ">", "="].freeze
+
+    attr_reader :target, :field, :operation
+
+    def initialize(target, field, operation)
+      @target = target
+      @field = field
+      @operation = operation
+    end
+
+    def apply_to(requirement)
+      case operation
+      when nil
+        Gem::Requirement.default
+      when :ignore_upper
+        remove_upper_bounds(requirement)
+      when String
+        Gem::Requirement.new(operation)
+      else
+        raise ArgumentError, "unsupported override operation: #{operation.inspect}"
+      end
+    end
+
+    private
+
+    def remove_upper_bounds(requirement)
+      return Gem::Requirement.default if requirement.nil? || requirement.none?
+
+      lower_bounds = requirement.requirements.filter_map do |op, version|
+        if LOWER_BOUND_OPERATORS.include?(op)
+          [op, version]
+        elsif op == "~>"
+          [">=", version]
+        end
+      end
+
+      return Gem::Requirement.default if lower_bounds.empty?
+
+      Gem::Requirement.new(lower_bounds.map {|op, v| "#{op} #{v}" })
+    end
+  end
+end

--- a/bundler/lib/bundler/override.rb
+++ b/bundler/lib/bundler/override.rb
@@ -2,7 +2,7 @@
 
 module Bundler
   class Override
-    LOWER_BOUND_OPERATORS = [">=", ">", "="].freeze
+    UPPER_BOUND_OPERATORS = ["<", "<="].freeze
 
     attr_reader :target, :field, :operation
 
@@ -30,17 +30,19 @@ module Bundler
     def remove_upper_bounds(requirement)
       return Gem::Requirement.default if requirement.nil? || requirement.none?
 
-      lower_bounds = requirement.requirements.filter_map do |op, version|
-        if LOWER_BOUND_OPERATORS.include?(op)
-          [op, version]
+      preserved = requirement.requirements.filter_map do |op, version|
+        if UPPER_BOUND_OPERATORS.include?(op)
+          nil
         elsif op == "~>"
           [">=", version]
+        else
+          [op, version]
         end
       end
 
-      return Gem::Requirement.default if lower_bounds.empty?
+      return Gem::Requirement.default if preserved.empty?
 
-      Gem::Requirement.new(lower_bounds.map {|op, v| "#{op} #{v}" })
+      Gem::Requirement.new(preserved.map {|op, v| "#{op} #{v}" })
     end
   end
 end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -510,7 +510,7 @@ module Bundler
     end
 
     def to_dependency_hash(dependencies, packages)
-      dependencies.inject({}) do |deps, dep|
+      apply_overrides(dependencies).inject({}) do |deps, dep|
         package = packages[dep.name]
 
         current_req = deps[package]
@@ -523,6 +523,16 @@ module Bundler
         end
 
         deps
+      end
+    end
+
+    def apply_overrides(dependencies)
+      return dependencies if @base.overrides.empty?
+
+      dependencies.map do |dep|
+        override = @base.overrides.find {|o| o.target == dep.name && o.field == :version }
+        next dep unless override
+        Gem::Dependency.new(dep.name, override.apply_to(dep.requirement))
       end
     end
 

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -5,9 +5,10 @@ require_relative "package"
 module Bundler
   class Resolver
     class Base
-      attr_reader :packages, :requirements, :source_requirements, :locked_specs
+      attr_reader :packages, :requirements, :source_requirements, :locked_specs, :overrides
 
       def initialize(source_requirements, dependencies, base, platforms, options)
+        @overrides = options.delete(:overrides) || []
         @source_requirements = source_requirements
         @locked_specs = options[:locked_specs]
 

--- a/spec/bundler/definition_spec.rb
+++ b/spec/bundler/definition_spec.rb
@@ -3,6 +3,24 @@
 require "bundler/definition"
 
 RSpec.describe Bundler::Definition do
+  describe "#overrides" do
+    before do
+      allow(Bundler::SharedHelpers).to receive(:find_gemfile) { bundled_app_gemfile }
+    end
+
+    subject { Bundler::Definition.new(bundled_app_lock, [], Bundler::SourceList.new, {}) }
+
+    it "defaults to an empty array" do
+      expect(subject.overrides).to eq([])
+    end
+
+    it "is writable" do
+      override = Bundler::Override.new("rails", :version, ">= 8.0")
+      subject.overrides = [override]
+      expect(subject.overrides).to eq([override])
+    end
+  end
+
   describe "#lock" do
     before do
       allow(Bundler::SharedHelpers).to receive(:find_gemfile) { bundled_app_gemfile }

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -416,5 +416,36 @@ RSpec.describe Bundler::Dsl do
       end.to raise_error(ArgumentError)
       expect(subject.overrides).to eq([])
     end
+
+    it "raises ArgumentError when target is neither :all nor a string" do
+      expect do
+        subject.override(:rails, version: ">= 8.0")
+      end.to raise_error(ArgumentError, /target must be :all or a gem name string/)
+    end
+
+    it "raises ArgumentError for an unsupported field" do
+      expect do
+        subject.override("rails", required_ruby_version: :ignore_upper)
+      end.to raise_error(ArgumentError, /unsupported override field `required_ruby_version:`/)
+    end
+
+    it "raises ArgumentError for a non-string, non-symbol, non-nil operation" do
+      expect do
+        subject.override("rails", version: 42)
+      end.to raise_error(ArgumentError, /override operation must be a String, Symbol, or nil/)
+    end
+
+    it "raises ArgumentError for an unsupported symbol operation" do
+      expect do
+        subject.override("rails", version: :explode)
+      end.to raise_error(ArgumentError, /unsupported override operation/)
+    end
+
+    it "rejects atomically when one field in a multi-field call is invalid" do
+      expect do
+        subject.override("rails", version: ">= 8.0", required_ruby_version: :ignore_upper)
+      end.to raise_error(ArgumentError, /unsupported override field/)
+      expect(subject.overrides).to eq([])
+    end
   end
 end

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -447,5 +447,27 @@ RSpec.describe Bundler::Dsl do
       end.to raise_error(ArgumentError, /unsupported override field/)
       expect(subject.overrides).to eq([])
     end
+
+    it "raises ArgumentError when the same target and field are overridden twice" do
+      subject.override("rails", version: ">= 8.0")
+      expect do
+        subject.override("rails", version: :ignore_upper)
+      end.to raise_error(ArgumentError, /duplicate override for "rails" `version:`/)
+    end
+
+    it "keeps the original override when a duplicate is rejected" do
+      subject.override("rails", version: ">= 8.0")
+      expect do
+        subject.override("rails", version: :ignore_upper)
+      end.to raise_error(ArgumentError)
+      expect(subject.overrides.size).to eq(1)
+      expect(subject.overrides.first.operation).to eq(">= 8.0")
+    end
+
+    it "allows different targets with the same field" do
+      subject.override("rails", version: ">= 8.0")
+      subject.override("nokogiri", version: :ignore_upper)
+      expect(subject.overrides.size).to eq(2)
+    end
   end
 end

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -366,4 +366,36 @@ RSpec.describe Bundler::Dsl do
       end
     end
   end
+
+  describe "#override" do
+    it "stores an Override for a gem with a version: operation" do
+      subject.override("rails", version: ">= 8.0")
+
+      expect(subject.overrides.size).to eq(1)
+      override = subject.overrides.first
+      expect(override.target).to eq("rails")
+      expect(override.field).to eq(:version)
+      expect(override.operation).to eq(">= 8.0")
+    end
+
+    it "accepts :ignore_upper as the operation" do
+      subject.override("nokogiri", version: :ignore_upper)
+      expect(subject.overrides.first.operation).to eq(:ignore_upper)
+    end
+
+    it "accepts nil as the operation" do
+      subject.override("legacy", version: nil)
+      expect(subject.overrides.first.operation).to be_nil
+    end
+
+    it "appends to overrides across multiple statements" do
+      subject.override("rails", version: ">= 8.0")
+      subject.override("nokogiri", version: :ignore_upper)
+      expect(subject.overrides.map(&:target)).to eq(["rails", "nokogiri"])
+    end
+
+    it "is empty by default" do
+      expect(subject.overrides).to eq([])
+    end
+  end
 end

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -397,5 +397,24 @@ RSpec.describe Bundler::Dsl do
     it "is empty by default" do
       expect(subject.overrides).to eq([])
     end
+
+    it "raises ArgumentError when target is :all and version: is given" do
+      expect do
+        subject.override(:all, version: ">= 8.0")
+      end.to raise_error(ArgumentError, /`override :all, version:` is not allowed/)
+    end
+
+    it "rejects :all + version: even when other fields are also given" do
+      expect do
+        subject.override(:all, required_ruby_version: :ignore_upper, version: ">= 8.0")
+      end.to raise_error(ArgumentError, /`override :all, version:` is not allowed/)
+    end
+
+    it "does not record any override when :all + version: is rejected" do
+      expect do
+        subject.override(:all, version: ">= 8.0")
+      end.to raise_error(ArgumentError)
+      expect(subject.overrides).to eq([])
+    end
   end
 end

--- a/spec/bundler/override_spec.rb
+++ b/spec/bundler/override_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::Override do
+  describe "#apply_to" do
+    context "when operation is a version spec string" do
+      it "replaces the existing requirement entirely" do
+        override = described_class.new("rails", :version, ">= 8.0")
+        result = override.apply_to(Gem::Requirement.new(">= 1.0", "< 2.0"))
+        expect(result).to eq(Gem::Requirement.new(">= 8.0"))
+      end
+
+      it "ignores the existing requirement regardless of its content" do
+        override = described_class.new("rails", :version, "= 1.0")
+        result = override.apply_to(Gem::Requirement.new(">= 99.0"))
+        expect(result).to eq(Gem::Requirement.new("= 1.0"))
+      end
+    end
+
+    context "when operation is :ignore_upper" do
+      it "removes < and <= operators" do
+        override = described_class.new("rails", :version, :ignore_upper)
+        result = override.apply_to(Gem::Requirement.new(">= 1.0", "< 2.0"))
+        expect(result).to eq(Gem::Requirement.new(">= 1.0"))
+      end
+
+      it "keeps >, >=, = operators" do
+        override = described_class.new("rails", :version, :ignore_upper)
+        result = override.apply_to(Gem::Requirement.new("> 1.0", "<= 2.0"))
+        expect(result).to eq(Gem::Requirement.new("> 1.0"))
+      end
+
+      it "converts ~> to >= preserving the lower bound" do
+        override = described_class.new("rails", :version, :ignore_upper)
+        result = override.apply_to(Gem::Requirement.new("~> 1.5"))
+        expect(result).to eq(Gem::Requirement.new(">= 1.5"))
+      end
+
+      it "returns the default requirement when only upper bounds remain" do
+        override = described_class.new("rails", :version, :ignore_upper)
+        result = override.apply_to(Gem::Requirement.new("< 2.0"))
+        expect(result).to eq(Gem::Requirement.default)
+      end
+
+      it "returns the default requirement when the input is nil" do
+        override = described_class.new("rails", :version, :ignore_upper)
+        expect(override.apply_to(nil)).to eq(Gem::Requirement.default)
+      end
+
+      it "returns the default requirement when the input is already the default" do
+        override = described_class.new("rails", :version, :ignore_upper)
+        expect(override.apply_to(Gem::Requirement.default)).to eq(Gem::Requirement.default)
+      end
+    end
+
+    context "when operation is nil" do
+      it "returns the default requirement" do
+        override = described_class.new("rails", :version, nil)
+        result = override.apply_to(Gem::Requirement.new(">= 1.0", "< 2.0"))
+        expect(result).to eq(Gem::Requirement.default)
+      end
+    end
+
+    context "when operation is unsupported" do
+      it "raises ArgumentError" do
+        override = described_class.new("rails", :version, 42)
+        expect { override.apply_to(Gem::Requirement.default) }.to raise_error(ArgumentError, /unsupported override operation/)
+      end
+    end
+  end
+end

--- a/spec/bundler/override_spec.rb
+++ b/spec/bundler/override_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe Bundler::Override do
         expect(result).to eq(Gem::Requirement.new(">= 1.5"))
       end
 
+      it "preserves != exclusion constraints" do
+        override = described_class.new("rails", :version, :ignore_upper)
+        result = override.apply_to(Gem::Requirement.new(">= 1.0", "!= 1.5.0", "< 2.0"))
+        expect(result).to eq(Gem::Requirement.new(">= 1.0", "!= 1.5.0"))
+      end
+
       it "returns the default requirement when only upper bounds remain" do
         override = described_class.new("rails", :version, :ignore_upper)
         result = override.apply_to(Gem::Requirement.new("< 2.0"))

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -88,4 +88,26 @@ RSpec.describe "override DSL" do
       expect(the_bundle).to include_gems "myrack 1.0.0"
     end
   end
+
+  context "with a version: nil operation" do
+    it "drops a direct dependency's pin entirely" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        override "myrack", version: nil
+        gem "myrack", "= 0.9.1"
+      G
+
+      expect(the_bundle).to include_gems "myrack 1.0.0"
+    end
+
+    it "drops a transitive dependency's pin entirely" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        override "myrack", version: nil
+        gem "myrack_middleware"
+      G
+
+      expect(the_bundle).to include_gems "myrack 1.0.0", "myrack_middleware 1.0"
+    end
+  end
 end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -66,4 +66,26 @@ RSpec.describe "override DSL" do
       expect(the_bundle).to include_gems "has_prerelease 1.1.pre"
     end
   end
+
+  context "with a version: :ignore_upper operation" do
+    it "strips a < upper bound on a direct dependency" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        override "myrack", version: :ignore_upper
+        gem "myrack", "< 1.0"
+      G
+
+      expect(the_bundle).to include_gems "myrack 1.0.0"
+    end
+
+    it "folds ~> into >= so newer versions become reachable" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        override "myrack", version: :ignore_upper
+        gem "myrack", "~> 0.9.1"
+      G
+
+      expect(the_bundle).to include_gems "myrack 1.0.0"
+    end
+  end
 end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -31,5 +31,24 @@ RSpec.describe "override DSL" do
 
       expect(the_bundle).to include_gems "myrack 0.9.1"
     end
+
+    it "applies the override against an existing lockfile" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack"
+      G
+
+      expect(the_bundle).to include_gems "myrack 1.0.0"
+
+      gemfile <<-G
+        source "https://gem.repo1"
+        override "myrack", version: "= 0.9.1"
+        gem "myrack"
+      G
+
+      bundle :install
+
+      expect(the_bundle).to include_gems "myrack 0.9.1"
+    end
   end
 end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe "override DSL" do
+  context "with a version: string operation" do
+    it "replaces a direct dependency requirement with the override version spec" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        override "myrack", version: "= 0.9.1"
+        gem "myrack"
+      G
+
+      expect(the_bundle).to include_gems "myrack 0.9.1"
+    end
+
+    it "replaces a transitive dependency requirement" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        override "myrack", version: "= 1.0.0"
+        gem "myrack_middleware"
+      G
+
+      expect(the_bundle).to include_gems "myrack 1.0.0", "myrack_middleware 1.0"
+    end
+
+    it "replaces the requirement even when the Gemfile pins a different version" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        override "myrack", version: "= 0.9.1"
+        gem "myrack", "= 1.0.0"
+      G
+
+      expect(the_bundle).to include_gems "myrack 0.9.1"
+    end
+  end
+end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -50,5 +50,20 @@ RSpec.describe "override DSL" do
 
       expect(the_bundle).to include_gems "myrack 0.9.1"
     end
+
+    it "pins a prerelease version that the Gemfile dependency would otherwise filter out" do
+      build_repo2 do
+        build_gem "has_prerelease", "1.0"
+        build_gem "has_prerelease", "1.1.pre"
+      end
+
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        override "has_prerelease", version: "= 1.1.pre"
+        gem "has_prerelease"
+      G
+
+      expect(the_bundle).to include_gems "has_prerelease 1.1.pre"
+    end
   end
 end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -109,5 +109,24 @@ RSpec.describe "override DSL" do
 
       expect(the_bundle).to include_gems "myrack 1.0.0", "myrack_middleware 1.0"
     end
+
+    it "applies a transitive-only override against an existing lockfile" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack_middleware"
+      G
+
+      expect(the_bundle).to include_gems "myrack 0.9.1", "myrack_middleware 1.0"
+
+      gemfile <<-G
+        source "https://gem.repo1"
+        override "myrack", version: "= 1.0.0"
+        gem "myrack_middleware"
+      G
+
+      bundle :install
+
+      expect(the_bundle).to include_gems "myrack 1.0.0", "myrack_middleware 1.0"
+    end
   end
 end

--- a/spec/support/windows_tag_group.rb
+++ b/spec/support/windows_tag_group.rb
@@ -189,6 +189,7 @@ module Spec
         "spec/bundler/uri_normalizer_spec.rb",
         "spec/install/gems/no_build_extension_spec.rb",
         "spec/install/gems/no_install_plugin_spec.rb",
+        "spec/bundler/override_spec.rb",
       ],
     }.freeze
   end

--- a/spec/support/windows_tag_group.rb
+++ b/spec/support/windows_tag_group.rb
@@ -190,6 +190,7 @@ module Spec
         "spec/install/gems/no_build_extension_spec.rb",
         "spec/install/gems/no_install_plugin_spec.rb",
         "spec/bundler/override_spec.rb",
+        "spec/install/gemfile/override_spec.rb",
       ],
     }.freeze
   end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

https://github.com/ruby/rubygems/discussions/9494, Supersedes #9454.

## What is your fix for the problem, implemented in this PR?

Adds a Gemfile-level `override` directive that rewrites a gem's version requirement before resolution. Phase 1 covers per-gem `version:` only.

```ruby
override "rails",   version: ">= 8.0"      # absolute replacement
override "rails",   version: :ignore_upper # strip <, <=, fold ~> into >=
override "legacy",  version: nil           # strip the requirement entirely
```

Applies to direct and transitive deps and against an existing lockfile. `Gemfile.lock` keeps recording resolved versions, not the rewrite.

Phase 2 will add `:all` and metadata fields:

```ruby
override :all,      required_ruby_version: :ignore_upper
override "old_gem", required_ruby_version: :ignore_upper
override "old_gem", required_rubygems_version: :ignore_upper
```

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
