### PR TITLE
Allow non-zero exit status in bundle config gemfile unset spec

### DIFF
--- a/spec/commands/config_spec.rb
+++ b/spec/commands/config_spec.rb
@@ -600,7 +600,7 @@ RSpec.describe "setting gemfile via config" do
       bundle "config set gemfile foo/bar_gemfile"
 
       bundle "config unset gemfile"
-      bundle "config get gemfile"
+      bundle "config get gemfile", raise_on_error: false
 
       expect(out).to include("You have not configured a value for `gemfile`")
       expect(File.read(bundled_app(".bundle/config"))).not_to include("BUNDLE_GEMFILE")


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes https://github.com/ruby/rubygems/actions/runs/25544640954/job/74980646086

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
