### PR TITLE
Remove pessimistic versioning in gem command output

### DIFF
--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -56,7 +56,7 @@ then repackaging it.
     if options[:version] != Gem::Requirement.default &&
        get_all_gem_names.size > 1
       alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
-                  " version requirements using `gem fetch 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
+                  " version requirements using `gem fetch 'my_gem:1.0.0' 'my_other_gem:>=2'`"
       terminate_interaction 1
     end
   end

--- a/lib/rubygems/commands/help_command.rb
+++ b/lib/rubygems/commands/help_command.rb
@@ -90,7 +90,9 @@ Use #gem to declare which gems you directly depend upon:
 
 To depend on a specific set of versions:
 
-  gem 'rake', '~> 10.3', '>= 10.3.2'
+  gem 'rake', '>= 10.3.2'
+  # or for multiple version restrictions
+  gem 'rake', '>= 10.3.2', "< 13"
 
 RubyGems will require the gem name when activating the gem using
 the RUBYGEMS_GEMDEPS environment variable or Gem::use_gemdeps.  Use the

--- a/lib/rubygems/commands/install_command.rb
+++ b/lib/rubygems/commands/install_command.rb
@@ -140,7 +140,7 @@ You can use `i` command instead of `install`.
     if options[:version] != Gem::Requirement.default &&
        get_all_gem_names.size > 1
       alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
-                  " version requirements using `gem install 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
+                  " version requirements using `gem install 'my_gem:1.0.0' 'my_other_gem:>=2'`"
       terminate_interaction 1
     end
   end

--- a/lib/rubygems/commands/uninstall_command.rb
+++ b/lib/rubygems/commands/uninstall_command.rb
@@ -117,7 +117,7 @@ that is a dependency of an existing gem.  You can use the
     if options[:version] != Gem::Requirement.default &&
        get_all_gem_names.size > 1
       alert_error "Can't use --version with multiple gems. You can specify multiple gems with" \
-                  " version requirements using `gem uninstall 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
+                  " version requirements using `gem uninstall 'my_gem:1.0.0' 'my_other_gem:>=2'`"
       terminate_interaction 1
     end
   end

--- a/test/rubygems/test_gem_commands_fetch_command.rb
+++ b/test/rubygems/test_gem_commands_fetch_command.rb
@@ -157,7 +157,7 @@ class TestGemCommandsFetchCommand < Gem::TestCase
     execute_with_term_error
 
     msg = "ERROR:  Can't use --version with multiple gems. You can specify multiple gems with" \
-      " version requirements using `gem fetch 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
+      " version requirements using `gem fetch 'my_gem:1.0.0' 'my_other_gem:>=2'`"
 
     assert_empty @ui.output
     assert_equal msg, @ui.error.chomp

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -880,7 +880,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_empty @cmd.installed_specs
 
     msg = "ERROR:  Can't use --version with multiple gems. You can specify multiple gems with" \
-      " version requirements using `gem install 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
+      " version requirements using `gem install 'my_gem:1.0.0' 'my_other_gem:>=2'`"
 
     assert_empty @ui.output
     assert_equal msg, @ui.error.chomp

--- a/test/rubygems/test_gem_commands_uninstall_command.rb
+++ b/test/rubygems/test_gem_commands_uninstall_command.rb
@@ -513,7 +513,7 @@ WARNING:  Use your OS package manager to uninstall vendor gems
     end
 
     msg = "ERROR:  Can't use --version with multiple gems. You can specify multiple gems with" \
-      " version requirements using `gem uninstall 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`"
+      " version requirements using `gem uninstall 'my_gem:1.0.0' 'my_other_gem:>=2'`"
 
     assert_empty @ui.output
     assert_equal msg, @ui.error.lines.last.chomp


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

At the recent developer meeting, we discussed switching from using pessimistic versioning by default to using optimistic versioning by default.

## What is your fix for the problem, implemented in this PR?

Switch examples to use `>=2` instead of `~>2.0.0` (which is really terrible as you are limited to 2.0.x versions).

For the help output, show a simpler example with a single version restriction, before an example with multiple version restrictions.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
