### PR TITLE
Close stdin immediately when using popen2e

### DIFF
--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -102,7 +102,8 @@ class Gem::Ext::Builder
       # Set $SOURCE_DATE_EPOCH for the subprocess.
       build_env = { "SOURCE_DATE_EPOCH" => Gem.source_date_epoch_string }.merge(env)
       output, status = begin
-                         Open3.popen2e(build_env, *command, chdir: dir) do |_stdin, stdouterr, wait_thread|
+                         Open3.popen2e(build_env, *command, chdir: dir) do |stdin, stdouterr, wait_thread|
+                           stdin.close
                            output = String.new
                            while line = stdouterr.gets
                              output << line

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -106,6 +106,22 @@ install:
     assert_match(/install: OK/, results)
   end
 
+  def test_class_run_closes_stdin
+    results = []
+    check_stdin_script = <<~'RUBY'
+      if IO.select([STDIN], nil, nil, 1)
+        puts "STDIN: #{STDIN.read.inspect}"
+      else
+        puts "NOT_READY"
+      end
+    RUBY
+
+    Gem::Ext::Builder.run([Gem.ruby, "-e", check_stdin_script], results)
+
+    command_output = results.last
+    assert_equal "STDIN: \"\"\n", command_output
+  end
+
   def test_build_extensions
     pend "terminates on mswin" if vc_windows? && ruby_repo?
 


### PR DESCRIPTION
It's good hygiene to close the stdin pipe as soon as you are done writing to it.

This can happen for example if "ruby extconf.rb" spawns another process (for example "cargo build", which may spawn arbitrary commands to fetch credentials) and any of those subprocesses attempt to read STDIN until it is closed.

We can close it as soon as it's created since we aren't writing to it at all.

## What was the end-user or developer problem that led to this PR?

Our CI was hanging and timing out at the "bundle install" step because a gem's extconf.rb calls `cargo build` which calls a custom command to fetch credentials and that command tries to read STDIN when it detects that it is given a pipe.

## What is your fix for the problem, implemented in this PR?

Close the STDIN pipe created by Open3 so that if a target command tries to read the pipe it will finish.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
