### PR TITLE
Do not hard-code permissions for new gem directories during bundle install

### DIFF
--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -20,7 +20,7 @@ module Bundler
       strict_rm_rf spec.extension_dir
 
       SharedHelpers.filesystem_access(gem_dir, :create) do
-        FileUtils.mkdir_p gem_dir, mode: 0o755
+        FileUtils.mkdir_p gem_dir
       end
 
       SharedHelpers.filesystem_access(gem_dir, :write) do

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -1332,7 +1332,13 @@ RSpec.describe "bundle install with gem sources" do
         bundle :install
         expect(out).to include("Bundle complete!")
         expect(err).to be_empty
-        expect(File.stat(foo_path).mode & 0o7777).to eq(0o2775)
+        # Linux's SysV-derived mkdir(2) propagates the set-group-ID bit
+        # from the parent directory to newly created subdirectories. BSD
+        # (including macOS) inherits the parent's group via mkdir(2) but
+        # does not copy the set-group-ID bit itself, so the expected
+        # mode differs by platform.
+        expected = RUBY_PLATFORM.include?("darwin") ? 0o0775 : 0o2775
+        expect(File.stat(foo_path).mode & 0o7777).to eq(expected)
       end
     end
   end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -1306,6 +1306,37 @@ RSpec.describe "bundle install with gem sources" do
     end
   end
 
+  describe "when using umask 002 and setgid bit", :permissions do
+    let(:gems_path) { bundled_app("vendor/#{Bundler.ruby_scope}/gems") }
+    let(:foo_path) { gems_path.join("foo-1.0.0") }
+
+    before do
+      build_repo4 do
+        build_gem "foo", "1.0.0" do |s|
+          s.write "CHANGELOG.md", "foo"
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo4"
+        gem 'foo'
+      G
+
+      FileUtils.mkdir_p(gems_path)
+      FileUtils.chmod("g+s", gems_path)
+    end
+
+    it "should create the gem directory with proper permissions" do
+      with_umask(0o002) do
+        bundle_config "path vendor"
+        bundle :install
+        expect(out).to include("Bundle complete!")
+        expect(err).to be_empty
+        expect(File.stat(foo_path).mode & 0o7777).to eq(0o2775)
+      end
+    end
+  end
+
   describe "parallel make" do
     before do
       unless Gem::Installer.private_method_defined?(:build_jobs)


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

This fixes #9395. Without this change, when running `bundle install`, any newly created gem directory has permissions `rwxr-xr-x` regardless of `umask` settings and regardless of the set-group-ID bit of the parent directory. This makes it much harder to remove gems in a multi-user environment (for example, where different developers have conducted deployments). It also differs from the behavior of `gem install ...`, which does respect the umask and the set-group-ID bit.

## What is your fix for the problem, implemented in this PR?

The `mode: 0o755` argument was removed from the `FileUtils.mkdir_p` call that creates the new directory for the gem being installed. This avoids setting specific permissions and lets the system's default permission handling (such as umask and set-group-ID bits) function.

The hard-coding was originally set up in 79386f4 as part of what appeared to be an unrelated reimplementation of `Bundler::RubyGemsGemInstaller#install`. Previous to that commit, Bundler::RubyGemsGemInstaller was using the implementation in the parent class, `GemInstaller#install`. In the commit, the implementation from GemInstaller was copied and then modified to fit Bundler's needs, removing code that wasn't necessary for Bundler. However, I believe a mistake was made during that modification. In the GemInstaller implementation, the relevant lines looked like this: https://github.com/ruby/rubygems/blob/79386f420a901cd26ba8f9a1a1378cf0ad9fc3f8/lib/rubygems/installer.rb#L303-L304

In that case, if `options[:dir_mode]` was nil, then the resulting call was `FileUtils.mkdir_p gem_dir, :mode => nil`, which was equivalent to `FileUtils.mkdir_p gem_dir`. If `options[:dir_mode]` was truthy, then the call was `FileUtils.mkdir_p gem_dir, :mode => 0755`. (Note that there was a line further down that ran `File.chmod(dir_mode, gem_dir) if dir_mode`.) My impression is that usually `options[:dir_mode]` is not set. 

After 79386f4, the Bundler implementation was: https://github.com/ruby/rubygems/blob/79386f420a901cd26ba8f9a1a1378cf0ad9fc3f8/bundler/lib/bundler/rubygems_gem_installer.rb#L22

This made it so that the `FileUtils.mkdir_p` call always set the `mode` parameter, instead of hardly ever. I suspect that the code `dir_mode && 0755` (using the short-circuiting operator) may have been misread as `dir_mode & 0755` (using the bitwise AND method). The bitwise-AND reading was how I read the code at first glance, and it would make sense that such an interpretation would lead someone to change the code to simply `0755` when removing `dir_mode`.

There have been some updates to both implementations since 79386f4, but nothing that affects the reasoning above. I saw no mentions of the permissions change in the commit message or associated pull request, and given that `gem install` continues to have the old behavior, I believe the change was unintentional. It is much more complicated to fix the permissions after the fact without invoking superuser privileges, so I think the right place to make the adjustment is here, where the files are being created.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)