### PR TITLE
Read `BUNDLE_VERSION` env var in `BundlerVersionFinder`

### DIFF
--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -70,6 +70,9 @@ module Gem::BundlerVersionFinder
   private_class_method :lockfile_contents
 
   def self.bundle_config_version
+    env_version = ENV["BUNDLE_VERSION"]
+    return env_version if env_version && !env_version.empty?
+
     version = nil
 
     [bundler_local_config_file, bundler_global_config_file].each do |config_file|

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -104,6 +104,48 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     end
   end
 
+  def test_bundler_version_with_bundle_version_env_system
+    ENV["BUNDLE_VERSION"] = "system"
+
+    bvf.stub(:lockfile_contents, "\n\nBUNDLED WITH\n   1.1.1.1\n") do
+      assert_nil bvf.bundler_version
+    end
+  end
+
+  def test_bundler_version_with_bundle_version_env_overrides_config
+    ENV["BUNDLE_VERSION"] = "2.3.4"
+
+    config_content = <<~CONFIG
+      BUNDLE_VERSION: "1.2.3"
+    CONFIG
+
+    Tempfile.create("bundle_config") do |f|
+      f.write(config_content)
+      f.flush
+
+      bvf.stub(:bundler_global_config_file, f.path) do
+        assert_equal v("2.3.4"), bvf.bundler_version
+      end
+    end
+  end
+
+  def test_bundler_version_with_empty_bundle_version_env
+    ENV["BUNDLE_VERSION"] = ""
+
+    config_content = <<~CONFIG
+      BUNDLE_VERSION: "1.2.3"
+    CONFIG
+
+    Tempfile.create("bundle_config") do |f|
+      f.write(config_content)
+      f.flush
+
+      bvf.stub(:bundler_global_config_file, f.path) do
+        assert_equal v("1.2.3"), bvf.bundler_version
+      end
+    end
+  end
+
   def test_bundler_version_with_bundle_config_non_existent_file
     bvf.stub(:bundler_global_config_file, "/non/existent/path") do
       assert_nil bvf.bundler_version


### PR DESCRIPTION





## What was the end-user or developer problem that led to this PR?

Fixes https://github.com/ruby/rubygems/issues/9534

## What is your fix for the problem, implemented in this PR?

`Bundler::Settings` resolves the `version` setting from the `BUNDLE_VERSION` environment variable, but `Gem::BundlerVersionFinder` only consulted the `.bundle/config` file.

As a result `BUNDLE_VERSION=system` was ignored at activation time and a lockfile-pinned bundler installed globally won out over the default gem.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
