### PR TITLE
Use Pathname#absolute?

### DIFF
--- a/bundler/lib/bundler/source/path.rb
+++ b/bundler/lib/bundler/source/path.rb
@@ -220,10 +220,11 @@ module Bundler
         # Some gem authors put absolute paths in their gemspec
         # and we have to save them from themselves
         spec.files = spec.files.filter_map do |path|
-          next path unless /\A#{Pathname::SEPARATOR_PAT}/o.match?(path)
+          pathname = Pathname.new(path)
+          next path unless pathname.absolute?
           next if File.directory?(path)
           begin
-            Pathname.new(path).relative_path_from(gem_dir).to_s
+            pathname.relative_path_from(gem_dir).to_s
           rescue ArgumentError
             path
           end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`Pathname::SEPARATOR_PAT` should be private, but was not set to private just due to a typo.
bundler will break by fixing the typo in pathname.

## What is your fix for the problem, implemented in this PR?

Use the public API `Pathname#absolute?` instead.
In any case, since the pathname will be created for `relative_path_from` anyway, I don't think it will cause a significant drop in performance.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
