### PR TITLE
[DOC] Fix the location of #9268

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+#--
+# Workaround for directly loading Gem::Version in some cases
+module Gem; end
+#++
+
 ##
 # The Version class processes string versions into comparable
 # values. A version string should normally be a series of numbers
@@ -165,9 +170,6 @@
 # version constraint would likely be warranted. However, outside of
 # specific situations, you should avoid using pessimistic versioning, as the
 # costs typically exceed the benefits.
-
-# Workaround for directly loading Gem::Version in some cases
-module Gem; end
 
 class Gem::Version
   include Comparable


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Because this module declaration is interrupted between the `Gem::Version` document and the definition, the document is not currently recognized as a document.

In addition, the comment is not a document for the entire `Gem` module, but is included as part of the module documentation.

## What is your fix for the problem, implemented in this PR?

Move the module before the `Gem::Version` document, and stop documenting the comment.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
