### PR TITLE
Remove version constraints on dev dependencies

### DIFF
--- a/bundler/lib/bundler/cli/gem.rb
+++ b/bundler/lib/bundler/cli/gem.rb
@@ -7,12 +7,6 @@ module Bundler
   end
 
   class CLI::Gem
-    TEST_FRAMEWORK_VERSIONS = {
-      "rspec" => "3.0",
-      "minitest" => "5.16",
-      "test-unit" => "3.0",
-    }.freeze
-
     DEFAULT_GITHUB_USERNAME = "[USERNAME]"
 
     attr_reader :options, :gem_name, :thor, :name, :target, :extension
@@ -117,7 +111,6 @@ module Bundler
 
       if test_framework = ask_and_set_test_framework
         config[:test] = test_framework
-        config[:test_framework_version] = TEST_FRAMEWORK_VERSIONS[test_framework]
 
         case test_framework
         when "rspec"
@@ -203,12 +196,10 @@ module Bundler
       config[:linter] = ask_and_set_linter
       case config[:linter]
       when "rubocop"
-        config[:linter_version] = rubocop_version
         Bundler.ui.info "RuboCop enabled in config"
         templates.merge!("rubocop.yml.tt" => ".rubocop.yml")
         config[:ignore_paths] << ".rubocop.yml"
       when "standard"
-        config[:linter_version] = standard_version
         Bundler.ui.info "Standard enabled in config"
         templates.merge!("standard.yml.tt" => ".standard.yml")
         config[:ignore_paths] << ".standard.yml"
@@ -470,14 +461,6 @@ module Bundler
 
     def required_ruby_version
       "3.2.0"
-    end
-
-    def rubocop_version
-      "1.21"
-    end
-
-    def standard_version
-      "1.3"
     end
 
     def github_username(git_username)

--- a/bundler/lib/bundler/templates/newgem/Gemfile.tt
+++ b/bundler/lib/bundler/templates/newgem/Gemfile.tt
@@ -13,12 +13,12 @@ gem "rake-compiler"
 <%- end -%>
 <%- if config[:test] -%>
 
-gem "<%= config[:test] %>", ">= <%= config[:test_framework_version] %>"
+gem "<%= config[:test] %>"
 <%- end -%>
 <%- if config[:linter] == "rubocop" -%>
 
-gem "rubocop", ">= <%= config[:linter_version] %>"
+gem "rubocop"
 <%- elsif config[:linter] == "standard" -%>
 
-gem "standard", ">= <%= config[:linter_version] %>"
+gem "standard"
 <%- end -%>

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -208,7 +208,8 @@ RSpec.describe "bundle gem" do
       builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
       builder.dependencies
       rubocop_dep = builder.dependencies.find {|d| d.name == "rubocop" }
-      expect(rubocop_dep).not_to be_nil
+      expect(rubocop_dep).not_to be_specific
+      expect(rubocop_dep.requirement).to eq(Gem::Requirement.new([">= 0"]))
     end
 
     it "generates a default .rubocop.yml" do
@@ -239,7 +240,8 @@ RSpec.describe "bundle gem" do
       builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
       builder.dependencies
       standard_dep = builder.dependencies.find {|d| d.name == "standard" }
-      expect(standard_dep).not_to be_nil
+      expect(standard_dep).not_to be_specific
+      expect(standard_dep.requirement).to eq(Gem::Requirement.new([">= 0"]))
     end
 
     it "generates a default .standard.yml" do
@@ -746,13 +748,14 @@ RSpec.describe "bundle gem" do
       expect(ignore_paths).to include("spec/")
     end
 
-    it "depends on a specific version of rspec in generated Gemfile" do
+    it "depends on a non-specific version of rspec in generated Gemfile" do
       allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       builder = Bundler::Dsl.new
       builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
       builder.dependencies
       rspec_dep = builder.dependencies.find {|d| d.name == "rspec" }
       expect(rspec_dep).not_to be_specific
+      expect(rspec_dep.requirement).to eq(Gem::Requirement.new([">= 0"]))
     end
   end
 
@@ -831,13 +834,14 @@ RSpec.describe "bundle gem" do
       bundle "gem #{gem_name} --test=minitest"
     end
 
-    it "depends on a specific version of minitest" do
+    it "depends on a non-specific version of minitest" do
       allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       builder = Bundler::Dsl.new
       builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
       builder.dependencies
       minitest_dep = builder.dependencies.find {|d| d.name == "minitest" }
       expect(minitest_dep).not_to be_specific
+      expect(minitest_dep.requirement).to eq(Gem::Requirement.new([">= 0"]))
     end
 
     it "builds spec skeleton" do
@@ -892,13 +896,14 @@ RSpec.describe "bundle gem" do
       bundle "gem #{gem_name} --test=test-unit"
     end
 
-    it "depends on a specific version of test-unit" do
+    it "depends on a non-specific version of test-unit" do
       allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
       builder = Bundler::Dsl.new
       builder.eval_gemfile(bundled_app("#{gem_name}/Gemfile"))
       builder.dependencies
       test_unit_dep = builder.dependencies.find {|d| d.name == "test-unit" }
       expect(test_unit_dep).not_to be_specific
+      expect(test_unit_dep.requirement).to eq(Gem::Requirement.new([">= 0"]))
     end
 
     it "builds spec skeleton" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

See #9562

## What is your fix for the problem, implemented in this PR?

Bundler doesn't need to have an opinion on the current version of these tools. We can just include them without specific constraint, and if the user doesn't want the most recent version for some reason they can add the necessary constraint themselves.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
