### PR TITLE
Add `bin/test-unit` for single-file test runs

### DIFF
--- a/bin/test-unit
+++ b/bin/test-unit
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../spec/support/switch_rubygems"
+require_relative "../spec/support/rubygems_ext"
+
+$LOAD_PATH.unshift File.expand_path("../test", __dir__)
+
+Spec::Rubygems.gem_load("test-unit", "test-unit")

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -45,11 +45,11 @@ To run the entire RubyGems test suite:
 
 To run an individual test file, for example `test/rubygems/test_deprecate.rb`:
 
-    ruby -Ilib:test:bundler/lib test/rubygems/test_deprecate.rb
+    bin/test-unit test/rubygems/test_deprecate.rb
 
 To run a specific test method named `test_default`:
 
-    ruby -Ilib:test:bundler/lib test/rubygems/test_deprecate.rb -n /test_default/
+    bin/test-unit test/rubygems/test_deprecate.rb -n /test_default/
 
 ### Bundler Tests (RSpec)
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

We need to run to test a single test file like:

```
$ ruby -Ilib:test:bundler/lib test/rubygems/test_deprecate.rb
```

It's common way to run xUnit test tool. But it's obscure to newer contributors.

## What is your fix for the problem, implemented in this PR?

`test-unit` gem provides `test-unit` cli for test runner. I added that same as `bin/rspec`. After that, we can invoke  single test file like:

```
$ bin/test-unit test/rubygems/test_deprecate.rb
```

/cc @tikkss

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
