### PR TITLE
Switch bundle add to use optimistic versioning by default

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -399,7 +399,8 @@ module Bundler
     method_option "glob", type: :string, banner: "The location of a dependency's .gemspec, expanded within Ruby (single quotes recommended)"
     method_option "quiet", type: :boolean, banner: "Only output warnings and errors."
     method_option "skip-install", type: :boolean, banner: "Adds gem to the Gemfile but does not install it"
-    method_option "optimistic", type: :boolean, banner: "Adds optimistic declaration of version to gem"
+    method_option "optimistic", type: :boolean, banner: "Ignored (now default behavior)"
+    method_option "pessimistic", type: :boolean, banner: "Adds pessimistic declaration of version to gem"
     method_option "strict", type: :boolean, banner: "Adds strict declaration of version to gem"
     def add(*gems)
       require_relative "cli/add"

--- a/bundler/lib/bundler/cli/add.rb
+++ b/bundler/lib/bundler/cli/add.rb
@@ -31,7 +31,7 @@ module Bundler
 
       Injector.inject(dependencies,
         conservative_versioning: options[:version].nil?, # Perform conservative versioning only when version is not specified
-        optimistic: options[:optimistic],
+        pessimistic: options[:pessimistic],
         strict: options[:strict])
     end
 
@@ -46,7 +46,7 @@ module Bundler
 
       raise InvalidOption, "You cannot specify `--branch` and `--ref` at the same time." if options["branch"] && options["ref"]
 
-      raise InvalidOption, "You cannot specify `--strict` and `--optimistic` at the same time." if options[:strict] && options[:optimistic]
+      raise InvalidOption, "You cannot specify `--strict` and `--pessimistic` at the same time." if options[:strict] && options[:pessimistic]
 
       # raise error when no gems are specified
       raise InvalidOption, "Please specify gems to add." if gems.empty?

--- a/bundler/lib/bundler/injector.rb
+++ b/bundler/lib/bundler/injector.rb
@@ -89,10 +89,10 @@ module Bundler
     def version_prefix
       if @options[:strict]
         "= "
-      elsif @options[:optimistic]
-        ">= "
-      else
+      elsif @options[:pessimistic]
         "~> "
+      else
+        ">= "
       end
     end
 

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -46,7 +46,10 @@ Do not print progress information to the standard output\.
 Adds the gem to the Gemfile but does not install it\.
 .TP
 \fB\-\-optimistic\fR
-Adds optimistic declaration of version\.
+Ignored (now default behavior)
+.TP
+\fB\-\-pessimistic\fR
+Adds pessimistic declaration of version\.
 .TP
 \fB\-\-strict\fR
 Adds strict declaration of version\.
@@ -62,7 +65,7 @@ You can add the \fBrails\fR gem with version greater than 1\.1 (not including 1\
 .IP "3." 4
 You can use the \fBhttps://gems\.example\.com\fR custom source and assign the gem to a group\.
 .IP
-\fBbundle add rails \-\-version "~> 5\.0\.0" \-\-source "https://gems\.example\.com" \-\-group "development"\fR
+\fBbundle add rails \-\-version ">= 5\.0\.0" \-\-source "https://gems\.example\.com" \-\-group "development"\fR
 .IP "4." 4
 The following adds the \fBgem\fR entry to the Gemfile without installing the gem\. You can install gems later via \fBbundle install\fR\.
 .IP

--- a/bundler/lib/bundler/man/bundle-add.1.ronn
+++ b/bundler/lib/bundler/man/bundle-add.1.ronn
@@ -51,7 +51,10 @@ Adds the named gem to the [`Gemfile(5)`][Gemfile(5)] and run `bundle install`.
   Adds the gem to the Gemfile but does not install it.
 
 * `--optimistic`:
-  Adds optimistic declaration of version.
+  Ignored (now default behavior)
+
+* `--pessimistic`:
+  Adds pessimistic declaration of version.
 
 * `--strict`:
   Adds strict declaration of version.
@@ -70,7 +73,7 @@ Adds the named gem to the [`Gemfile(5)`][Gemfile(5)] and run `bundle install`.
 3. You can use the `https://gems.example.com` custom source and assign the gem
    to a group.
 
-   `bundle add rails --version "~> 5.0.0" --source "https://gems.example.com" --group "development"`
+   `bundle add rails --version ">= 5.0.0" --source "https://gems.example.com" --group "development"`
 
 4. The following adds the `gem` entry to the Gemfile without installing the
    gem. You can install gems later via `bundle install`.

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -38,34 +38,34 @@ RSpec.describe "bundle add" do
   end
 
   describe "without version specified" do
-    it "version requirement becomes ~> major.minor.patch when resolved version is < 1.0" do
+    it "version requirement becomes >= major.minor.patch when resolved version is < 1.0" do
       bundle "add 'bar'"
-      expect(bundled_app_gemfile.read).to match(/gem "bar", "~> 0.12.3"/)
+      expect(bundled_app_gemfile.read).to match(/gem "bar", ">= 0.12.3"/)
       expect(the_bundle).to include_gems "bar 0.12.3"
     end
 
-    it "version requirement becomes ~> major.minor when resolved version is > 1.0" do
+    it "version requirement becomes >= major.minor when resolved version is > 1.0" do
       bundle "add 'baz'"
-      expect(bundled_app_gemfile.read).to match(/gem "baz", "~> 1.2"/)
+      expect(bundled_app_gemfile.read).to match(/gem "baz", ">= 1.2"/)
       expect(the_bundle).to include_gems "baz 1.2.3"
     end
 
-    it "version requirement becomes ~> major.minor.patch.pre when resolved version is < 1.0" do
+    it "version requirement becomes >= major.minor.patch.pre when resolved version is < 1.0" do
       bundle "add 'cat'"
-      expect(bundled_app_gemfile.read).to match(/gem "cat", "~> 0.12.3.pre"/)
+      expect(bundled_app_gemfile.read).to match(/gem "cat", ">= 0.12.3.pre"/)
       expect(the_bundle).to include_gems "cat 0.12.3.pre"
     end
 
-    it "version requirement becomes ~> major.minor.pre when resolved version is > 1.0.pre" do
+    it "version requirement becomes >= major.minor.pre when resolved version is >= 1.0.pre" do
       bundle "add 'dog'"
-      expect(bundled_app_gemfile.read).to match(/gem "dog", "~> 1.1.pre"/)
+      expect(bundled_app_gemfile.read).to match(/gem "dog", ">= 1.1.pre"/)
       expect(the_bundle).to include_gems "dog 1.1.3.pre"
     end
 
-    it "version requirement becomes ~> major.minor.pre.tail when resolved version has a very long tail pre version" do
+    it "version requirement becomes >= major.minor.pre.tail when resolved version has a very long tail pre version" do
       bundle "add 'lemur'"
       # the trailing pre purposely matches the release version to ensure that subbing the release doesn't change the pre.version"
-      expect(bundled_app_gemfile.read).to match(/gem "lemur", "~> 3.1.pre.2023.1.1"/)
+      expect(bundled_app_gemfile.read).to match(/gem "lemur", ">= 3.1.pre.2023.1.1"/)
       expect(the_bundle).to include_gems "lemur 3.1.1.pre.2023.1.1"
     end
   end
@@ -100,13 +100,13 @@ RSpec.describe "bundle add" do
   describe "with --group" do
     it "adds dependency for the specified group" do
       bundle "add 'foo' --group='development'"
-      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", group: :development/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", ">= 2.0", group: :development/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
 
     it "adds dependency to more than one group" do
       bundle "add 'foo' --group='development, test'"
-      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", groups: \[:development, :test\]/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", ">= 2.0", groups: \[:development, :test\]/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -115,7 +115,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified source" do
       bundle "add 'foo' --source='https://gem.repo2'"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "foo", "~> 2.0", source: "https://gem.repo2"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "foo", ">= 2.0", source: "https://gem.repo2"})
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -124,7 +124,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified path" do
       bundle "add 'foo' --path='#{lib_path("foo-2.0")}'"
 
-      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", path: "#{lib_path("foo-2.0")}"/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", ">= 2.0", path: "#{lib_path("foo-2.0")}"/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -133,7 +133,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified git source" do
       bundle "add foo --git=#{lib_path("foo-2.0")}"
 
-      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", git: "#{lib_path("foo-2.0")}"/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", ">= 2.0", git: "#{lib_path("foo-2.0")}"/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -146,7 +146,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified git source and branch" do
       bundle "add foo --git=#{lib_path("foo-2.0")} --branch=test"
 
-      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2.0", git: "#{lib_path("foo-2.0")}", branch: "test"/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", ">= 2.0", git: "#{lib_path("foo-2.0")}", branch: "test"/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -155,7 +155,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified git source and branch" do
       bundle "add foo --git=#{lib_path("foo-2.0")} --ref=#{revision_for(lib_path("foo-2.0"))}"
 
-      expect(bundled_app_gemfile.read).to match(/gem "foo", "~> 2\.0", git: "#{lib_path("foo-2.0")}", ref: "#{revision_for(lib_path("foo-2.0"))}"/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", ">= 2\.0", git: "#{lib_path("foo-2.0")}", ref: "#{revision_for(lib_path("foo-2.0"))}"/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -169,39 +169,39 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified github source" do
       bundle "add rake --github=ruby/rake"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", github: "ruby\/rake"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", ">= 13\.\d+", github: "ruby\/rake"})
     end
 
     it "adds dependency with specified github source and branch" do
       bundle "add rake --github=ruby/rake --branch=main"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", github: "ruby\/rake", branch: "main"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", ">= 13\.\d+", github: "ruby\/rake", branch: "main"})
     end
 
     it "adds dependency with specified github source and ref" do
       ref = revision_for(lib_path("rake-13.0"))
       bundle "add rake --github=ruby/rake --ref=#{ref}"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", github: "ruby\/rake", ref: "#{ref}"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", ">= 13\.\d+", github: "ruby\/rake", ref: "#{ref}"})
     end
 
     it "adds dependency with specified github source and glob" do
       bundle "add rake --github=ruby/rake --glob='./*.gemspec'"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", github: "ruby\/rake", glob: "\.\/\*\.gemspec"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", ">= 13\.\d+", github: "ruby\/rake", glob: "\.\/\*\.gemspec"})
     end
 
     it "adds dependency with specified github source, branch and glob" do
       bundle "add rake --github=ruby/rake --branch=main --glob='./*.gemspec'"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", github: "ruby\/rake", branch: "main", glob: "\.\/\*\.gemspec"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", ">= 13\.\d+", github: "ruby\/rake", branch: "main", glob: "\.\/\*\.gemspec"})
     end
 
     it "adds dependency with specified github source, ref and glob" do
       ref = revision_for(lib_path("rake-13.0"))
       bundle "add rake --github=ruby/rake --ref=#{ref} --glob='./*.gemspec'"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "rake", "~> 13\.\d+", github: "ruby\/rake", ref: "#{ref}", glob: "\.\/\*\.gemspec"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "rake", ">= 13\.\d+", github: "ruby\/rake", ref: "#{ref}", glob: "\.\/\*\.gemspec"})
     end
   end
 
@@ -209,7 +209,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified git source" do
       bundle "add foo --git=#{lib_path("foo-2.0")} --glob='./*.gemspec'"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "foo", "~> 2.0", git: "#{lib_path("foo-2.0")}", glob: "\./\*\.gemspec"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "foo", ">= 2.0", git: "#{lib_path("foo-2.0")}", glob: "\./\*\.gemspec"})
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -222,7 +222,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified git source and branch" do
       bundle "add foo --git=#{lib_path("foo-2.0")} --branch=test --glob='./*.gemspec'"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "foo", "~> 2.0", git: "#{lib_path("foo-2.0")}", branch: "test", glob: "\./\*\.gemspec"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "foo", ">= 2.0", git: "#{lib_path("foo-2.0")}", branch: "test", glob: "\./\*\.gemspec"})
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -231,7 +231,7 @@ RSpec.describe "bundle add" do
     it "adds dependency with specified git source and branch" do
       bundle "add foo --git=#{lib_path("foo-2.0")} --ref=#{revision_for(lib_path("foo-2.0"))} --glob='./*.gemspec'"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "foo", "~> 2\.0", git: "#{lib_path("foo-2.0")}", ref: "#{revision_for(lib_path("foo-2.0"))}", glob: "\./\*\.gemspec"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "foo", ">= 2\.0", git: "#{lib_path("foo-2.0")}", ref: "#{revision_for(lib_path("foo-2.0"))}", glob: "\./\*\.gemspec"})
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -308,9 +308,17 @@ RSpec.describe "bundle add" do
   end
 
   describe "with --optimistic" do
-    it "adds optimistic version" do
+    it "ignores option" do
       bundle "add 'foo' --optimistic"
       expect(bundled_app_gemfile.read).to include %(gem "foo", ">= 2.0")
+      expect(the_bundle).to include_gems "foo 2.0"
+    end
+  end
+
+  describe "with --pessimistic" do
+    it "adds pessimistic version" do
+      bundle "add 'foo' --pessimistic"
+      expect(bundled_app_gemfile.read).to include %(gem "foo", "~> 2.0")
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -356,18 +364,18 @@ RSpec.describe "bundle add" do
   end
 
   describe "with no option" do
-    it "adds pessimistic version" do
+    it "adds optimistic version" do
       bundle "add 'foo'"
-      expect(bundled_app_gemfile.read).to include %(gem "foo", "~> 2.0")
+      expect(bundled_app_gemfile.read).to include %(gem "foo", ">= 2.0")
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
 
-  describe "with --optimistic and --strict" do
+  describe "with --pessimistic and --strict" do
     it "throws error" do
-      bundle "add 'foo' --strict --optimistic", raise_on_error: false
+      bundle "add 'foo' --strict --pessimistic", raise_on_error: false
 
-      expect(err).to include("You cannot specify `--strict` and `--optimistic` at the same time")
+      expect(err).to include("You cannot specify `--strict` and `--pessimistic` at the same time")
     end
   end
 
@@ -375,8 +383,8 @@ RSpec.describe "bundle add" do
     it "adds multiple gems to gemfile" do
       bundle "add bar baz"
 
-      expect(bundled_app_gemfile.read).to match(/gem "bar", "~> 0.12.3"/)
-      expect(bundled_app_gemfile.read).to match(/gem "baz", "~> 1.2"/)
+      expect(bundled_app_gemfile.read).to match(/gem "bar", ">= 0.12.3"/)
+      expect(bundled_app_gemfile.read).to match(/gem "baz", ">= 1.2"/)
     end
 
     it "throws error if any of the specified gems are present in the gemfile with different version" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Add the recent developer meeting, we discussed switching from using pessimistic versioning by default to using optimistic versioning by default. 

## What is your fix for the problem, implemented in this PR?

This is the a step in that direction. It makes bundle add without a explicit version given to use >= (optimistic) instead of ~> (pessimistic). With this, the bundle add --optimistic option is now ignored, since the behavior is now the default. This adds a --pessimistic option to set a pessimistic version.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
