### PR TITLE
Fall back to lockfile version when `BUNDLE_VERSION` is "lockfile"

### DIFF
--- a/lib/rubygems/bundler_version_finder.rb
+++ b/lib/rubygems/bundler_version_finder.rb
@@ -2,7 +2,8 @@
 
 module Gem::BundlerVersionFinder
   def self.bundler_version
-    return if bundle_config_version == "system"
+    bcv = bundle_config_version
+    return if bcv == "system"
 
     v = ENV["BUNDLER_VERSION"]
     v = nil if v&.empty?
@@ -10,7 +11,7 @@ module Gem::BundlerVersionFinder
     v ||= bundle_update_bundler_version
     return if v == true
 
-    v ||= bundle_config_version
+    v ||= bcv unless bcv == "lockfile"
 
     v ||= lockfile_version
     return unless v

--- a/test/rubygems/test_gem_bundler_version_finder.rb
+++ b/test/rubygems/test_gem_bundler_version_finder.rb
@@ -146,6 +146,31 @@ class TestGemBundlerVersionFinder < Gem::TestCase
     end
   end
 
+  def test_bundler_version_with_bundle_version_env_lockfile
+    ENV["BUNDLE_VERSION"] = "lockfile"
+
+    bvf.stub(:lockfile_contents, "\n\nBUNDLED WITH\n   1.1.1.1\n") do
+      assert_equal v("1.1.1.1"), bvf.bundler_version
+    end
+  end
+
+  def test_bundler_version_with_bundle_config_version_lockfile
+    config_content = <<~CONFIG
+      BUNDLE_VERSION: "lockfile"
+    CONFIG
+
+    Tempfile.create("bundle_config") do |f|
+      f.write(config_content)
+      f.flush
+
+      bvf.stub(:bundler_global_config_file, f.path) do
+        bvf.stub(:lockfile_contents, "\n\nBUNDLED WITH\n   1.1.1.1\n") do
+          assert_equal v("1.1.1.1"), bvf.bundler_version
+        end
+      end
+    end
+  end
+
   def test_bundler_version_with_bundle_config_non_existent_file
     bvf.stub(:bundler_global_config_file, "/non/existent/path") do
       assert_nil bvf.bundler_version


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler treats "lockfile" as a special value for the version setting, meaning "use the version recorded in BUNDLED WITH".

`BundlerVersionFinder` was passing the raw string to `Gem::Version.new` and raising `ArgumentError` both from the env var added in #9538 and from `.bundle/config`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
