### PR TITLE
ci: declare contents:read on sync-ruby workflow

### DIFF
--- a/.github/workflows/sync-ruby.yml
+++ b/.github/workflows/sync-ruby.yml
@@ -2,6 +2,9 @@ name: Sync ruby
 on:
   push:
     branches: [master]
+permissions:
+  contents: read
+
 jobs:
   sync:
     name: Sync ruby


### PR DESCRIPTION
Adds `permissions: contents: read` at the workflow level on `.github/workflows/sync-ruby.yml`. The job already uses `actions/create-github-app-token` to mint a separate App token for the cross-repo dispatch, so `GITHUB_TOKEN` itself only ever needs read access for the initial checkout. The workflow is already SHA-pinned and sets `persist-credentials: false`, which is great defensive hygiene; this is the small remaining piece.

The motivation for being explicit even when the inherited default may already be reasonable is CVE-2025-30066 - the March 2025 `tj-actions/changed-files` compromise where a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs. The blast radius matched the issued scope. Pinning per workflow caps the runtime authority of every action in the chain regardless of the org default and survives a future default-widening change. OpenSSF Scorecard's Token-Permissions check also only credits explicit per-workflow declarations.

YAML validated locally with `yaml.safe_load`.
