### PR TITLE
Extend Gemfile `override` DSL with `:all` target and metadata fields (Phase 2)

### DIFF
--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -244,11 +244,6 @@ module Bundler
       Bundler.settings[:deployment]
     end
 
-    def overrides
-      return [] unless defined?(@definition) && @definition
-      @definition.overrides
-    end
-
     def locked_gems
       @locked_gems ||=
         if defined?(@definition) && @definition

--- a/bundler/lib/bundler.rb
+++ b/bundler/lib/bundler.rb
@@ -244,6 +244,11 @@ module Bundler
       Bundler.settings[:deployment]
     end
 
+    def overrides
+      return [] unless defined?(@definition) && @definition
+      @definition.overrides
+    end
+
     def locked_gems
       @locked_gems ||=
         if defined?(@definition) && @definition

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -111,12 +111,12 @@ module Bundler
         @locked_bundler_version = @locked_gems.bundler_version
         @locked_ruby_version = @locked_gems.ruby_version
         @locked_deps = @locked_gems.dependencies
-        @originally_locked_specs = SpecSet.new(@locked_gems.specs)
+        @originally_locked_specs = SpecSet.new(@locked_gems.specs).with_overrides(@overrides)
         @originally_locked_sources = @locked_gems.sources
         @locked_checksums = @locked_gems.checksums
 
         if @unlocking_all
-          @locked_specs   = SpecSet.new([])
+          @locked_specs   = SpecSet.new([]).with_overrides(@overrides)
           @locked_sources = []
         else
           @locked_specs   = @originally_locked_specs
@@ -137,7 +137,7 @@ module Bundler
         @most_specific_locked_platform = nil
         @platforms      = []
         @locked_deps    = {}
-        @locked_specs   = SpecSet.new([])
+        @locked_specs   = SpecSet.new([]).with_overrides(@overrides)
         @locked_sources = []
         @originally_locked_specs = @locked_specs
         @originally_locked_sources = @locked_sources
@@ -506,7 +506,7 @@ module Bundler
     def normalize_platforms
       resolve.normalize_platforms!(current_dependencies, platforms)
 
-      @resolve = SpecSet.new(resolve.for(current_dependencies, @platforms))
+      @resolve = SpecSet.new(resolve.for(current_dependencies, @platforms)).with_overrides(@overrides)
     end
 
     def add_platform(platform)
@@ -762,7 +762,7 @@ module Bundler
       local_platform_needed_for_resolvability = @most_specific_non_local_locked_platform && !@platforms.include?(Bundler.local_platform)
       @platforms << Bundler.local_platform if local_platform_needed_for_resolvability
 
-      result = SpecSet.new(resolver.start)
+      result = SpecSet.new(resolver.start).with_overrides(@overrides)
 
       @resolved_bundler_version = result.find {|spec| spec.name == "bundler" }&.version
 
@@ -788,7 +788,7 @@ module Bundler
         result.add_originally_invalid_platforms!(platforms, @originally_invalid_platforms)
       end
 
-      SpecSet.new(result.for(dependencies, @platforms | [Gem::Platform::RUBY]))
+      SpecSet.new(result.for(dependencies, @platforms | [Gem::Platform::RUBY])).with_overrides(@overrides)
     end
 
     def precompute_source_requirements_for_indirect_dependencies?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1061,11 +1061,10 @@ module Bundler
 
     def converge_overrides_outside_dependencies
       @overrides.each do |override|
-        if override.target == :all
-          unlock_all_locked_specs_for_override
-          next
-        end
-
+        # :all overrides are intentionally not pre-unlocked. They take effect on
+        # fresh resolution (no lockfile) or when the user runs `bundle update`.
+        # Forcing a full re-resolve from a single :all directive would surprise
+        # users with unrelated dependency churn.
         next unless override.target.is_a?(String)
 
         name = override.target
@@ -1076,15 +1075,6 @@ module Bundler
         # Other fields are not visible there, so they always reach here.
         next if override.field == :version && @dependencies.any? {|d| d.name == name }
 
-        @gems_to_unlock << name
-        @changed_dependencies << name
-      end
-    end
-
-    def unlock_all_locked_specs_for_override
-      @originally_locked_specs.each do |locked_spec|
-        name = locked_spec.name
-        next if @changed_dependencies.include?(name)
         @gems_to_unlock << name
         @changed_dependencies << name
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -111,12 +111,13 @@ module Bundler
         @locked_bundler_version = @locked_gems.bundler_version
         @locked_ruby_version = @locked_gems.ruby_version
         @locked_deps = @locked_gems.dependencies
-        @originally_locked_specs = SpecSet.new(@locked_gems.specs).with_overrides(@overrides)
+        Override.attach(@locked_gems.specs, @overrides)
+        @originally_locked_specs = SpecSet.new(@locked_gems.specs)
         @originally_locked_sources = @locked_gems.sources
         @locked_checksums = @locked_gems.checksums
 
         if @unlocking_all
-          @locked_specs   = SpecSet.new([]).with_overrides(@overrides)
+          @locked_specs   = SpecSet.new([])
           @locked_sources = []
         else
           @locked_specs   = @originally_locked_specs
@@ -137,7 +138,7 @@ module Bundler
         @most_specific_locked_platform = nil
         @platforms      = []
         @locked_deps    = {}
-        @locked_specs   = SpecSet.new([]).with_overrides(@overrides)
+        @locked_specs   = SpecSet.new([])
         @locked_sources = []
         @originally_locked_specs = @locked_specs
         @originally_locked_sources = @locked_sources
@@ -338,11 +339,11 @@ module Bundler
       elsif no_resolve_needed?
         if deleted_deps.any?
           Bundler.ui.debug "Some dependencies were deleted, using a subset of the resolution from the lockfile"
-          SpecSet.new(filter_specs(@locked_specs, @dependencies - deleted_deps)).with_overrides(@overrides)
+          SpecSet.new(filter_specs(@locked_specs, @dependencies - deleted_deps))
         else
           Bundler.ui.debug "Found no changes, using resolution from the lockfile"
           if @removed_platforms.any? || @locked_gems.may_include_redundant_platform_specific_gems?
-            SpecSet.new(filter_specs(@locked_specs, @dependencies)).with_overrides(@overrides)
+            SpecSet.new(filter_specs(@locked_specs, @dependencies))
           else
             @locked_specs
           end
@@ -506,7 +507,7 @@ module Bundler
     def normalize_platforms
       resolve.normalize_platforms!(current_dependencies, platforms)
 
-      @resolve = SpecSet.new(resolve.for(current_dependencies, @platforms)).with_overrides(@overrides)
+      @resolve = SpecSet.new(resolve.for(current_dependencies, @platforms))
     end
 
     def add_platform(platform)
@@ -762,7 +763,7 @@ module Bundler
       local_platform_needed_for_resolvability = @most_specific_non_local_locked_platform && !@platforms.include?(Bundler.local_platform)
       @platforms << Bundler.local_platform if local_platform_needed_for_resolvability
 
-      result = SpecSet.new(resolver.start).with_overrides(@overrides)
+      result = SpecSet.new(resolver.start)
 
       @resolved_bundler_version = result.find {|spec| spec.name == "bundler" }&.version
 
@@ -788,7 +789,7 @@ module Bundler
         result.add_originally_invalid_platforms!(platforms, @originally_invalid_platforms)
       end
 
-      SpecSet.new(result.for(dependencies, @platforms | [Gem::Platform::RUBY])).with_overrides(@overrides)
+      SpecSet.new(result.for(dependencies, @platforms | [Gem::Platform::RUBY]))
     end
 
     def precompute_source_requirements_for_indirect_dependencies?

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -644,7 +644,7 @@ module Bundler
     end
 
     def apply_override_to(dep)
-      override = @overrides.find {|o| o.target == dep.name && o.field == :version }
+      override = Override.find_for(@overrides, dep.name, :version)
       return dep unless override
       new_dep = dep.dup
       new_dep.instance_variable_set(:@requirement, override.apply_to(dep.requirement))

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -338,11 +338,11 @@ module Bundler
       elsif no_resolve_needed?
         if deleted_deps.any?
           Bundler.ui.debug "Some dependencies were deleted, using a subset of the resolution from the lockfile"
-          SpecSet.new(filter_specs(@locked_specs, @dependencies - deleted_deps))
+          SpecSet.new(filter_specs(@locked_specs, @dependencies - deleted_deps)).with_overrides(@overrides)
         else
           Bundler.ui.debug "Found no changes, using resolution from the lockfile"
           if @removed_platforms.any? || @locked_gems.may_include_redundant_platform_specific_gems?
-            SpecSet.new(filter_specs(@locked_specs, @dependencies))
+            SpecSet.new(filter_specs(@locked_specs, @dependencies)).with_overrides(@overrides)
           else
             @locked_specs
           end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1061,6 +1061,11 @@ module Bundler
 
     def converge_overrides_outside_dependencies
       @overrides.each do |override|
+        if override.target == :all
+          unlock_all_locked_specs_for_override
+          next
+        end
+
         next unless override.target.is_a?(String)
 
         name = override.target
@@ -1071,6 +1076,15 @@ module Bundler
         # Other fields are not visible there, so they always reach here.
         next if override.field == :version && @dependencies.any? {|d| d.name == name }
 
+        @gems_to_unlock << name
+        @changed_dependencies << name
+      end
+    end
+
+    def unlock_all_locked_specs_for_override
+      @originally_locked_specs.each do |locked_spec|
+        name = locked_spec.name
+        next if @changed_dependencies.include?(name)
         @gems_to_unlock << name
         @changed_dependencies << name
       end

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1065,8 +1065,11 @@ module Bundler
 
         name = override.target
         next if @changed_dependencies.include?(name)
-        next if @dependencies.any? {|d| d.name == name }
         next if @originally_locked_specs[name].empty?
+        # version: overrides on direct deps are detected in the per-dep
+        # converge_dependencies loop via apply_override_to + matches_spec?.
+        # Other fields are not visible there, so they always reach here.
+        next if override.field == :version && @dependencies.any? {|d| d.name == name }
 
         @gems_to_unlock << name
         @changed_dependencies << name

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -201,8 +201,9 @@ module Bundler
         validate_override_uniqueness!(target, field)
       end
 
+      source_location = caller_locations(1, 1)&.first
       operations.each do |field, operation|
-        @overrides << Override.new(target, field, operation)
+        @overrides << Override.new(target, field, operation, source_location: source_location)
       end
     end
 

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -185,7 +185,7 @@ module Bundler
       with_source(git_source) { yield }
     end
 
-    SUPPORTED_OVERRIDE_FIELDS = [:version].freeze
+    SUPPORTED_OVERRIDE_FIELDS = [:version, :required_ruby_version, :required_rubygems_version].freeze
     SUPPORTED_OVERRIDE_SYMBOL_OPERATIONS = [:ignore_upper].freeze
 
     def override(target, **operations)
@@ -193,6 +193,10 @@ module Bundler
 
       if target == :all && operations.key?(:version)
         raise ArgumentError, "`override :all, version:` is not allowed; version requirements are per-gem"
+      end
+
+      if target == :all && operations.any?
+        raise ArgumentError, "`override :all` is not yet supported"
       end
 
       operations.each do |field, operation|
@@ -274,7 +278,8 @@ module Bundler
 
     def validate_override_field!(field)
       return if SUPPORTED_OVERRIDE_FIELDS.include?(field)
-      raise ArgumentError, "unsupported override field `#{field}:`; only `version:` is currently supported"
+      supported = SUPPORTED_OVERRIDE_FIELDS.map {|f| "`#{f}:`" }.join(", ")
+      raise ArgumentError, "unsupported override field `#{field}:`; supported fields: #{supported}"
     end
 
     def validate_override_operation!(operation)

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -279,7 +279,9 @@ module Bundler
 
     def validate_override_operation!(operation)
       case operation
-      when String, nil
+      when String
+        Gem::Requirement.new(operation)
+      when nil
         # ok
       when Symbol
         return if SUPPORTED_OVERRIDE_SYMBOL_OPERATIONS.include?(operation)
@@ -287,6 +289,8 @@ module Bundler
       else
         raise ArgumentError, "override operation must be a String, Symbol, or nil, got #{operation.inspect}"
       end
+    rescue Gem::Requirement::BadRequirementError => e
+      raise ArgumentError, "invalid override version requirement #{operation.inspect}: #{e.message}"
     end
 
     def validate_override_uniqueness!(target, field)

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -195,10 +195,6 @@ module Bundler
         raise ArgumentError, "`override :all, version:` is not allowed; version requirements are per-gem"
       end
 
-      if target == :all && operations.any?
-        raise ArgumentError, "`override :all` is not yet supported"
-      end
-
       operations.each do |field, operation|
         validate_override_field!(field)
         validate_override_operation!(operation)

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -211,12 +211,13 @@ module Bundler
     end
 
     def ensure_specs_are_compatible!
+      overrides = @definition.overrides
       @definition.specs.each do |spec|
-        unless spec.matches_current_ruby?
+        unless spec.matches_current_ruby_with_overrides?(overrides)
           raise InstallError, "#{spec.full_name} requires ruby version #{spec.required_ruby_version}, " \
             "which is incompatible with the current version, #{Gem.ruby_version}"
         end
-        unless spec.matches_current_rubygems?
+        unless spec.matches_current_rubygems_with_overrides?(overrides)
           raise InstallError, "#{spec.full_name} requires rubygems version #{spec.required_rubygems_version}, " \
             "which is incompatible with the current version, #{Gem.rubygems_version}"
         end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -30,6 +30,7 @@ module Bundler
       lazy_spec.dependencies = s.runtime_dependencies
       lazy_spec.required_ruby_version = s.required_ruby_version
       lazy_spec.required_rubygems_version = s.required_rubygems_version
+      lazy_spec.overrides = s.overrides if s.is_a?(LazySpecification)
       lazy_spec
     end
 

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -9,7 +9,7 @@ module Bundler
     include ForcePlatform
 
     attr_reader :name, :version, :platform, :materialization
-    attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version
+    attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version, :overrides
 
     #
     # For backwards compatibility with existing lockfiles, if the most specific
@@ -234,8 +234,9 @@ module Bundler
     # about the mismatch higher up the stack, right before trying to install the
     # bad gem.
     def choose_compatible(candidates, fallback_to_non_installable: Bundler.frozen_bundle?)
+      override_list = overrides || []
       search = candidates.reverse.find do |spec|
-        spec.is_a?(StubSpecification) || spec.matches_current_metadata?
+        spec.is_a?(StubSpecification) || spec.matches_current_metadata_with_overrides?(override_list)
       end
       if search.nil? && fallback_to_non_installable
         search = candidates.last

--- a/bundler/lib/bundler/man/gemfile.5
+++ b/bundler/lib/bundler/man/gemfile.5
@@ -461,21 +461,23 @@ The \fBgemspec\fR method supports optional \fB:path\fR, \fB:glob\fR, \fB:name\fR
 .P
 When a \fBgemspec\fR dependency encounters version conflicts during resolution, the local version under development will always be selected \-\- even if there are remote versions that better match other requirements for the \fBgemspec\fR gem\.
 .SH "OVERRIDE"
-The \fBoverride\fR directive rewrites the version requirement on another gem before resolution runs\. It targets the common case where an upstream gem's published metadata is too narrow on the current project's machine \-\- a stale upper bound, an unwanted floor, or a transitive pin that has to be lifted\.
+The \fBoverride\fR directive rewrites a constraint on another gem before resolution runs\. It targets the common case where an upstream gem's published metadata is too narrow on the current project's machine \-\- a stale upper bound, an unwanted floor, or a transitive pin that has to be lifted\.
 .IP "" 4
 .nf
 override <target>, <field>: <operation>
 .fi
 .IP "" 0
 .P
-\fB<target>\fR is a gem name string\. \fB<field>\fR is \fBversion:\fR\. \fB<operation>\fR is one of:
+\fB<target>\fR is a gem name string or \fB:all\fR\. \fB<field>\fR is one of \fBversion:\fR, \fBrequired_ruby_version:\fR, or \fBrequired_rubygems_version:\fR\. \fB<operation>\fR is one of:
 .IP "\(bu" 4
-a version requirement string (e\.g\. \fB">= 8\.0"\fR), which \fBreplaces\fR the target's version requirement absolutely\. The original requirement, both direct and transitive, is discarded in favour of the override\.
+a version requirement string (e\.g\. \fB">= 8\.0"\fR), which \fBreplaces\fR the target's requirement absolutely\. The original requirement, both direct and transitive, is discarded in favour of the override\.
 .IP "\(bu" 4
 \fB:ignore_upper\fR, which removes upper\-bound operators (\fB<\fR and \fB<=\fR) from the existing requirement and folds \fB~>\fR into its lower bound (\fB~> 1\.5\fR becomes \fB>= 1\.5\fR)\. Other operators, including \fB!=\fR, are preserved\.
 .IP "\(bu" 4
 \fBnil\fR, which collapses the requirement to \fB>= 0\fR (no constraint at all)\.
 .IP "" 0
+.P
+\fB:all\fR only applies to \fBrequired_ruby_version:\fR and \fBrequired_rubygems_version:\fR\. A per\-gem override on the same field takes precedence over an \fB:all\fR override\. \fB:all + version:\fR is rejected: version requirements only make sense per gem\.
 .P
 Multiple \fBoverride\fR calls for distinct targets are allowed; declaring the same \fBtarget\fR and \fBfield\fR twice is an error\.
 .IP "" 4
@@ -491,11 +493,17 @@ override "nokogiri", version: :ignore_upper
 # Drop the version pin on legacy entirely\.
 override "legacy", version: nil
 
+# Loosen every gem's required_ruby_version upper bound\.
+override :all, required_ruby_version: :ignore_upper
+
+# Override one specific gem's required_rubygems_version\.
+override "tricky", required_rubygems_version: nil
+
 gem "rails", "~> 7\.0"
 .fi
 .IP "" 0
 .P
-The override only affects resolution; \fBGemfile\.lock\fR continues to reflect the resolved versions, not the rewritten requirements\.
+The override only affects resolution and the install\-time Ruby/RubyGems compatibility checks; \fBGemfile\.lock\fR continues to reflect the resolved versions, not the rewritten requirements\. When resolution still fails, Bundler appends the active overrides (with their Gemfile location) to the error message so it is clear which override shaped the constraint set\.
 .SH "SOURCE PRIORITY"
 When attempting to locate a gem to satisfy a gem requirement, bundler uses the following priority order:
 .IP "1." 4

--- a/bundler/lib/bundler/man/gemfile.5.ronn
+++ b/bundler/lib/bundler/man/gemfile.5.ronn
@@ -543,23 +543,28 @@ remote versions that better match other requirements for the `gemspec` gem.
 
 ## OVERRIDE
 
-The `override` directive rewrites the version requirement on another gem
-before resolution runs. It targets the common case where an upstream gem's
+The `override` directive rewrites a constraint on another gem before
+resolution runs. It targets the common case where an upstream gem's
 published metadata is too narrow on the current project's machine -- a stale
 upper bound, an unwanted floor, or a transitive pin that has to be lifted.
 
     override <target>, <field>: <operation>
 
-`<target>` is a gem name string. `<field>` is `version:`. `<operation>` is
+`<target>` is a gem name string or `:all`. `<field>` is one of `version:`,
+`required_ruby_version:`, or `required_rubygems_version:`. `<operation>` is
 one of:
 
   * a version requirement string (e.g. `">= 8.0"`), which **replaces** the
-    target's version requirement absolutely. The original requirement, both
-    direct and transitive, is discarded in favour of the override.
+    target's requirement absolutely. The original requirement, both direct
+    and transitive, is discarded in favour of the override.
   * `:ignore_upper`, which removes upper-bound operators (`<` and `<=`) from
     the existing requirement and folds `~>` into its lower bound (`~> 1.5`
     becomes `>= 1.5`). Other operators, including `!=`, are preserved.
   * `nil`, which collapses the requirement to `>= 0` (no constraint at all).
+
+`:all` only applies to `required_ruby_version:` and `required_rubygems_version:`.
+A per-gem override on the same field takes precedence over an `:all` override.
+`:all + version:` is rejected: version requirements only make sense per gem.
 
 Multiple `override` calls for distinct targets are allowed; declaring the
 same `target` and `field` twice is an error.
@@ -575,10 +580,19 @@ same `target` and `field` twice is an error.
     # Drop the version pin on legacy entirely.
     override "legacy", version: nil
 
+    # Loosen every gem's required_ruby_version upper bound.
+    override :all, required_ruby_version: :ignore_upper
+
+    # Override one specific gem's required_rubygems_version.
+    override "tricky", required_rubygems_version: nil
+
     gem "rails", "~> 7.0"
 
-The override only affects resolution; `Gemfile.lock` continues to reflect
-the resolved versions, not the rewritten requirements.
+The override only affects resolution and the install-time Ruby/RubyGems
+compatibility checks; `Gemfile.lock` continues to reflect the resolved
+versions, not the rewritten requirements. When resolution still fails,
+Bundler appends the active overrides (with their Gemfile location) to the
+error message so it is clear which override shaped the constraint set.
 
 ## SOURCE PRIORITY
 

--- a/bundler/lib/bundler/match_metadata.rb
+++ b/bundler/lib/bundler/match_metadata.rb
@@ -7,11 +7,11 @@ module Bundler
     end
 
     def matches_current_ruby?
-      @required_ruby_version.satisfied_by?(Gem.ruby_version)
+      effective_required_ruby_version.satisfied_by?(Gem.ruby_version)
     end
 
     def matches_current_rubygems?
-      @required_rubygems_version.satisfied_by?(Gem.rubygems_version)
+      effective_required_rubygems_version.satisfied_by?(Gem.rubygems_version)
     end
 
     def expanded_dependencies
@@ -25,6 +25,22 @@ module Bundler
       return if requirement.nil? || requirement.none?
 
       Gem::Dependency.new("#{name}\0", requirement)
+    end
+
+    private
+
+    def effective_required_ruby_version
+      apply_metadata_override(@required_ruby_version, :required_ruby_version)
+    end
+
+    def effective_required_rubygems_version
+      apply_metadata_override(@required_rubygems_version, :required_rubygems_version)
+    end
+
+    def apply_metadata_override(requirement, field)
+      override = Override.find_for(Bundler.overrides, name, field)
+      return requirement unless override
+      override.apply_to(requirement)
     end
   end
 end

--- a/bundler/lib/bundler/match_metadata.rb
+++ b/bundler/lib/bundler/match_metadata.rb
@@ -7,11 +7,23 @@ module Bundler
     end
 
     def matches_current_ruby?
-      effective_required_ruby_version.satisfied_by?(Gem.ruby_version)
+      @required_ruby_version.satisfied_by?(Gem.ruby_version)
     end
 
     def matches_current_rubygems?
-      effective_required_rubygems_version.satisfied_by?(Gem.rubygems_version)
+      @required_rubygems_version.satisfied_by?(Gem.rubygems_version)
+    end
+
+    def matches_current_metadata_with_overrides?(overrides)
+      matches_current_ruby_with_overrides?(overrides) && matches_current_rubygems_with_overrides?(overrides)
+    end
+
+    def matches_current_ruby_with_overrides?(overrides)
+      effective_required_version(@required_ruby_version, :required_ruby_version, overrides).satisfied_by?(Gem.ruby_version)
+    end
+
+    def matches_current_rubygems_with_overrides?(overrides)
+      effective_required_version(@required_rubygems_version, :required_rubygems_version, overrides).satisfied_by?(Gem.rubygems_version)
     end
 
     def expanded_dependencies
@@ -29,18 +41,10 @@ module Bundler
 
     private
 
-    def effective_required_ruby_version
-      apply_metadata_override(@required_ruby_version, :required_ruby_version)
-    end
-
-    def effective_required_rubygems_version
-      apply_metadata_override(@required_rubygems_version, :required_rubygems_version)
-    end
-
-    def apply_metadata_override(requirement, field)
-      override = Override.find_for(Bundler.overrides, name, field)
-      return requirement unless override
-      override.apply_to(requirement)
+    def effective_required_version(requirement, field, overrides)
+      return requirement if overrides.nil? || overrides.empty?
+      override = Override.find_for(overrides, name, field)
+      override ? override.apply_to(requirement) : requirement
     end
   end
 end

--- a/bundler/lib/bundler/match_remote_metadata.rb
+++ b/bundler/lib/bundler/match_remote_metadata.rb
@@ -6,18 +6,33 @@ module Bundler
     # API didn't include that field, so some marshalled specs in the index have it
     # set to +nil+.
     def matches_current_ruby?
-      @required_ruby_version ||= _remote_specification.required_ruby_version || Gem::Requirement.default
-
+      ensure_required_ruby_version_loaded
       super
     end
 
     def matches_current_rubygems?
-      # A fallback is included because the original version of the specification
-      # API didn't include that field, so some marshalled specs in the index have it
-      # set to +nil+.
-      @required_rubygems_version ||= _remote_specification.required_rubygems_version || Gem::Requirement.default
-
+      ensure_required_rubygems_version_loaded
       super
+    end
+
+    def matches_current_ruby_with_overrides?(overrides)
+      ensure_required_ruby_version_loaded
+      super
+    end
+
+    def matches_current_rubygems_with_overrides?(overrides)
+      ensure_required_rubygems_version_loaded
+      super
+    end
+
+    private
+
+    def ensure_required_ruby_version_loaded
+      @required_ruby_version ||= _remote_specification.required_ruby_version || Gem::Requirement.default # rubocop:disable Naming/MemoizedInstanceVariableName
+    end
+
+    def ensure_required_rubygems_version_loaded
+      @required_rubygems_version ||= _remote_specification.required_rubygems_version || Gem::Requirement.default # rubocop:disable Naming/MemoizedInstanceVariableName
     end
   end
 

--- a/bundler/lib/bundler/override.rb
+++ b/bundler/lib/bundler/override.rb
@@ -9,6 +9,16 @@ module Bundler
         overrides.find {|o| o.target == :all && o.field == field }
     end
 
+    # Attach the given overrides onto every LazySpecification in `specs` so
+    # downstream consumers (LazySpecification#choose_compatible, the install-
+    # time compatibility check, etc.) can read the override list off the spec
+    # itself. Non-LazySpec entries (StubSpecification, Gem::Specification, ...)
+    # are left untouched.
+    def self.attach(specs, overrides)
+      return if overrides.nil? || overrides.empty?
+      specs.each {|s| s.overrides = overrides if s.is_a?(LazySpecification) }
+    end
+
     attr_reader :target, :field, :operation, :source_location
 
     def initialize(target, field, operation, source_location: nil)

--- a/bundler/lib/bundler/override.rb
+++ b/bundler/lib/bundler/override.rb
@@ -4,6 +4,10 @@ module Bundler
   class Override
     UPPER_BOUND_OPERATORS = ["<", "<="].freeze
 
+    def self.find_for(overrides, name, field)
+      overrides.find {|o| o.target == name && o.field == field }
+    end
+
     attr_reader :target, :field, :operation
 
     def initialize(target, field, operation)

--- a/bundler/lib/bundler/override.rb
+++ b/bundler/lib/bundler/override.rb
@@ -9,12 +9,18 @@ module Bundler
         overrides.find {|o| o.target == :all && o.field == field }
     end
 
-    attr_reader :target, :field, :operation
+    attr_reader :target, :field, :operation, :source_location
 
-    def initialize(target, field, operation)
+    def initialize(target, field, operation, source_location: nil)
       @target = target
       @field = field
       @operation = operation
+      @source_location = source_location
+    end
+
+    def source_location_label
+      return nil unless @source_location
+      "#{File.basename(@source_location.path)}:#{@source_location.lineno}"
     end
 
     def apply_to(requirement)

--- a/bundler/lib/bundler/override.rb
+++ b/bundler/lib/bundler/override.rb
@@ -5,7 +5,8 @@ module Bundler
     UPPER_BOUND_OPERATORS = ["<", "<="].freeze
 
     def self.find_for(overrides, name, field)
-      overrides.find {|o| o.target == name && o.field == field }
+      overrides.find {|o| o.target == name && o.field == field } ||
+        overrides.find {|o| o.target == :all && o.field == field }
     end
 
     attr_reader :target, :field, :operation

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -530,7 +530,7 @@ module Bundler
       return dependencies if @base.overrides.empty?
 
       dependencies.map do |dep|
-        override = @base.overrides.find {|o| o.target == dep.name && o.field == :version }
+        override = Override.find_for(@base.overrides, dep.name, :version)
         next dep unless override
         Gem::Dependency.new(dep.name, override.apply_to(dep.requirement))
       end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -82,6 +82,7 @@ module Bundler
       solver = PubGrub::VersionSolver.new(source: self, root: root, strategy: Strategy.new(self), logger: logger)
       result = solver.solve
       resolved_specs = result.flat_map {|package, version| version.to_specs(package, @most_specific_locked_platform) }
+      Override.attach(resolved_specs, @base.overrides)
       SpecSet.new(resolved_specs).specs_with_additional_variants_from(@base.locked_specs)
     rescue PubGrub::SolveFailure => e
       incompatibility = e.incompatibility

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -64,7 +64,9 @@ module Bundler
 
       @cached_dependencies = Hash.new do |dependencies, package|
         dependencies[package] = Hash.new do |versions, version|
-          versions[version] = to_dependency_hash(version.dependencies.reject {|d| d.name == package.name }, @packages)
+          deps = version.dependencies.reject {|d| d.name == package.name }
+          deps = apply_metadata_overrides(deps, package.name)
+          versions[version] = to_dependency_hash(deps, @packages)
         end
       end
 
@@ -531,6 +533,23 @@ module Bundler
 
       dependencies.map do |dep|
         override = Override.find_for(@base.overrides, dep.name, :version)
+        next dep unless override
+        Gem::Dependency.new(dep.name, override.apply_to(dep.requirement))
+      end
+    end
+
+    METADATA_DEP_FIELD = {
+      "Ruby\0" => :required_ruby_version,
+      "RubyGems\0" => :required_rubygems_version,
+    }.freeze
+
+    def apply_metadata_overrides(dependencies, name)
+      return dependencies if @base.overrides.empty?
+
+      dependencies.map do |dep|
+        field = METADATA_DEP_FIELD[dep.name]
+        next dep unless field
+        override = Override.find_for(@base.overrides, name, field)
         next dep unless override
         Gem::Dependency.new(dep.name, override.apply_to(dep.requirement))
       end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -122,7 +122,23 @@ module Bundler
         explanation << extended_explanation
       end
 
+      override_summary = override_diagnostic_summary
+      explanation << override_summary if override_summary
+
       raise SolveFailure.new(explanation)
+    end
+
+    def override_diagnostic_summary
+      return nil if @base.overrides.empty?
+
+      lines = ["Bundler applied the following overrides while resolving:"]
+      @base.overrides.each do |override|
+        target = override.target == :all ? ":all" : override.target.inspect
+        location = override.source_location_label
+        lines << "  override #{target}, #{override.field}: #{override.operation.inspect}" \
+          "#{location ? " (declared at #{location})" : ""}"
+      end
+      "\n\n#{lines.join("\n")}"
     end
 
     def find_names_to_relax(incompatibility)

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -16,7 +16,11 @@ module Bundler
 
     def with_overrides(overrides)
       @overrides = overrides || []
-      @specs.each {|s| s.overrides = @overrides if s.respond_to?(:overrides=) }
+      # Only LazySpecification carries an overrides accessor. Avoid
+      # respond_to?(:overrides=) here because RemoteSpecification#respond_to?
+      # forwards to _remote_specification, which would force-load the
+      # backing gemspec to answer the question.
+      @specs.each {|s| s.overrides = @overrides if s.is_a?(LazySpecification) }
       self
     end
 

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -7,21 +7,8 @@ module Bundler
     include Enumerable
     include TSort
 
-    attr_accessor :overrides
-
     def initialize(specs)
       @specs = specs
-      @overrides = []
-    end
-
-    def with_overrides(overrides)
-      @overrides = overrides || []
-      # Only LazySpecification carries an overrides accessor. Avoid
-      # respond_to?(:overrides=) here because RemoteSpecification#respond_to?
-      # forwards to _remote_specification, which would force-load the
-      # backing gemspec to answer the question.
-      @specs.each {|s| s.overrides = @overrides if s.is_a?(LazySpecification) }
-      self
     end
 
     def for(dependencies, platforms = [nil], legacy_platforms = [nil], skips: [])
@@ -138,7 +125,7 @@ module Bundler
     def materialize(deps)
       materialize_dependencies(deps)
 
-      SpecSet.new(materialized_specs).with_overrides(@overrides)
+      SpecSet.new(materialized_specs)
     end
 
     # Materialize for all the specs in the spec set, regardless of what platform they're for
@@ -159,7 +146,7 @@ module Bundler
     def incomplete_specs_for_platform(deps, platform)
       return [] if @specs.empty?
 
-      validation_set = self.class.new(@specs).with_overrides(@overrides)
+      validation_set = self.class.new(@specs)
       validation_set.for(deps, [platform])
       validation_set.incomplete_specs
     end
@@ -242,7 +229,7 @@ module Bundler
     end
 
     def valid?(s)
-      s.matches_current_metadata_with_overrides?(@overrides) && valid_dependencies?(s)
+      s.matches_current_metadata? && valid_dependencies?(s)
     end
 
     def to_s

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -155,7 +155,7 @@ module Bundler
     def incomplete_specs_for_platform(deps, platform)
       return [] if @specs.empty?
 
-      validation_set = self.class.new(@specs)
+      validation_set = self.class.new(@specs).with_overrides(@overrides)
       validation_set.for(deps, [platform])
       validation_set.incomplete_specs
     end

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -7,8 +7,17 @@ module Bundler
     include Enumerable
     include TSort
 
+    attr_accessor :overrides
+
     def initialize(specs)
       @specs = specs
+      @overrides = []
+    end
+
+    def with_overrides(overrides)
+      @overrides = overrides || []
+      @specs.each {|s| s.overrides = @overrides if s.respond_to?(:overrides=) }
+      self
     end
 
     def for(dependencies, platforms = [nil], legacy_platforms = [nil], skips: [])
@@ -125,7 +134,7 @@ module Bundler
     def materialize(deps)
       materialize_dependencies(deps)
 
-      SpecSet.new(materialized_specs)
+      SpecSet.new(materialized_specs).with_overrides(@overrides)
     end
 
     # Materialize for all the specs in the spec set, regardless of what platform they're for
@@ -229,7 +238,7 @@ module Bundler
     end
 
     def valid?(s)
-      s.matches_current_metadata? && valid_dependencies?(s)
+      s.matches_current_metadata_with_overrides?(@overrides) && valid_dependencies?(s)
     end
 
     def to_s

--- a/bundler/lib/bundler/spec_set.rb
+++ b/bundler/lib/bundler/spec_set.rb
@@ -274,13 +274,25 @@ module Bundler
 
       valid_platform = lookup.all? do |_, specs|
         spec = specs.first
+        # The matching candidates returned by source.specs.search are remote
+        # specs that do not carry the override list themselves. Borrow it from
+        # the LazySpec we are validating so platform-variant validation honors
+        # the same overrides the install/resolve path already applies.
+        overrides = spec.is_a?(LazySpecification) ? Array(spec.overrides) : []
         matching_specs = spec.source.specs.search([spec.name, spec.version])
         platform_spec = MatchPlatform.select_best_platform_match(matching_specs, platform).find do |s|
-          valid?(s)
+          s.matches_current_metadata_with_overrides?(overrides) && valid_dependencies?(s)
         end
 
         if platform_spec
-          new_specs << LazySpecification.from_spec(platform_spec) unless specs.include?(platform_spec)
+          unless specs.include?(platform_spec)
+            new_lazy = LazySpecification.from_spec(platform_spec)
+            # Carry the overrides forward so a follow-up complete_platform
+            # call that picks this synthesized variant as its exemplar still
+            # honors the user's override list.
+            new_lazy.overrides = overrides if overrides.any?
+            new_specs << new_lazy
+          end
           true
         else
           false

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -441,6 +441,19 @@ RSpec.describe Bundler::Dsl do
       end.to raise_error(ArgumentError, /unsupported override operation/)
     end
 
+    it "raises ArgumentError for an unparsable version string" do
+      expect do
+        subject.override("rails", version: "not a version")
+      end.to raise_error(ArgumentError, /invalid override version requirement/)
+    end
+
+    it "does not record an override when the version string is invalid" do
+      expect do
+        subject.override("rails", version: "not a version")
+      end.to raise_error(ArgumentError)
+      expect(subject.overrides).to eq([])
+    end
+
     it "rejects atomically when one field in a multi-field call is invalid" do
       expect do
         subject.override("rails", version: ">= 8.0", required_ruby_version: :ignore_upper)

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -444,10 +444,19 @@ RSpec.describe Bundler::Dsl do
       expect(override.operation).to be_nil
     end
 
-    it "raises ArgumentError for `override :all, required_ruby_version:` until :all is implemented" do
-      expect do
-        subject.override(:all, required_ruby_version: :ignore_upper)
-      end.to raise_error(ArgumentError, /`override :all` is not yet supported/)
+    it "stores an Override targeting :all with a metadata field" do
+      subject.override(:all, required_ruby_version: :ignore_upper)
+      override = subject.overrides.first
+      expect(override.target).to eq(:all)
+      expect(override.field).to eq(:required_ruby_version)
+      expect(override.operation).to eq(:ignore_upper)
+    end
+
+    it "stores an Override targeting :all with required_rubygems_version" do
+      subject.override(:all, required_rubygems_version: nil)
+      override = subject.overrides.first
+      expect(override.target).to eq(:all)
+      expect(override.field).to eq(:required_rubygems_version)
     end
 
     it "raises ArgumentError for a non-string, non-symbol, non-nil operation" do

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -425,8 +425,29 @@ RSpec.describe Bundler::Dsl do
 
     it "raises ArgumentError for an unsupported field" do
       expect do
-        subject.override("rails", required_ruby_version: :ignore_upper)
-      end.to raise_error(ArgumentError, /unsupported override field `required_ruby_version:`/)
+        subject.override("rails", as: "y")
+      end.to raise_error(ArgumentError, /unsupported override field `as:`/)
+    end
+
+    it "stores an Override for a gem with a required_ruby_version: operation" do
+      subject.override("rails", required_ruby_version: :ignore_upper)
+      override = subject.overrides.first
+      expect(override.target).to eq("rails")
+      expect(override.field).to eq(:required_ruby_version)
+      expect(override.operation).to eq(:ignore_upper)
+    end
+
+    it "stores an Override for a gem with a required_rubygems_version: operation" do
+      subject.override("rails", required_rubygems_version: nil)
+      override = subject.overrides.first
+      expect(override.field).to eq(:required_rubygems_version)
+      expect(override.operation).to be_nil
+    end
+
+    it "raises ArgumentError for `override :all, required_ruby_version:` until :all is implemented" do
+      expect do
+        subject.override(:all, required_ruby_version: :ignore_upper)
+      end.to raise_error(ArgumentError, /`override :all` is not yet supported/)
     end
 
     it "raises ArgumentError for a non-string, non-symbol, non-nil operation" do
@@ -456,7 +477,7 @@ RSpec.describe Bundler::Dsl do
 
     it "rejects atomically when one field in a multi-field call is invalid" do
       expect do
-        subject.override("rails", version: ">= 8.0", required_ruby_version: :ignore_upper)
+        subject.override("rails", version: ">= 8.0", as: "y")
       end.to raise_error(ArgumentError, /unsupported override field/)
       expect(subject.overrides).to eq([])
     end

--- a/spec/bundler/override_spec.rb
+++ b/spec/bundler/override_spec.rb
@@ -34,6 +34,33 @@ RSpec.describe "MatchMetadata override-aware checks" do
   end
 end
 
+RSpec.describe "LazySpecification override propagation" do
+  let(:overrides) { [Bundler::Override.new("rails", :required_ruby_version, :ignore_upper)] }
+
+  it "carries overrides forward from a source LazySpec via from_spec" do
+    src = Bundler::LazySpecification.new("rails", "8.0", Gem::Platform::RUBY)
+    src.overrides = overrides
+    derived = Bundler::LazySpecification.from_spec(src)
+    expect(derived.overrides).to eq(overrides)
+  end
+
+  it "does not call respond_to? on the source spec, avoiding gemspec lazy load" do
+    # If from_spec used respond_to?(:overrides), a RemoteSpec source would
+    # force-load the backing gemspec. Use a stand-in object whose
+    # respond_to? raises to prove it is never asked.
+    src = Object.new
+    src.define_singleton_method(:name) { "rails" }
+    src.define_singleton_method(:version) { Gem::Version.new("8.0") }
+    src.define_singleton_method(:platform) { Gem::Platform::RUBY }
+    src.define_singleton_method(:source) { nil }
+    src.define_singleton_method(:runtime_dependencies) { [] }
+    src.define_singleton_method(:required_ruby_version) { Gem::Requirement.default }
+    src.define_singleton_method(:required_rubygems_version) { Gem::Requirement.default }
+    src.define_singleton_method(:respond_to?) {|*| raise "from_spec must not call respond_to?" }
+    expect { Bundler::LazySpecification.from_spec(src) }.not_to raise_error
+  end
+end
+
 RSpec.describe Bundler::Override do
   describe ".find_for" do
     it "returns the matching override by target and field" do

--- a/spec/bundler/override_spec.rb
+++ b/spec/bundler/override_spec.rb
@@ -1,6 +1,28 @@
 # frozen_string_literal: true
 
 RSpec.describe Bundler::Override do
+  describe ".find_for" do
+    it "returns the matching override by target and field" do
+      a = described_class.new("rails", :version, ">= 8.0")
+      b = described_class.new("nokogiri", :version, :ignore_upper)
+      expect(described_class.find_for([a, b], "rails", :version)).to be(a)
+    end
+
+    it "returns nil when no override matches the target" do
+      a = described_class.new("rails", :version, ">= 8.0")
+      expect(described_class.find_for([a], "sinatra", :version)).to be_nil
+    end
+
+    it "returns nil when no override matches the field" do
+      a = described_class.new("rails", :version, ">= 8.0")
+      expect(described_class.find_for([a], "rails", :required_ruby_version)).to be_nil
+    end
+
+    it "returns nil for an empty overrides list" do
+      expect(described_class.find_for([], "rails", :version)).to be_nil
+    end
+  end
+
   describe "#apply_to" do
     context "when operation is a version spec string" do
       it "replaces the existing requirement entirely" do

--- a/spec/bundler/override_spec.rb
+++ b/spec/bundler/override_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe Bundler::Override do
     it "returns nil for an empty overrides list" do
       expect(described_class.find_for([], "rails", :version)).to be_nil
     end
+
+    it "falls back to an :all override on the same field" do
+      a = described_class.new(:all, :required_ruby_version, :ignore_upper)
+      expect(described_class.find_for([a], "rails", :required_ruby_version)).to be(a)
+    end
+
+    it "prefers a per-gem override over a matching :all override" do
+      per_gem = described_class.new("rails", :required_ruby_version, ">= 3.4")
+      all_target = described_class.new(:all, :required_ruby_version, :ignore_upper)
+      expect(described_class.find_for([all_target, per_gem], "rails", :required_ruby_version)).to be(per_gem)
+    end
+
+    it "does not fall back to :all when the field differs" do
+      a = described_class.new(:all, :required_ruby_version, :ignore_upper)
+      expect(described_class.find_for([a], "rails", :required_rubygems_version)).to be_nil
+    end
   end
 
   describe "#apply_to" do

--- a/spec/bundler/override_spec.rb
+++ b/spec/bundler/override_spec.rb
@@ -1,5 +1,39 @@
 # frozen_string_literal: true
 
+RSpec.describe "MatchMetadata override-aware checks" do
+  let(:spec_class) do
+    Class.new do
+      include Bundler::MatchMetadata
+      attr_accessor :name
+      def initialize(name, ruby_req, rubygems_req)
+        @name = name
+        @required_ruby_version = ruby_req
+        @required_rubygems_version = rubygems_req
+      end
+    end
+  end
+
+  it "matches_current_metadata? ignores overrides (strict path)" do
+    spec = spec_class.new("rails", Gem::Requirement.new("< #{Gem.ruby_version}"), Gem::Requirement.default)
+    overrides = [Bundler::Override.new("rails", :required_ruby_version, :ignore_upper)]
+    # Strict method MUST NOT apply overrides; guards SelfManager and other generic callers.
+    expect(spec.matches_current_metadata?).to be(false)
+    expect(spec.matches_current_metadata_with_overrides?(overrides)).to be(true)
+  end
+
+  it "matches_current_ruby_with_overrides? returns the strict result for an empty override list" do
+    spec = spec_class.new("rails", Gem::Requirement.new(">= #{Gem.ruby_version}"), Gem::Requirement.default)
+    expect(spec.matches_current_ruby_with_overrides?([])).to be(true)
+    expect(spec.matches_current_ruby_with_overrides?(nil)).to be(true)
+  end
+
+  it "matches_current_rubygems_with_overrides? honors :all override" do
+    spec = spec_class.new("rails", Gem::Requirement.default, Gem::Requirement.new("< #{Gem.rubygems_version}"))
+    overrides = [Bundler::Override.new(:all, :required_rubygems_version, :ignore_upper)]
+    expect(spec.matches_current_rubygems_with_overrides?(overrides)).to be(true)
+  end
+end
+
 RSpec.describe Bundler::Override do
   describe ".find_for" do
     it "returns the matching override by target and field" do

--- a/spec/bundler/spec_set_spec.rb
+++ b/spec/bundler/spec_set_spec.rb
@@ -93,29 +93,4 @@ RSpec.describe Bundler::SpecSet do
     end
   end
 
-  describe "#with_overrides" do
-    it "defaults to an empty override list" do
-      expect(described_class.new([]).overrides).to eq([])
-    end
-
-    it "stores the overrides supplied" do
-      override = Bundler::Override.new("rails", :version, ">= 8.0")
-      expect(described_class.new([]).with_overrides([override]).overrides).to eq([override])
-    end
-
-    it "treats nil as an empty override list" do
-      set = described_class.new([])
-      override = Bundler::Override.new("rails", :version, ">= 8.0")
-      set.with_overrides([override])
-      set.with_overrides(nil)
-      expect(set.overrides).to eq([])
-    end
-
-    it "cascades overrides to contained specs that accept them" do
-      lazy = Bundler::LazySpecification.new("rails", "8.0", Gem::Platform::RUBY)
-      override = Bundler::Override.new("rails", :version, ">= 8.0")
-      described_class.new([lazy]).with_overrides([override])
-      expect(lazy.overrides).to eq([override])
-    end
-  end
 end

--- a/spec/bundler/spec_set_spec.rb
+++ b/spec/bundler/spec_set_spec.rb
@@ -92,4 +92,30 @@ RSpec.describe Bundler::SpecSet do
       ]
     end
   end
+
+  describe "#with_overrides" do
+    it "defaults to an empty override list" do
+      expect(described_class.new([]).overrides).to eq([])
+    end
+
+    it "stores the overrides supplied" do
+      override = Bundler::Override.new("rails", :version, ">= 8.0")
+      expect(described_class.new([]).with_overrides([override]).overrides).to eq([override])
+    end
+
+    it "treats nil as an empty override list" do
+      set = described_class.new([])
+      override = Bundler::Override.new("rails", :version, ">= 8.0")
+      set.with_overrides([override])
+      set.with_overrides(nil)
+      expect(set.overrides).to eq([])
+    end
+
+    it "cascades overrides to contained specs that accept them" do
+      lazy = Bundler::LazySpecification.new("rails", "8.0", Gem::Platform::RUBY)
+      override = Bundler::Override.new("rails", :version, ">= 8.0")
+      described_class.new([lazy]).with_overrides([override])
+      expect(lazy.overrides).to eq([override])
+    end
+  end
 end

--- a/spec/bundler/spec_set_spec.rb
+++ b/spec/bundler/spec_set_spec.rb
@@ -93,4 +93,56 @@ RSpec.describe Bundler::SpecSet do
     end
   end
 
+  describe "#complete_platform" do
+    let(:platform) { Gem::Platform.new("x86_64-linux") }
+
+    let(:platform_variant) do
+      build_spec("needs_old_ruby", "1.0", platform).first.tap do |s|
+        s.required_ruby_version = Gem::Requirement.new("< #{Gem.ruby_version}")
+      end
+    end
+
+    let(:lazy_spec) do
+      lazy = Bundler::LazySpecification.new("needs_old_ruby", Gem::Version.new("1.0"), Gem::Platform::RUBY)
+      lazy.required_ruby_version = Gem::Requirement.new("< #{Gem.ruby_version}")
+      source = double("source")
+      source_specs = double("source_specs")
+      allow(source).to receive(:specs).and_return(source_specs)
+      allow(source_specs).to receive(:search).
+        with(["needs_old_ruby", Gem::Version.new("1.0")]).and_return([platform_variant])
+      lazy.source = source
+      lazy
+    end
+
+    it "rejects a platform variant whose strict metadata is incompatible when no override is attached" do
+      set = described_class.new([lazy_spec])
+      expect(set.send(:complete_platform, platform)).to be(false)
+    end
+
+    it "accepts a platform variant when the LazySpec carries an override that allows it" do
+      lazy_spec.overrides = [Bundler::Override.new("needs_old_ruby", :required_ruby_version, :ignore_upper)]
+      set = described_class.new([lazy_spec])
+      expect(set.send(:complete_platform, platform)).to be(true)
+    end
+
+    it "carries overrides onto a synthesized LazySpec so a follow-up complete_platform still honors them" do
+      override = Bundler::Override.new("needs_old_ruby", :required_ruby_version, :ignore_upper)
+      lazy_spec.overrides = [override]
+      second_platform = Gem::Platform.new("aarch64-linux")
+      second_variant = build_spec("needs_old_ruby", "1.0", second_platform).first.tap do |s|
+        s.required_ruby_version = Gem::Requirement.new("< #{Gem.ruby_version}")
+      end
+      allow(lazy_spec.source.specs).to receive(:search).
+        with(["needs_old_ruby", Gem::Version.new("1.0")]).and_return([platform_variant, second_variant])
+
+      set = described_class.new([lazy_spec])
+      expect(set.send(:complete_platform, platform)).to be(true)
+      # The synthesized x86_64-linux variant is now in the set. If lookup
+      # picks it as exemplar for the next platform check, the override list
+      # must still be reachable via its overrides accessor.
+      synthesized = set.to_a.find {|s| s.platform == platform }
+      expect(synthesized.overrides).to eq([override])
+      expect(set.send(:complete_platform, second_platform)).to be(true)
+    end
+  end
 end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -129,4 +129,16 @@ RSpec.describe "override DSL" do
       expect(the_bundle).to include_gems "myrack 1.0.0", "myrack_middleware 1.0"
     end
   end
+
+  context "lockfile contents" do
+    it "does not record the override directive in Gemfile.lock" do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        override "myrack", version: "= 0.9.1"
+        gem "myrack"
+      G
+
+      expect(lockfile).not_to match(/override/i)
+    end
+  end
 end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe "override DSL" do
       expect(err).to include("still_blocked")
     end
 
-    it "re-resolves a previously locked spec when an :all metadata override is added" do
+    it "preserves locked versions when an :all metadata override is added without bundle update" do
       build_repo2 do
         build_gem "selectable", "1.0"
         build_gem "selectable", "2.0" do |s|
@@ -313,7 +313,13 @@ RSpec.describe "override DSL" do
         gem "selectable"
       G
 
+      # :all override alone does not pre-unlock locked specs; narrow change
+      # should not trigger unrelated lockfile churn.
       bundle :lock
+      expect(lockfile).to include("selectable (1.0)")
+
+      # bundle update opts the user into re-resolution under the override.
+      bundle "update selectable"
       expect(lockfile).to include("selectable (2.0)")
     end
   end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -317,4 +317,58 @@ RSpec.describe "override DSL" do
       expect(lockfile).to include("selectable (2.0)")
     end
   end
+
+  context "install-time compatibility" do
+    it "installs a gem whose required_ruby_version excludes the current Ruby when an override removes the constraint" do
+      build_repo2 do
+        build_gem "needs_old_ruby", "1.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+      end
+
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        override "needs_old_ruby", required_ruby_version: nil
+        gem "needs_old_ruby"
+      G
+
+      expect(the_bundle).to include_gems "needs_old_ruby 1.0"
+    end
+
+    it "installs a gem whose required_rubygems_version excludes the current RubyGems when an override removes it" do
+      build_repo2 do
+        build_gem "needs_old_rubygems", "1.0" do |s|
+          s.required_rubygems_version = "< #{Gem.rubygems_version}"
+        end
+      end
+
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        override "needs_old_rubygems", required_rubygems_version: nil
+        gem "needs_old_rubygems"
+      G
+
+      expect(the_bundle).to include_gems "needs_old_rubygems 1.0"
+    end
+
+    it "installs every gem when :all required_ruby_version override is in effect" do
+      build_repo2 do
+        build_gem "needs_old_ruby_a", "1.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+        build_gem "needs_old_ruby_b", "1.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+      end
+
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        override :all, required_ruby_version: :ignore_upper
+        gem "needs_old_ruby_a"
+        gem "needs_old_ruby_b"
+      G
+
+      expect(the_bundle).to include_gems "needs_old_ruby_a 1.0", "needs_old_ruby_b 1.0"
+    end
+  end
 end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -141,4 +141,106 @@ RSpec.describe "override DSL" do
       expect(lockfile).not_to match(/override/i)
     end
   end
+
+  context "with a required_ruby_version: operation" do
+    it "lets the resolver pick a gem whose required_ruby_version excludes the current Ruby with :ignore_upper" do
+      build_repo2 do
+        build_gem "needs_old_ruby", "1.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        override "needs_old_ruby", required_ruby_version: :ignore_upper
+        gem "needs_old_ruby"
+      G
+
+      bundle :lock
+      expect(lockfile).to include("needs_old_ruby (1.0)")
+    end
+
+    it "lets the resolver pick the gem with required_ruby_version: nil" do
+      build_repo2 do
+        build_gem "needs_old_ruby", "1.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        override "needs_old_ruby", required_ruby_version: nil
+        gem "needs_old_ruby"
+      G
+
+      bundle :lock
+      expect(lockfile).to include("needs_old_ruby (1.0)")
+    end
+
+    it "applies to a transitive dependency's required_ruby_version" do
+      build_repo2 do
+        build_gem "needs_old_ruby", "1.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+        build_gem "wraps_old", "1.0" do |s|
+          s.add_dependency "needs_old_ruby"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        override "needs_old_ruby", required_ruby_version: :ignore_upper
+        gem "wraps_old"
+      G
+
+      bundle :lock
+      expect(lockfile).to include("needs_old_ruby (1.0)")
+      expect(lockfile).to include("wraps_old (1.0)")
+    end
+
+    it "re-resolves a direct dep when a metadata override is added against an existing lockfile" do
+      build_repo2 do
+        build_gem "selectable", "1.0"
+        build_gem "selectable", "2.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        gem "selectable"
+      G
+
+      bundle :lock
+      expect(lockfile).to include("selectable (1.0)")
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        override "selectable", required_ruby_version: :ignore_upper
+        gem "selectable"
+      G
+
+      bundle :lock
+      expect(lockfile).to include("selectable (2.0)")
+    end
+  end
+
+  context "with a required_rubygems_version: operation" do
+    it "lets the resolver pick a gem whose required_rubygems_version excludes the current RubyGems with :ignore_upper" do
+      build_repo2 do
+        build_gem "needs_old_rubygems", "1.0" do |s|
+          s.required_rubygems_version = "< #{Gem.rubygems_version}"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        override "needs_old_rubygems", required_rubygems_version: :ignore_upper
+        gem "needs_old_rubygems"
+      G
+
+      bundle :lock
+      expect(lockfile).to include("needs_old_rubygems (1.0)")
+    end
+  end
 end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -243,4 +243,78 @@ RSpec.describe "override DSL" do
       expect(lockfile).to include("needs_old_rubygems (1.0)")
     end
   end
+
+  context "with an :all target" do
+    it "applies required_ruby_version: :ignore_upper to every gem" do
+      build_repo2 do
+        build_gem "needs_old_ruby_a", "1.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+        build_gem "needs_old_ruby_b", "1.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        override :all, required_ruby_version: :ignore_upper
+        gem "needs_old_ruby_a"
+        gem "needs_old_ruby_b"
+      G
+
+      bundle :lock
+      expect(lockfile).to include("needs_old_ruby_a (1.0)")
+      expect(lockfile).to include("needs_old_ruby_b (1.0)")
+    end
+
+    it "is overridden by a per-gem override on the same field" do
+      build_repo2 do
+        build_gem "permissive", "1.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+        build_gem "still_blocked", "1.0" do |s|
+          s.required_ruby_version = "= #{Gem.ruby_version}.999"
+        end
+      end
+
+      # :all says ignore_upper (would unblock both), but per-gem on
+      # still_blocked nails it to a hard requirement that still fails.
+      gemfile <<-G
+        source "https://gem.repo2"
+        override :all, required_ruby_version: :ignore_upper
+        override "still_blocked", required_ruby_version: "= #{Gem.ruby_version}.999"
+        gem "permissive"
+        gem "still_blocked"
+      G
+
+      bundle :lock, raise_on_error: false
+      expect(err).to include("still_blocked")
+    end
+
+    it "re-resolves a previously locked spec when an :all metadata override is added" do
+      build_repo2 do
+        build_gem "selectable", "1.0"
+        build_gem "selectable", "2.0" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        gem "selectable"
+      G
+
+      bundle :lock
+      expect(lockfile).to include("selectable (1.0)")
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        override :all, required_ruby_version: :ignore_upper
+        gem "selectable"
+      G
+
+      bundle :lock
+      expect(lockfile).to include("selectable (2.0)")
+    end
+  end
 end

--- a/spec/install/gemfile/override_spec.rb
+++ b/spec/install/gemfile/override_spec.rb
@@ -318,6 +318,27 @@ RSpec.describe "override DSL" do
     end
   end
 
+  context "diagnostic on resolve failure" do
+    it "lists active overrides with their Gemfile location" do
+      build_repo2 do
+        build_gem "needs_old_ruby", "1.0" do |s|
+          s.required_ruby_version = "= #{Gem.ruby_version}.999"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo2"
+        override "needs_old_ruby", required_ruby_version: "= #{Gem.ruby_version}.999"
+        gem "needs_old_ruby"
+      G
+
+      bundle :lock, raise_on_error: false
+      expect(err).to include("Bundler applied the following overrides")
+      expect(err).to include("override \"needs_old_ruby\", required_ruby_version:")
+      expect(err).to match(/declared at Gemfile:\d+/)
+    end
+  end
+
   context "install-time compatibility" do
     it "installs a gem whose required_ruby_version excludes the current Ruby when an override removes the constraint" do
       build_repo2 do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Follow-up to #9517 (Phase 1), continuing https://github.com/ruby/rubygems/discussions/9494. Phase 1 only covered per-gem `version:` overrides; Phase 2 adds the remaining operations the discussion called for: an `:all` target and the `required_ruby_version` / `required_rubygems_version` metadata fields, with overrides honored at install time as well as during resolution.

## What is your fix for the problem, implemented in this PR?

Extends the existing `override` DSL with metadata fields and an `:all` target.

```ruby
override "rails", required_ruby_version: :ignore_upper
override "rails", required_rubygems_version: nil

override :all, required_ruby_version: :ignore_upper
override :all, required_rubygems_version: nil
```

`:all + version:` stays banned — version requirements are inherently per-gem. A per-gem override takes precedence over an `:all` override on the same field.

The Phase 1 operations carry over unchanged: an absolute requirement string replaces the constraint, `:ignore_upper` drops `<` / `<=` and folds `~>` into `>=`, and `nil` collapses to `>= 0`.

Overrides are now honored by the install-time Ruby / RubyGems compatibility check too (previously install would still error even when resolution had picked a deliberately overridden gem). When resolution still fails, Bundler appends the active overrides — with their Gemfile location — to the error message so it's clear which directive shaped the constraint set.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
