### PR TITLE
Use optimistic version constraints in bundle gem output

### DIFF
--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -6,19 +6,19 @@ source "https://rubygems.org"
 gemspec
 
 gem "irb"
-gem "rake", "~> 13.0"
+gem "rake", ">= 13.0"
 <%- if config[:ext] -%>
 
 gem "rake-compiler"
 <%- end -%>
 <%- if config[:test] -%>
 
-gem "<%= config[:test] %>", "~> <%= config[:test_framework_version] %>"
+gem "<%= config[:test] %>", ">= <%= config[:test_framework_version] %>"
 <%- end -%>
 <%- if config[:linter] == "rubocop" -%>
 
-gem "rubocop", "~> <%= config[:linter_version] %>"
+gem "rubocop", ">= <%= config[:linter_version] %>"
 <%- elsif config[:linter] == "standard" -%>
 
-gem "standard", "~> <%= config[:linter_version] %>"
+gem "standard", ">= <%= config[:linter_version] %>"
 <%- end -%>

--- a/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
+++ b/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt
@@ -45,12 +45,12 @@ Gem::Specification.new do |spec|
 <%- end -%>
 
   # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  # spec.add_dependency "example-gem", ">= 1.0"
 <%- if config[:ext] == 'rust' -%>
-  spec.add_dependency "rb_sys", "~> 0.9.127"
+  spec.add_dependency "rb_sys", ">= 0.9.127"
 <%- end -%>
 <%- if config[:ext] == 'go' -%>
-  spec.add_dependency "go_gem", "~> 0.2"
+  spec.add_dependency "go_gem", ">= 0.2"
 <%- end -%>
 
   # For more information and examples about making a new gem, check out our

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -752,7 +752,7 @@ RSpec.describe "bundle gem" do
       builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
       builder.dependencies
       rspec_dep = builder.dependencies.find {|d| d.name == "rspec" }
-      expect(rspec_dep).to be_specific
+      expect(rspec_dep).not_to be_specific
     end
   end
 
@@ -837,7 +837,7 @@ RSpec.describe "bundle gem" do
       builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
       builder.dependencies
       minitest_dep = builder.dependencies.find {|d| d.name == "minitest" }
-      expect(minitest_dep).to be_specific
+      expect(minitest_dep).not_to be_specific
     end
 
     it "builds spec skeleton" do
@@ -898,7 +898,7 @@ RSpec.describe "bundle gem" do
       builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
       builder.dependencies
       test_unit_dep = builder.dependencies.find {|d| d.name == "test-unit" }
-      expect(test_unit_dep).to be_specific
+      expect(test_unit_dep).not_to be_specific
     end
 
     it "builds spec skeleton" do
@@ -1829,7 +1829,7 @@ RSpec.describe "bundle gem" do
       end
 
       it "includes go_gem in gem_name.gemspec" do
-        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include('spec.add_dependency "go_gem", "~> 0.2"')
+        expect(bundled_app("#{gem_name}/#{gem_name}.gemspec").read).to include('spec.add_dependency "go_gem", ">= 0.2"')
       end
 
       it "includes go_gem extension in extconf.rb" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Add the recent developer meeting, we discussed switching from using pessimistic versioning by default to using optimistic versioning by default.

## What is your fix for the problem, implemented in this PR?

This changes the gemspec and Gemfile created by `bundle gem` to use optimistic versions for dependencies.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
