### PR TITLE
Change Gem::Version#approximate_recommendation to be optimistic

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -325,7 +325,7 @@ class Gem::Version
   end
 
   ##
-  # A recommended version for use with a ~> Requirement.
+  # A recommended version for use with a >= Requirement.
 
   def approximate_recommendation
     segments = self.segments
@@ -334,7 +334,7 @@ class Gem::Version
     segments.pop    while segments.size > 2
     segments.push 0 while segments.size < 2
 
-    recommendation = "~> #{segments.join(".")}"
+    recommendation = ">= #{segments.join(".")}"
     recommendation += ".a" if prerelease?
     recommendation
   end

--- a/test/rubygems/test_gem_version.rb
+++ b/test/rubygems/test_gem_version.rb
@@ -165,25 +165,25 @@ class TestGemVersion < Gem::TestCase
   end
 
   def test_approximate_recommendation
-    assert_approximate_equal "~> 1.0", "1"
+    assert_approximate_equal ">= 1.0", "1"
     assert_approximate_satisfies_itself "1"
 
-    assert_approximate_equal "~> 1.0", "1.0"
+    assert_approximate_equal ">= 1.0", "1.0"
     assert_approximate_satisfies_itself "1.0"
 
-    assert_approximate_equal "~> 1.2", "1.2"
+    assert_approximate_equal ">= 1.2", "1.2"
     assert_approximate_satisfies_itself "1.2"
 
-    assert_approximate_equal "~> 1.2", "1.2.0"
+    assert_approximate_equal ">= 1.2", "1.2.0"
     assert_approximate_satisfies_itself "1.2.0"
 
-    assert_approximate_equal "~> 1.2", "1.2.3"
+    assert_approximate_equal ">= 1.2", "1.2.3"
     assert_approximate_satisfies_itself "1.2.3"
 
-    assert_approximate_equal "~> 1.2.a", "1.2.3.a.4"
+    assert_approximate_equal ">= 1.2.a", "1.2.3.a.4"
     assert_approximate_satisfies_itself "1.2.3.a.4"
 
-    assert_approximate_equal "~> 1.9.a", "1.9.0.dev"
+    assert_approximate_equal ">= 1.9.a", "1.9.0.dev"
     assert_approximate_satisfies_itself "1.9.0.dev"
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Add the recent developer meeting, we discussed switching from using pessimistic versioning by default to using optimistic versioning by default.

## What is your fix for the problem, implemented in this PR?

This changes `Gem::Version#approximate_recommendation` to be optimistic instead of pessimistic.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
