### PR TITLE
Skip git source exclusion when lockfile cannot backfill

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1210,16 +1210,20 @@ module Bundler
     def find_source_requirements
       preload_git_sources
 
+      # Only safe to exclude when locked_requirements (merged below) backfills the gap.
+      nothing_changed = nothing_changed?
+      excluded = nothing_changed ? excluded_git_sources : []
+
       # Record the specs available in each gem's source, so that those
       # specs will be available later when the resolver knows where to
       # look for that gemspec (or its dependencies)
       source_requirements = if precompute_source_requirements_for_indirect_dependencies?
-        all_requirements = source_map.all_requirements(excluded_git_sources)
+        all_requirements = source_map.all_requirements(excluded)
         { default: default_source }.merge(all_requirements)
       else
-        { default: Source::RubygemsAggregate.new(sources, source_map, excluded_git_sources) }.merge(source_map.direct_requirements)
+        { default: Source::RubygemsAggregate.new(sources, source_map, excluded) }.merge(source_map.direct_requirements)
       end
-      source_requirements.merge!(source_map.locked_requirements) if nothing_changed?
+      source_requirements.merge!(source_map.locked_requirements) if nothing_changed
       metadata_dependencies.each do |dep|
         source_requirements[dep.name] = sources.metadata_source
       end

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -317,5 +317,53 @@ RSpec.describe "bundle install" do
       expect(the_bundle).to include_gems("production_gem 1.0")
       expect(the_bundle).not_to include_gems("development_gem 1.0")
     end
+
+    it "resolves indirect dependencies from a git source not in the requested groups" do
+      build_lib "activesupport", "1.0", path: lib_path("rails/activesupport")
+      build_git "activerecord", "1.0", path: lib_path("rails") do |s|
+        s.add_dependency "activesupport", "= 1.0"
+      end
+
+      gemfile <<-G
+        source "https://gem.repo1"
+
+        gem "activerecord", :git => "#{lib_path("rails")}"
+
+        group :ci do
+          gem "myrack"
+        end
+      G
+
+      bundle_config "only ci"
+      bundle :install
+
+      expect(the_bundle).to include_gems("myrack 1.0.0")
+      expect(the_bundle).not_to include_gems("activerecord 1.0")
+    end
+
+    it "resolves indirect dependencies from a git source not in the requested groups (without compact_index dependency API)" do
+      build_lib "activesupport", "1.0", path: lib_path("rails/activesupport")
+      build_git "activerecord", "1.0", path: lib_path("rails") do |s|
+        s.add_dependency "activesupport", "= 1.0"
+      end
+
+      gemfile <<-G
+        source "https://gem.repo1"
+
+        gem "activerecord", :git => "#{lib_path("rails")}"
+
+        group :ci do
+          gem "myrack"
+        end
+      G
+
+      # Force the RubygemsAggregate code path in find_source_requirements by
+      # making the dependency API unavailable.
+      bundle_config "only ci"
+      bundle :install, artifice: "endpoint_api_forbidden"
+
+      expect(the_bundle).to include_gems("myrack 1.0.0")
+      expect(the_bundle).not_to include_gems("activerecord 1.0")
+    end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

#9536: starting with Bundler 4.0.7, `BUNDLE_ONLY=<group> bundle install` fails with "Could not find compatible versions" when the Gemfile has a default-group gem fetched from a git source and **no Gemfile.lock is present**. Reproducer from the issue:

```ruby
# Gemfile
source "https://rubygems.org"
gem "activerecord", git: "https://github.com/rails/rails.git", branch: "main"
group :ci do
  gem "rubocop"
end
```

```
$ rm -f Gemfile.lock
$ BUNDLE_ONLY=ci bundle install
Resolving dependencies...
Could not find compatible versions

Because every version of activerecord depends on activesupport = 8.2.0.alpha
  and activesupport = 8.2.0.alpha could not be found in rubygems repository https://rubygems.org/ or installed locally,
  activerecord cannot be used.
So, because Gemfile depends on activerecord >= 0,
  version solving has failed.
```

Bundler 4.0.6 succeeds; 4.0.7 — 4.0.11 fail. The regression is between those tags.

## What is your fix for the problem, implemented in this PR?

### Diagnosis

The regression was introduced by #9234, which added `needed_git_sources` / `excluded_git_sources` and threaded `excluded_git_sources` into `Bundler::Definition#find_source_requirements`:

```ruby
source_requirements = if precompute_source_requirements_for_indirect_dependencies?
  all_requirements = source_map.all_requirements(excluded_git_sources)
  { default: default_source }.merge(all_requirements)
else
  { default: Source::RubygemsAggregate.new(sources, source_map, excluded_git_sources) }.merge(source_map.direct_requirements)
end
source_requirements.merge!(source_map.locked_requirements) if nothing_changed?
```

With `BUNDLE_ONLY=ci`:

- `requested_groups = [:ci]`
- `dependencies_for([:ci])` only contains `rubocop` (a rubygems source)
- `needed_git_sources` returns `[]`, so the rails-git source (used by the default-group `activerecord`) is treated as **excluded**
- `source_map.all_requirements` then skips that source when filling indirect-dependency mappings
- The indirect dep `activesupport` (a sibling spec in the rails git tree) is not mapped to rails-git, so the resolver looks for it in the default rubygems source, doesn't find `= 8.2.0.alpha`, and gives up

The #9234 spec only passed because it pre-created a complete lockfile; with `nothing_changed?` true, `source_map.locked_requirements` (merged a few lines down) backfilled the gap. Without a Gemfile.lock that fallback is absent.

### Fix

Gate the exclusion on `nothing_changed?` so it only applies when the lockfile is guaranteed to cover the excluded sources:

```ruby
nothing_changed = nothing_changed?
excluded = nothing_changed ? excluded_git_sources : []
```

- When `nothing_changed?` is true → behavior identical to #9234 (and `nothing_changed?` itself implies `lockfile_exists?` and that `@missing_lockfile_dep` / `@locked_spec_with_missing_deps` / `@locked_spec_with_invalid_deps` are all false, so `locked_requirements` really does cover the excluded source).
- When `nothing_changed?` is false → fall back to passing `[]`, i.e. the resolver sees every git source (the pre-#9234 behavior for this case).

The `needed_git_sources` filter in `preload_git_sources` is left in place, so #9234's parallel-preload optimization for `--without`-only git sources is preserved.

### Alternatives considered

- **Revert #9234 entirely**: would also fix #9536 but would discard the parallel-preload skip (which is genuinely useful when a default-group `bundle install --without dev` is run with a complete lockfile and a private dev git URL). Rejected.
- **Group-aware resolution**: making the resolver only consider `dependencies_for(requested_groups)` so excluded git sources are not even on the dependency graph. This would fix #9536 too and would also let `--without` skip private git sources without a lockfile, but it changes Bundler's "complete lockfile" invariant. Too large for this regression fix; left for a separate design discussion.

### End-to-end verification

Verified on Fedora with the exact reproducer from #9536, using `Gemfile` without `Gemfile.lock`:

| Bundler                                       | `BUNDLE_ONLY=ci bundle install` |
|-----------------------------------------------|---------------------------------|
| 4.0.6                                         | ✅ Bundle complete!             |
| 4.0.7 — 4.0.11 (current master)               | ❌ Could not find compatible versions |
| this PR                                       | ✅ Bundle complete!             |

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)

Two regression specs cover both branches of `find_source_requirements`:
- `source_map.all_requirements(excluded)` (compact_index dependency API, the default path)
- `Source::RubygemsAggregate.new(sources, source_map, excluded)` (via the `endpoint_api_forbidden` artifice)

The existing #9234 spec (`"works if you exclude a group with a git gem"`) is unchanged and still passes.