### PR TITLE
Fix prepare_release detection of already-backported PRs

### DIFF
--- a/tool/release.rb
+++ b/tool/release.rb
@@ -372,13 +372,22 @@ class Release
 
   # Source SHAs already cherry-picked onto the stable branch, derived from the
   # `(cherry picked from commit X)` footer that `git cherry-pick -x` records.
-  # This is more reliable than matching merge commit subjects, which only
-  # catches PRs merged with "Create a merge commit". Squash-merged PRs are
-  # cherry-picked as plain commits with subjects like `"Foo (#1234)"` or
-  # without any PR reference, so subject-based detection misses them.
+  # When the footer references a merge commit (PRs merged with "Create a merge
+  # commit", picked with `-m 1`), also include the individual PR commits the
+  # merge introduced, otherwise `gh search prs` would still re-discover the PR
+  # through those commits left on master.
   def released_commit_shas
-    @released_commit_shas ||= `git log --format=%B #{@previous_release_tag}..#{@stable_branch}`
-      .scan(/cherry picked from commit ([0-9a-f]+)/).flatten.to_set
+    @released_commit_shas ||= begin
+      log = `git log --format=%B #{@previous_release_tag}..#{@stable_branch}`
+      shas = Set.new
+      log.scan(/cherry picked from commit ([0-9a-f]+)/).flatten.each do |sha|
+        shas << sha
+        parents = `git rev-list --parents -n 1 #{sha} 2>/dev/null`.strip.split.drop(1)
+        next unless parents.size >= 2
+        shas.merge(`git log --format=%H #{parents[0]}..#{parents[1]}`.split("\n"))
+      end
+      shas
+    end
   end
 
   def scan_unreleased_pull_requests(ids)

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -394,7 +394,12 @@ class Release
     pulls = []
     ids.each do |id|
       pull = gh_client.pull_request("ruby/rubygems", id)
-      pulls << pull if pull.merged_at
+      next unless pull.merged_at
+      # `gh search prs` can associate a PR with commits left behind by
+      # force-pushes that no longer match the merged HEAD. Confirm the PR is
+      # actually unreleased by comparing its merge commit SHA directly.
+      next if @level == :patch && released_commit_shas.include?(pull.merge_commit_sha)
+      pulls << pull
     end
     pulls
   end

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -370,14 +370,15 @@ class Release
     @unreleased_pull_requests ||= scan_unreleased_pull_requests(unreleased_pr_ids)
   end
 
-  def released_pull_requests
-    @released_pull_requests ||= begin
-      commits = `git log --oneline --grep "^Merge pull request #" #{@previous_release_tag}..#{@stable_branch}`.split("\n")
-      commits.filter_map do |commit|
-        match = commit.match(/Merge pull request #(\d+) from /)
-        match[1].to_i if match
-      end
-    end
+  # Source SHAs already cherry-picked onto the stable branch, derived from the
+  # `(cherry picked from commit X)` footer that `git cherry-pick -x` records.
+  # This is more reliable than matching merge commit subjects, which only
+  # catches PRs merged with "Create a merge commit". Squash-merged PRs are
+  # cherry-picked as plain commits with subjects like `"Foo (#1234)"` or
+  # without any PR reference, so subject-based detection misses them.
+  def released_commit_shas
+    @released_commit_shas ||= `git log --format=%B #{@previous_release_tag}..#{@stable_branch}`
+      .scan(/cherry picked from commit ([0-9a-f]+)/).flatten.to_set
   end
 
   def scan_unreleased_pull_requests(ids)
@@ -391,7 +392,8 @@ class Release
 
   def unreleased_pr_ids
     head = @level == :minor_or_major ? "HEAD" : "master"
-    commits = `git log --format=%h #{@previous_release_tag}..#{head}`.split("\n")
+    commits = `git log --format=%H #{@previous_release_tag}..#{head}`.split("\n")
+    commits.reject! {|sha| released_commit_shas.include?(sha) } if @level == :patch
 
     # GitHub search API has a rate limit of 30 requests per minute for authenticated users
     rate_limit = 28
@@ -406,9 +408,7 @@ class Release
       result = `gh search prs --repo ruby/rubygems #{batch.join(",")} --json number --jq '.[].number'`.strip
       unless result.empty?
         result.split("\n").each do |pr_number|
-          pr_id = pr_number.to_i
-          next if @level == :patch && released_pull_requests.include?(pr_id)
-          pr_ids.add(pr_id)
+          pr_ids.add(pr_number.to_i)
         end
       end
 


### PR DESCRIPTION
`prepare_release` listed already-backported PRs as backport candidates because `released_pull_requests` only matched `Merge pull request #N` subjects, missing the squash-merged PRs that make up most of what we cherry-pick.

The fix builds `released_commit_shas` from the `(cherry picked from commit X)` footers that `git cherry-pick -x` records, expands the range when the footer points to a merge commit so its individual PR commits on master are also excluded, and re-checks each candidate's `merge_commit_sha` after `gh search prs` to absorb force-push noise where stale commits still associate with a merged PR.

Verified on 4.0: the candidate list shrinks from a noisy ~16 to #5029, #9502, #9514, #9527, which matches the actual outstanding backports for 4.0.12.