### PR TITLE
Add `--sig` and `--no-sig` flag for RBS signatures

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -584,6 +584,7 @@ module Bundler
     method_option :linter, type: :string, lazy_default: Bundler.settings["gem.linter"] || "", enum: %w[rubocop standard], banner: "Add a linter and code formatter, either RuboCop or Standard. Set a default with `bundle config set --global gem.linter (rubocop|standard)`"
     method_option :github_username, type: :string, default: Bundler.settings["gem.github_username"], banner: "Set your username on GitHub", desc: "Fill in GitHub username on README so that you don't have to do it manually. Set a default with `bundle config set --global gem.github_username <your_username>`."
     method_option :bundle, type: :boolean, default: Bundler.settings["gem.bundle"], banner: "Automatically run `bundle install` after creation. Set a default with `bundle config set --global gem.bundle true`"
+    method_option :sig, type: :boolean, default: true, banner: "Generate signatures for your library."
 
     def gem(name)
       require_relative "cli/gem"

--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -82,6 +82,7 @@ module Bundler
         homepage_uri: homepage_uri,
         source_code_uri: source_code_uri,
         changelog_uri: changelog_uri,
+        sig: options[:sig],
       }
       ensure_safe_gem_name(name, constant_array)
 
@@ -89,7 +90,6 @@ module Bundler
         "Gemfile.tt" => Bundler.preferred_gemfile_name,
         "lib/newgem.rb.tt" => "lib/#{namespaced_path}.rb",
         "lib/newgem/version.rb.tt" => "lib/#{namespaced_path}/version.rb",
-        "sig/newgem.rbs.tt" => "sig/#{namespaced_path}.rbs",
         "newgem.gemspec.tt" => "#{name}.gemspec",
         "Rakefile.tt" => "Rakefile",
         "README.md.tt" => "README.md",
@@ -247,6 +247,12 @@ module Bundler
         )
 
         config[:go_module_username] = config[:github_username] == DEFAULT_GITHUB_USERNAME ? "username" : config[:github_username]
+      end
+
+      if config[:sig]
+        templates.merge!(
+          "sig/newgem.rbs.tt" => "sig/#{namespaced_path}.rbs",
+        )
       end
 
       if target.exist? && !target.directory?

--- a/bundler/lib/bundler/man/bundle-gem.1
+++ b/bundler/lib/bundler/man/bundle-gem.1
@@ -100,6 +100,12 @@ Run \fBbundle install\fR after creating the gem\.
 .TP
 \fB\-\-no\-bundle\fR
 Do not run \fBbundle install\fR after creating the gem\.
+.TP
+\fB\-\-sig\fR
+Create RBS signatures (in \fBsig/\fR, matching the structure in \fBlib/\fR)\. This behavior is enabled by default\.
+.TP
+\fB\-\-no\-sig\fR
+Do not add RBS signatures\.
 .SH "SEE ALSO"
 .IP "\(bu" 4
 bundle config(1) \fIbundle\-config\.1\.html\fR

--- a/bundler/lib/bundler/man/bundle-gem.1.ronn
+++ b/bundler/lib/bundler/man/bundle-gem.1.ronn
@@ -145,6 +145,13 @@ configuration file using the following names:
 * `--no-bundle`:
   Do not run `bundle install` after creating the gem.
 
+* `--sig`:
+  Create RBS signatures (in `sig/`, matching the structure in `lib/`). This
+  behavior is enabled by default.
+
+* `--no-sig`:
+  Do not add RBS signatures.
+
 ## SEE ALSO
 
 * [bundle config(1)](bundle-config.1.html)

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -1367,6 +1367,22 @@ RSpec.describe "bundle gem" do
     end
   end
 
+  context "--sig option" do
+    context "with --sig" do
+      it "includes rbs signatures" do
+        bundle "gem #{gem_name} --sig"
+        expect(bundled_app("#{gem_name}/sig/#{gem_name}.rbs")).to exist
+      end
+    end
+
+    context "with --no-sig" do
+      it "does not include rbs signatures" do
+        bundle "gem #{gem_name} --no-sig"
+        expect(bundled_app("#{gem_name}/sig/#{gem_name}.rbs")).not_to exist
+      end
+    end
+  end
+
   shared_examples_for "paths that depend on gem name" do
     it "generates entrypoint, version file and signatures file at the proper path, with the proper content" do
       bundle "gem #{gem_name}"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

I do not tend to use RBS signatures, so when I create a new gem I would like the option to not generate them in the first place.

## What is your fix for the problem, implemented in this PR?

This adds `--sig` and `--no-sig` so the user can specify whether or not they want signatures. The default is enabled so nothing changes for anybody used the existing behavior unless they opt in.

I understand based on discussion in #5041 that this was deemed unnecessary (specifically https://github.com/ruby/rubygems/pull/5041#issuecomment-982335015), but I think that after a few years of having RBS signatures available it seems that usage is not so universal as to justify having no opt out (besides deleting the files). I didn't add any persistent config to make `--no-sig` a system default since it seems like we probably like having the nudge towards using RBS signatures by default, but at least in my own use of `bundle gem` I would appreciate being able to turn it off.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
