### PR TITLE
Detect merge strategy when cherry-picking PRs for backport

### DIFF
--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -52,17 +52,7 @@ There is a `bin/rake prepare_release[<target_rubygems_version>]` rake task that 
 
 Note that this task requires all user facing pull requests to be tagged with specific labels. See [Merging a PR](../bundler/playbooks/MERGING_A_PR.md) for details.
 
-Also note that when this task cherry-picks, it cherry-picks the merge commits using the following command:
-
-```bash
-$ git cherry-pick -m 1 MERGE_COMMIT_SHAS
-```
-
-For example, for PR [#5029](https://github.com/rubygems/bundler/pull/5029), we cherry picked commit [dd6aef9](https://github.com/rubygems/bundler/commit/dd6aef97a5f2e7173f406267256a8c319d6134ab), not [4fe9291](https://github.com/rubygems/bundler/commit/4fe92919f51e3463f0aad6fa833ab68044311f03) using:
-
-```bash
-$ git cherry-pick -m 1 dd6aef9
-```
+Also note that when this task cherry-picks, the strategy depends on how the PR was merged on GitHub. PRs merged with "Create a merge commit" are cherry-picked using `git cherry-pick -m 1 MERGE_COMMIT_SHA` against the merge commit. PRs merged with "Squash and merge" are cherry-picked directly against their single commit. PRs merged with "Rebase and merge" are cherry-picked as a range covering all of the rebased commits, so that none of them is silently dropped.
 
 After running the task, you'll have a release branch ready to be merged into the stable branch. You'll want to open a PR from this branch into the stable branch and provided CI is green, you can go ahead, merge the PR and run release tasks as specified below from the updated stable branch.
 

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -268,22 +268,55 @@ class Release
 
     puts "The following unreleased prs were found:\n#{prs.map {|pr| "* #{pr.url}" }.join("\n")}"
 
-    unless system("git", "cherry-pick", "-x", "-m", "1", *prs.map(&:merge_commit_sha))
+    prs.each do |pr|
+      args = cherry_pick_args_for(pr)
+      next if system("git", "cherry-pick", "-x", *args)
+
       warn <<~MSG
 
-        Opening a new shell to fix the cherry-pick errors manually. You can do the following now:
+        Cherry-picking #{pr.url} failed. Opening a new shell to fix the errors manually. You can do the following now:
 
-        * Find the PR that caused the merge conflict.
-        * If you'd like to include that PR in the release, tag it with an appropriate label. Then type `exit 1` and rerun the task so that the PR is cherry-picked before and the conflict is fixed.
-        * If you don't want to include that PR in the release, fix conflicts manually, run `git add . && git cherry-pick --continue` once done, and if it succeeds, run `exit 0` to resume the release preparation.
+        * If you'd like to include that PR in the release, fix conflicts manually, run `git add . && git cherry-pick --continue` once done, and if it succeeds, run `exit 0` to resume the release preparation.
+        * If you don't want to include that PR in the release, run `git cherry-pick --abort` and then `exit 0` to skip it and resume.
+        * To abort the entire release preparation, run `exit 1`.
 
       MSG
 
       unless system(ENV["SHELL"] || "zsh")
-        system("git", "cherry-pick", "--abort", exception: true)
+        system("git", "cherry-pick", "--abort")
         raise "Failed to resolve conflicts, resetting original state"
       end
     end
+  end
+
+  # Builds the `git cherry-pick` arguments for a PR by detecting which merge
+  # strategy GitHub used. PRs merged with "Create a merge commit" are picked
+  # with `-m 1` against the merge commit. PRs merged with "Squash and merge"
+  # produce a single commit, which is picked directly. PRs merged with
+  # "Rebase and merge" produce N linear commits ending at `merge_commit_sha`,
+  # so we cherry-pick the full range to avoid silently dropping commits.
+  def cherry_pick_args_for(pr)
+    sha = pr.merge_commit_sha
+    parents = `git rev-list --parents -n 1 #{sha}`.strip.split.drop(1)
+
+    if parents.size >= 2
+      ["-m", "1", sha]
+    else
+      pr_commits = gh_client.pull_request_commits("ruby/rubygems", pr.number)
+
+      if pr_commits.size > 1 && rebase_merged?(sha, pr_commits)
+        ["#{sha}~#{pr_commits.size}..#{sha}"]
+      else
+        [sha]
+      end
+    end
+  end
+
+  def rebase_merged?(sha, pr_commits)
+    n = pr_commits.size
+    master_subjects = `git log -n #{n} --format=%s #{sha}`.lines.map(&:strip).reverse
+    pr_subjects = pr_commits.map {|c| c.commit.message.lines.first.strip }
+    master_subjects == pr_subjects
   end
 
   def cut_changelogs_and_bump_versions


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The release task assumed every PR was merged with "Create a merge commit" and used `git cherry-pick -m 1 MERGE_COMMIT_SHA`.

So, I couldn't backport https://github.com/ruby/rubygems/pull/5029 because this PR has merge commit.

## What is your fix for the problem, implemented in this PR?

For PRs merged with "Rebase and merge" `merge_commit_sha` is just the tip of the rebased commits, so picking only that one silently drops the preceding commits and typically conflicts.

Inspect the parent count of `merge_commit_sha` and, when it is not a merge commit, fetch the PR commits from GitHub to decide between squash (single commit) and rebase (range of N commits).

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
