### PR TITLE
Document and test all available gemrc configuration keys

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -26,9 +26,22 @@ require "rbconfig"
 # RubyGems options use symbol keys.  Valid options are:
 #
 # +:backtrace+:: See #backtrace
-# +:sources+:: Sets Gem::sources
+# +:bulk_threshold+:: See #bulk_threshold
 # +:verbose+:: See #verbose
+# +:update_sources+:: See #update_sources
 # +:concurrent_downloads+:: See #concurrent_downloads
+# +:cert_expiration_length_days+:: See #cert_expiration_length_days
+# +:install_extension_in_lib+:: See #install_extension_in_lib
+# +:ipv4_fallback_enabled+:: See #ipv4_fallback_enabled
+# +:global_gem_cache+:: See #global_gem_cache
+# +:use_psych+:: See #use_psych
+# +:gemhome+:: See #home
+# +:gempath+:: See #path
+# +:sources+:: Sets Gem::sources
+# +:disable_default_gem_server+:: See #disable_default_gem_server
+# +:ssl_verify_mode+:: See #ssl_verify_mode
+# +:ssl_ca_cert+:: See #ssl_ca_cert
+# +:ssl_client_cert+:: See #ssl_client_cert
 #
 # gemrc files may exist in various locations and are read and merged in
 # the following order:

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -53,6 +53,7 @@ class TestGemConfigFile < Gem::TestCase
       fp.puts ":sources:"
       fp.puts "  - http://more-gems.example.com"
       fp.puts "install: --wrappers"
+      fp.puts ":gemhome: /tmp/gems"
       fp.puts ":gempath:"
       fp.puts "- /usr/ruby/1.8/lib/ruby/gems/1.8"
       fp.puts "- /var/ruby/1.8/gem_home"
@@ -61,6 +62,7 @@ class TestGemConfigFile < Gem::TestCase
       fp.puts ":cert_expiration_length_days: 28"
       fp.puts ":install_extension_in_lib: false"
       fp.puts ":ipv4_fallback_enabled: true"
+      fp.puts ":use_psych: true"
     end
 
     util_config_file
@@ -70,6 +72,7 @@ class TestGemConfigFile < Gem::TestCase
     assert_equal false, @cfg.update_sources
     assert_equal %w[http://more-gems.example.com], @cfg.sources
     assert_equal "--wrappers", @cfg[:install]
+    assert_equal "/tmp/gems", @cfg.home
     assert_equal(["/usr/ruby/1.8/lib/ruby/gems/1.8", "/var/ruby/1.8/gem_home"],
                  @cfg.path)
     assert_equal 0, @cfg.ssl_verify_mode
@@ -77,6 +80,7 @@ class TestGemConfigFile < Gem::TestCase
     assert_equal 28, @cfg.cert_expiration_length_days
     assert_equal false, @cfg.install_extension_in_lib
     assert_equal true, @cfg.ipv4_fallback_enabled
+    assert_equal true, @cfg.use_psych
   end
 
   def test_initialize_ipv4_fallback_enabled_env
@@ -105,7 +109,7 @@ class TestGemConfigFile < Gem::TestCase
 
   def test_initialize_global_gem_cache_gemrc
     File.open @temp_conf, "w" do |fp|
-      fp.puts "global_gem_cache: true"
+      fp.puts ":global_gem_cache: true"
     end
 
     util_config_file %W[--config-file #{@temp_conf}]
@@ -113,9 +117,19 @@ class TestGemConfigFile < Gem::TestCase
     assert_equal true, @cfg.global_gem_cache
   end
 
+  def test_initialize_use_psych_env
+    orig_use_psych = ENV["RUBYGEMS_USE_PSYCH"]
+    ENV["RUBYGEMS_USE_PSYCH"] = "true"
+    util_config_file %W[--config-file #{@temp_conf}]
+
+    assert_equal true, @cfg.use_psych
+  ensure
+    ENV["RUBYGEMS_USE_PSYCH"] = orig_use_psych
+  end
+
   def test_initialize_concurrent_downloads
     File.open @temp_conf, "w" do |fp|
-      fp.puts "concurrent_downloads: 2"
+      fp.puts ":concurrent_downloads: 2"
     end
 
     util_config_file %W[--config-file #{@temp_conf}]


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

I noticed that some gemrc configuration keys were not documented in the current [RubyGems ConfigFile document page](https://docs.ruby-lang.org/en/master/Gem/ConfigFile.html).

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

I documented the missing gemrc configuration keys, and added and updated tests for gemrc configuration use_psych and gemhome keys that didn't have the assertions.

The documented configuration key order aligns with the following part.

https://github.com/ruby/rubygems/blob/287175d4ae57340e22c6f1d21da1489d7dac35c5/lib/rubygems/config_file.rb#L240-L257

I fixed test_initialize_global_gem_cache_gemrc and
test_initialize_concurrent_downloads to test with symbolic keys, as global_gem_cache and use_psych keys are documented as a symbolic key.

I tested with the following Ruby in Fedora Linux 43.

```
$ which ruby
~/.local/ruby-4.1.0-debug-3ef48ef9c8-openssl-4.1.0-7194354488/bin/ruby

$ ruby -v
ruby 4.1.0dev (2026-05-19T11:31:50Z master 3ef48ef9c8) +PRISM [x86_64-linux]
```

I confirmed the updated document page by the following commands:

```
$ bin/rake docs:server
...
Serving documentation at: http://localhost:4000
Press Ctrl+C to stop.

$ firefox http://localhost:4000/Gem/ConfigFile.html
```

I tested the updated test file by the following command:

```
$ ruby -Ilib:test:bundler/lib test/rubygems/test_gem_config_file.rb
Loaded suite test/rubygems/test_gem_config_file
Started
..........................................
Finished in 0.169670163 seconds.
-----------------------------------------------------------------------------------------------------------------------------
42 tests, 199 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------
247.54 tests/s, 1172.86 assertions/s
Coverage report generated for rubygems to /home/jaruga/var/git/ruby/rubygems/coverage.
Line Coverage: 33.56% (1766 / 5263)
```

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
