### PR TITLE
Fix two issues by including the ruby platform variants in the lock file

### DIFF
--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -77,7 +77,7 @@ module Bundler
         gemfile_specs + dependency_specs
       end
 
-      specs.sort_by(&:name).uniq(&:name).each do |current_spec|
+      specs_for_outdated_check(specs).each do |current_spec|
         next unless gems.empty? || gems.include?(current_spec.name)
 
         active_spec = retrieve_active_spec(definition, current_spec)
@@ -150,6 +150,12 @@ module Bundler
       else
         "Bundle up to date!\n"
       end
+    end
+
+    def specs_for_outdated_check(specs)
+      specs.group_by(&:name).values.filter_map do |matching_specs|
+        MatchPlatform.select_best_platform_match(matching_specs, Bundler.local_platform).first || matching_specs.first
+      end.sort_by(&:name)
     end
 
     def retrieve_active_spec(definition, current_spec)

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -9,7 +9,8 @@ module Bundler
     include ForcePlatform
 
     attr_reader :name, :version, :platform, :materialization
-    attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version, :overrides
+    attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version
+    attr_accessor :overrides, :locked_platforms
 
     #
     # For backwards compatibility with existing lockfiles, if the most specific
@@ -49,6 +50,7 @@ module Bundler
       @force_ruby_platform = default_force_ruby_platform
       @most_specific_locked_platform = nil
       @materialization = nil
+      @locked_platforms = nil
     end
 
     def missing?
@@ -145,7 +147,7 @@ module Bundler
         # Exact spec is incompatible; in frozen mode, try to find a compatible platform variant
         # In non-frozen mode, return nil to trigger re-resolution and lockfile update
         if Bundler.frozen_bundle?
-          materialize([name, version]) {|specs| resolve_best_platform(specs) }
+          materialize([name, version]) {|specs| resolve_best_platform(specs, locked_platforms_only: true) }
         end
       else
         materialize([name, version]) {|specs| resolve_best_platform(specs) }
@@ -186,12 +188,12 @@ module Bundler
     # Try platforms in order of preference until finding a compatible spec.
     # Used for legacy lockfiles and as a fallback when the exact locked spec
     # is incompatible. Falls back to frozen bundle behavior if none match.
-    def resolve_best_platform(specs)
-      find_compatible_platform_spec(specs) || frozen_bundle_fallback(specs)
+    def resolve_best_platform(specs, locked_platforms_only: false)
+      find_compatible_platform_spec(specs, locked_platforms_only: locked_platforms_only) || frozen_bundle_fallback(specs)
     end
 
-    def find_compatible_platform_spec(specs)
-      candidate_platforms.each do |plat|
+    def find_compatible_platform_spec(specs, locked_platforms_only: false)
+      candidate_platforms(locked_platforms_only: locked_platforms_only).each do |plat|
         candidates = MatchPlatform.select_best_platform_match(specs, plat)
         spec = choose_compatible(candidates, fallback_to_non_installable: false)
         return spec if spec
@@ -201,9 +203,12 @@ module Bundler
 
     # Platforms to try in order of preference. Ruby platform is last since it
     # requires compilation, but works when precompiled gems are incompatible.
-    def candidate_platforms
+    def candidate_platforms(locked_platforms_only: false)
       target = source.is_a?(Source::Path) ? platform : Bundler.local_platform
-      [target, platform, Gem::Platform::RUBY].uniq
+      platforms = [target, platform, Gem::Platform::RUBY].uniq
+      return platforms unless locked_platforms_only && locked_platforms
+
+      platforms & locked_platforms
     end
 
     # In frozen mode, accept any candidate. Will error at install time.

--- a/bundler/lib/bundler/materialization.rb
+++ b/bundler/lib/bundler/materialization.rb
@@ -12,6 +12,7 @@ module Bundler
       @dep = dep
       @platform = platform
       @candidates = candidates
+      set_locked_platforms
     end
 
     def complete?
@@ -55,5 +56,14 @@ module Bundler
     private
 
     attr_reader :dep, :platform
+
+    def set_locked_platforms
+      return unless @candidates
+
+      platforms = @candidates.map(&:platform)
+      @candidates.each do |candidate|
+        candidate.locked_platforms = platforms if candidate.respond_to?(:locked_platforms=)
+      end
+    end
   end
 end

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -305,10 +305,14 @@ module Bundler
           next groups if package.force_ruby_platform?
         end
 
-        platform_group = Resolver::SpecGroup.new(platform_specs.flatten.uniq)
+        platform_specs = platform_specs.flatten.uniq
+        platform_group = Resolver::SpecGroup.new((platform_specs + ruby_specs).uniq)
         next groups if platform_group == ruby_group
 
         groups << Resolver::Candidate.new(version, group: platform_group, priority: 1)
+
+        platform_only_group = Resolver::SpecGroup.new(platform_specs)
+        groups << Resolver::Candidate.new(version, group: platform_only_group, priority: 0) unless platform_only_group == platform_group
 
         groups
       end

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -1083,8 +1083,10 @@ RSpec.describe "bundle lock" do
     simulate_platform("x86-mingw32") { bundle :lock }
 
     checksums = checksums_section_when_enabled do |c|
+      c.checksum gem_repo4, "ffi", "1.9.14"
       c.checksum gem_repo4, "ffi", "1.9.14", "x86-mingw32"
       c.checksum gem_repo4, "gssapi", "1.2.0"
+      c.checksum gem_repo4, "mixlib-shellout", "2.2.6"
       c.checksum gem_repo4, "mixlib-shellout", "2.2.6", "universal-mingw32"
       c.checksum gem_repo4, "win32-process", "0.8.3"
     end
@@ -1093,9 +1095,11 @@ RSpec.describe "bundle lock" do
       GEM
         remote: https://gem.repo4/
         specs:
+          ffi (1.9.14)
           ffi (1.9.14-x86-mingw32)
           gssapi (1.2.0)
             ffi (>= 1.0.1)
+          mixlib-shellout (2.2.6)
           mixlib-shellout (2.2.6-universal-mingw32)
             win32-process (~> 0.8.2)
           win32-process (0.8.3)

--- a/spec/install/gemfile/platform_spec.rb
+++ b/spec/install/gemfile/platform_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe "bundle install across platforms" do
         c.checksum gem_repo4, "empyrean", "0.1.0"
         c.checksum gem_repo4, "ffi", "1.9.23", "java"
         c.checksum gem_repo4, "method_source", "0.9.0"
+        c.checksum gem_repo4, "pry", "0.11.3"
         c.checksum gem_repo4, "pry", "0.11.3", "java"
         c.checksum gem_repo4, "spoon", "0.0.6"
       end
@@ -220,6 +221,9 @@ RSpec.describe "bundle install across platforms" do
             empyrean (0.1.0)
             ffi (1.9.23-java)
             method_source (0.9.0)
+            pry (0.11.3)
+              coderay (~> 1.1.0)
+              method_source (~> 0.9.0)
             pry (0.11.3-java)
               coderay (~> 1.1.0)
               method_source (~> 0.9.0)

--- a/spec/install/gemfile/specific_platform_spec.rb
+++ b/spec/install/gemfile/specific_platform_spec.rb
@@ -262,7 +262,62 @@ RSpec.describe "bundle install with specific platforms" do
       end
     end
 
-    it "installs the ruby variant but Bundler.setup still complains when only an incompatible platform-specific variant is locked" do
+    it "adds and installs the ruby variant when only an incompatible platform-specific variant was locked" do
+      build_repo4 do
+        build_gem "nokogiri", "1.18.10"
+        build_gem "nokogiri", "1.18.10" do |s|
+          s.platform = "x86_64-linux"
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+      end
+
+      gemfile <<~G
+        source "https://gem.repo4"
+
+        gem "nokogiri"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            nokogiri (1.18.10-x86_64-linux)
+
+        PLATFORMS
+          x86_64-linux
+
+        DEPENDENCIES
+          nokogiri
+
+        BUNDLED WITH
+          #{Bundler::VERSION}
+      L
+
+      simulate_platform "x86_64-linux" do
+        bundle "install --verbose"
+        expect(out).to include("Installing nokogiri 1.18.10")
+        expect(the_bundle).to include_gem("nokogiri 1.18.10")
+      end
+
+      expect(lockfile).to eq <<~L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            nokogiri (1.18.10)
+            nokogiri (1.18.10-x86_64-linux)
+
+        PLATFORMS
+          x86_64-linux
+
+        DEPENDENCIES
+          nokogiri
+
+        BUNDLED WITH
+          #{Bundler::VERSION}
+      L
+    end
+
+    it "fails at install time when only an incompatible platform-specific variant is locked" do
       build_repo4 do
         build_gem "nokogiri", "1.18.10"
         build_gem "nokogiri", "1.18.10" do |s|
@@ -295,14 +350,8 @@ RSpec.describe "bundle install with specific platforms" do
 
       simulate_platform "x86_64-linux" do
         bundle "install --verbose", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
-        expect(exitstatus).to eq(0)
-        expect(out).to include("Fetching nokogiri 1.18.10\n")
-        expect(out).to include("Installing nokogiri 1.18.10\n")
-
-        # FIXME: We should not install an alternative and then refuse to use it.
-        ruby "require 'bundler'; Bundler.setup", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
         expect(exitstatus).not_to eq(0)
-        expect(err).to include("Could not find nokogiri-1.18.10-x86_64-linux in locally installed gems")
+        expect(err).to include("nokogiri-1.18.10-x86_64-linux requires ruby version < #{Gem.ruby_version}")
       end
     end
   end
@@ -810,10 +859,13 @@ RSpec.describe "bundle install with specific platforms" do
       bundle "update --conservative nokogiri"
     end
 
+    checksums.checksum gem_repo4, "nokogiri", "1.13.0"
+
     expect(lockfile).to eq <<~L
       GEM
         remote: https://gem.repo4/
         specs:
+          nokogiri (1.13.0)
           nokogiri (1.13.0-x86_64-darwin)
           sorbet-static (0.5.10601-x86_64-darwin)
 
@@ -822,6 +874,61 @@ RSpec.describe "bundle install with specific platforms" do
 
       DEPENDENCIES
         nokogiri
+        sorbet-static
+      #{checksums}
+      BUNDLED WITH
+        #{Bundler::VERSION}
+    L
+  end
+
+  it "locks ruby fallback variant dependencies without adding the ruby platform" do
+    build_repo4 do
+      build_gem "native_tool", "1.0" do |s|
+        s.add_dependency "rake"
+      end
+
+      build_gem "native_tool", "1.0" do |s|
+        s.platform = "x86_64-linux"
+      end
+
+      build_gem "rake"
+
+      build_gem "sorbet-static", "0.5.10601" do |s|
+        s.platform = "x86_64-linux"
+      end
+    end
+
+    simulate_platform "x86_64-linux" do
+      install_gemfile <<~G
+        source "https://gem.repo4"
+
+        gem "native_tool"
+        gem "sorbet-static"
+      G
+    end
+
+    checksums = checksums_section_when_enabled do |c|
+      c.checksum gem_repo4, "native_tool", "1.0"
+      c.checksum gem_repo4, "native_tool", "1.0", "x86_64-linux"
+      c.checksum gem_repo4, "rake", "1.0"
+      c.checksum gem_repo4, "sorbet-static", "0.5.10601", "x86_64-linux"
+    end
+
+    expect(lockfile).to eq <<~L
+      GEM
+        remote: https://gem.repo4/
+        specs:
+          native_tool (1.0)
+            rake
+          native_tool (1.0-x86_64-linux)
+          rake (1.0)
+          sorbet-static (0.5.10601-x86_64-linux)
+
+      PLATFORMS
+        x86_64-linux
+
+      DEPENDENCIES
+        native_tool
         sorbet-static
       #{checksums}
       BUNDLED WITH

--- a/spec/install/gemfile/specific_platform_spec.rb
+++ b/spec/install/gemfile/specific_platform_spec.rb
@@ -261,6 +261,50 @@ RSpec.describe "bundle install with specific platforms" do
         expect(the_bundle).not_to include_gem("nokogiri 1.18.10 x86_64-linux")
       end
     end
+
+    it "installs the ruby variant but Bundler.setup still complains when only an incompatible platform-specific variant is locked" do
+      build_repo4 do
+        build_gem "nokogiri", "1.18.10"
+        build_gem "nokogiri", "1.18.10" do |s|
+          s.platform = "x86_64-linux"
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+      end
+
+      gemfile <<~G
+        source "https://gem.repo4"
+
+        gem "nokogiri"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            nokogiri (1.18.10-x86_64-linux)
+
+        PLATFORMS
+          x86_64-linux
+
+        DEPENDENCIES
+          nokogiri
+
+        BUNDLED WITH
+          #{Bundler::VERSION}
+      L
+
+      simulate_platform "x86_64-linux" do
+        bundle "install --verbose", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+        expect(exitstatus).to eq(0)
+        expect(out).to include("Fetching nokogiri 1.18.10\n")
+        expect(out).to include("Installing nokogiri 1.18.10\n")
+
+        # FIXME: We should not install an alternative and then refuse to use it.
+        ruby "require 'bundler'; Bundler.setup", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+        expect(exitstatus).not_to eq(0)
+        expect(err).to include("Could not find nokogiri-1.18.10-x86_64-linux in locally installed gems")
+      end
+    end
   end
 
   it "doesn't discard previously installed platform specific gem and fall back to ruby on subsequent bundles" do

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -1324,6 +1324,7 @@ RSpec.describe "the lockfile format" do
       G
 
       checksums = checksums_section_when_enabled do |c|
+        c.checksum gem_repo2, "platform_specific", "1.0"
         c.checksum gem_repo2, "platform_specific", "1.0", "universal-java-16"
       end
 
@@ -1331,6 +1332,7 @@ RSpec.describe "the lockfile format" do
         GEM
           remote: https://gem.repo2/
           specs:
+            platform_specific (1.0)
             platform_specific (1.0-universal-java-16)
 
         PLATFORMS

--- a/spec/resolver/platform_spec.rb
+++ b/spec/resolver/platform_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Resolving platform craziness" do
     should_resolve_as %w[foo-1.0.0]
   end
 
-  it "prefers the platform specific gem to the ruby version" do
+  it "prefers the platform specific gem to the ruby version, but keeps the ruby fallback" do
     @index = build_index do
       gem "foo", "1.0.0"
       gem "foo", "1.0.0", "x64-mingw-ucrt"
@@ -79,7 +79,7 @@ RSpec.describe "Resolving platform craziness" do
     dep "foo"
     platforms "x64-mingw-ucrt"
 
-    should_resolve_as %w[foo-1.0.0-x64-mingw-ucrt]
+    should_resolve_as %w[foo-1.0.0 foo-1.0.0-x64-mingw-ucrt]
   end
 
   describe "on a linux platform" do
@@ -88,7 +88,7 @@ RSpec.describe "Resolving platform craziness" do
     # Gem's platform is *-linux => gem is glibc + maybe musl compatible
     # Gem's platform is *-linux-musl => gem is musl compatible but not glibc
 
-    it "favors the platform version-specific gem on a version-specifying linux platform" do
+    it "favors the platform version-specific gem on a version-specifying linux platform, but keeps the ruby fallback" do
       @index = build_index do
         gem "foo", "1.0.0"
         gem "foo", "1.0.0", "x86_64-linux"
@@ -97,10 +97,10 @@ RSpec.describe "Resolving platform craziness" do
       dep "foo"
       platforms "x86_64-linux-musl"
 
-      should_resolve_as %w[foo-1.0.0-x86_64-linux-musl]
+      should_resolve_as %w[foo-1.0.0 foo-1.0.0-x86_64-linux-musl]
     end
 
-    it "favors the version-less gem over the version-specific gem on a gnu linux platform" do
+    it "favors the version-less gem over the version-specific gem on a gnu linux platform, but keeps the ruby fallback" do
       @index = build_index do
         gem "foo", "1.0.0"
         gem "foo", "1.0.0", "x86_64-linux"
@@ -109,7 +109,7 @@ RSpec.describe "Resolving platform craziness" do
       dep "foo"
       platforms "x86_64-linux"
 
-      should_resolve_as %w[foo-1.0.0-x86_64-linux]
+      should_resolve_as %w[foo-1.0.0 foo-1.0.0-x86_64-linux]
     end
 
     it "ignores the platform version-specific gem on a gnu linux platform" do
@@ -122,7 +122,7 @@ RSpec.describe "Resolving platform craziness" do
       should_not_resolve
     end
 
-    it "falls back to the platform version-less gem on a linux platform with a version" do
+    it "falls back to the platform version-less gem on a linux platform with a version, but keeps the ruby fallback" do
       @index = build_index do
         gem "foo", "1.0.0"
         gem "foo", "1.0.0", "x86_64-linux"
@@ -130,7 +130,7 @@ RSpec.describe "Resolving platform craziness" do
       dep "foo"
       platforms "x86_64-linux-musl"
 
-      should_resolve_as %w[foo-1.0.0-x86_64-linux]
+      should_resolve_as %w[foo-1.0.0 foo-1.0.0-x86_64-linux]
     end
 
     it "falls back to the ruby platform gem on a gnu linux platform when only a version-specifying gem is available" do


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

2 issues:
- When the lock file only contains platform specific variants but install is being done by a version of ruby that doesn't work with the platform version bundler will install the ruby variant... but then at setup time it errors because it looks for the platform variant and it isn't there.  bundler doesn't need to install an alternative that doesn't satisfy it's own requirements.  The first commit adds a test that verifies this behavior (the second commit updates the test to fail earlier but with a suggestion people can use to resolve the issue).
- It's been a long standing issue that you can't easily retain the ruby platform variant of some gems (by adding "ruby" to the list of platforms) if not all gems support it.  This separates those two concepts by locking the ruby platform variant without requiring all gems to support the "ruby" platform.  By updating your lockfile this way you can resolve the previous issue (and also stop having to edit the lock file by hand). 

## What is your fix for the problem, implemented in this PR?

Keep the ruby variants and their dependencies in the lockfile when they would be useful as a fallback regardless of whether the ruby platform is included.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
