### PR TITLE
Fix a bug that `Gem::YAMLSerializer.load` ignores quotation

### DIFF
--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -95,6 +95,25 @@ module Gem
 
         if stripped.start_with?("- ") || stripped == "-"
           parse_sequence(indent, anchor)
+        elsif stripped.start_with?("\"") && stripped.end_with?("\"")
+          # We don't need to care about the following case here:
+          #   1. "value with comment" # ...
+          #   2. "key": "value"
+          #
+          # 1. must not happen because YAMLSerializer doesn't emit any
+          # comment. YAMLSerializer parses only YAML that is generated
+          # by YAMLSerializer.
+          #
+          # 2. must not happen because #parse_node isn't used non
+          # top-level mapping. Non top-level mapping always uses
+          # #parse_mapping. Top-level mapping never use the '"key":
+          # "value"' form because all top-level keys
+          # ("!ruby/object:Gem::Specification"'s keys) are known and
+          # #emit_specification doesn't quote anything.
+          parse_plain_scalar(indent, anchor)
+        elsif stripped.start_with?("'") && stripped.end_with?("'")
+          # See also the above note for double quotation.
+          parse_plain_scalar(indent, anchor)
         elsif stripped =~ MAPPING_KEY_RE && !stripped.start_with?("!ruby/object:")
           parse_mapping(indent, anchor)
         elsif stripped.start_with?("!ruby/object:")

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -318,6 +318,20 @@ class TestGemSafeYAML < Gem::TestCase
     assert_kind_of Hash, reqs
   end
 
+  def test_requirement_quote
+    yaml = <<~YAML
+      requirements:
+        - "system: arrow-glib>=25.0.0: amazon_linux: arrow-glib-devel"
+        - 'system: arrow-glib>=25.0.0: fedora: libarrow-glib-devel'
+    YAML
+
+    expected = [
+      "system: arrow-glib>=25.0.0: amazon_linux: arrow-glib-devel",
+      "system: arrow-glib>=25.0.0: fedora: libarrow-glib-devel",
+    ]
+    assert_equal expected, yaml_load(yaml)["requirements"]
+  end
+
   def test_rdoc_options_hash_converted_to_array
     # Some gemspecs incorrectly have rdoc_options: {} instead of rdoc_options: []
     yaml = <<~YAML


### PR DESCRIPTION
Fix #9551

## What was the end-user or developer problem that led to this PR?

`.gemspec` is serialized to YAML (`metadata.gz`) in `.gem`. `metadata.gz` may use double quote for string value like:

```yaml
requirements:
  - "system: arrow-glib>=25.0.0: amazon_linux: arrow-glib-devel"
```

`Gem::YAMLSerializer.load` ignores the quotation and parses it as a map:

```ruby
{
  "requirements" => [
    {"\"system" => "arrow-glib>=25.0.0: amazon_linux: arrow-glib-devel\""},
  ]
}
```    

## What is your fix for the problem, implemented in this PR?

Recognize quotation and parse quoted value as a string value.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
