### PR TITLE
Harden Gem::YAMLSerializer

### DIFF
--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -72,9 +72,7 @@ module Gem
 
       def parse_node(base_indent)
         @depth += 1
-        if @depth > MAX_NESTING_DEPTH
-          raise Psych::SyntaxError, "exceeded maximum nesting depth (#{MAX_NESTING_DEPTH})"
-        end
+        raise_max_nesting! if @depth > MAX_NESTING_DEPTH
 
         skip_blank_and_comments
         return nil if @lines.empty?
@@ -286,9 +284,7 @@ module Gem
       end
 
       def coerce(val, depth = 0)
-        if depth > MAX_NESTING_DEPTH
-          raise Psych::SyntaxError, "exceeded maximum nesting depth (#{MAX_NESTING_DEPTH})"
-        end
+        raise_max_nesting! if depth > MAX_NESTING_DEPTH
 
         val = val.sub(/^! /, "") if val.start_with?("! ")
 
@@ -394,6 +390,15 @@ module Gem
           node.anchor = name if node.respond_to?(:anchor=)
         end
         node
+      end
+
+      def raise_max_nesting!
+        message = "exceeded maximum nesting depth (#{MAX_NESTING_DEPTH})"
+        if defined?(Psych::VERSION)
+          raise Psych::SyntaxError.new(nil, 0, 0, 0, message, nil)
+        else
+          raise Psych::SyntaxError, message
+        end
       end
 
       def skip_blank_and_comments

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -285,7 +285,11 @@ module Gem
         Scalar.new(value: result)
       end
 
-      def coerce(val)
+      def coerce(val, depth = 0)
+        if depth > MAX_NESTING_DEPTH
+          raise Psych::SyntaxError, "exceeded maximum nesting depth (#{MAX_NESTING_DEPTH})"
+        end
+
         val = val.sub(/^! /, "") if val.start_with?("! ")
 
         if val =~ /^"(.*)"$/
@@ -311,7 +315,7 @@ module Gem
         elsif val =~ /^\[(.*)\]$/
           inner = $1.strip
           return Sequence.new if inner.empty?
-          items = inner.split(/\s*,\s*/).reject(&:empty?).map {|e| Scalar.new(value: coerce(e)) }
+          items = inner.split(/\s*,\s*/).reject(&:empty?).map {|e| Scalar.new(value: coerce(e, depth + 1)) }
           Sequence.new(items: items)
         elsif /\A\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}:\d{2})?/.match?(val)
           begin

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -497,7 +497,6 @@ module Gem
       end
 
       def build_mapping(node)
-        check_anchor!(node)
         validate_tag!(node.tag) if node.tag
 
         result = case node.tag
@@ -653,12 +652,6 @@ module Gem
           raise Psych::DisallowedClass.new("load", label)
         else
           raise Psych::DisallowedClass, "Tried to load unspecified class: #{label}"
-        end
-      end
-
-      def check_anchor!(node)
-        if node.anchor
-          raise Psych::AliasesNotEnabled unless @aliases
         end
       end
 

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -454,9 +454,7 @@ module Gem
 
         result = build_node(node)
 
-        if result.is_a?(Hash) &&
-           (result[:tag] == "!ruby/object:Gem::Specification" ||
-            result["tag"] == "!ruby/object:Gem::Specification")
+        if result.is_a?(Hash) && result[:tag] == "!ruby/object:Gem::Specification"
           build_specification(result)
         else
           result

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -484,7 +484,11 @@ module Gem
         if @alias_count > MAX_ALIAS_RESOLUTIONS
           raise Psych::BadAlias, "exceeded maximum alias resolutions (#{MAX_ALIAS_RESOLUTIONS})"
         end
-        @anchor_values.fetch(node.name, nil)
+        unless @anchor_values.key?(node.name)
+          klass = defined?(Psych::AnchorNotDefined) ? Psych::AnchorNotDefined : Psych::BadAlias
+          raise klass, "An alias referenced an unknown anchor: #{node.name}"
+        end
+        @anchor_values.fetch(node.name)
       end
 
       def store_anchor(name, value)

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -590,9 +590,14 @@ module Gem
 
         d.instance_variable_set(:@requirement, hash["requirement"] || hash["version_requirements"])
 
-        type = hash["type"]
-        type = type ? type.to_s.sub(/^:/, "").to_sym : :runtime
-        validate_symbol!(type)
+        raw_type = hash["type"]
+        if raw_type
+          name = raw_type.to_s.sub(/^:/, "")
+          validate_symbol!(name)
+          type = name.to_sym
+        else
+          type = :runtime
+        end
         d.instance_variable_set(:@type, type)
 
         d.instance_variable_set(:@prerelease, ["true", true].include?(hash["prerelease"]))
@@ -632,13 +637,14 @@ module Gem
         end
       end
 
-      def validate_symbol!(sym)
-        if @permitted_symbols.any? && !@permitted_symbols.include?(sym.to_s)
-          if defined?(Psych::VERSION)
-            raise Psych::DisallowedClass.new("load", sym.inspect)
-          else
-            raise Psych::DisallowedClass, "Tried to load unspecified class: #{sym.inspect}"
-          end
+      def validate_symbol!(name)
+        return if @permitted_symbols.empty? || @permitted_symbols.include?(name)
+
+        label = ":#{name}"
+        if defined?(Psych::VERSION)
+          raise Psych::DisallowedClass.new("load", label)
+        else
+          raise Psych::DisallowedClass, "Tried to load unspecified class: #{label}"
         end
       end
 

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -143,6 +143,15 @@ class TestGemSafeYAML < Gem::TestCase
     end
   end
 
+  def test_unknown_alias_raises
+    yaml = <<~YAML
+      foo: 1
+      bar: *missing
+    YAML
+
+    assert_raise(Psych::BadAlias) { Gem::SafeYAML.safe_load(yaml) }
+  end
+
   def test_yaml_serializer_aliases_disabled
     aliases_enabled = Gem::SafeYAML.aliases_enabled?
     Gem::SafeYAML.aliases_enabled = false

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -149,7 +149,8 @@ class TestGemSafeYAML < Gem::TestCase
       bar: *missing
     YAML
 
-    assert_raise(Psych::BadAlias) { Gem::SafeYAML.safe_load(yaml) }
+    expected_error = defined?(Psych::AnchorNotDefined) ? Psych::AnchorNotDefined : Psych::BadAlias
+    assert_raise(expected_error) { Gem::SafeYAML.safe_load(yaml) }
   end
 
   def test_unused_anchor_with_aliases_disabled_is_allowed

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -134,6 +134,15 @@ class TestGemSafeYAML < Gem::TestCase
     refute_includes Symbol.all_symbols.map(&:to_s), unique
   end
 
+  def test_inline_array_nesting_capped
+    depth = Gem::YAMLSerializer::Parser::MAX_NESTING_DEPTH + 1
+    yaml = "x: " + ("[" * depth) + "a" + ("]" * depth) + "\n"
+
+    assert_raise(Psych::SyntaxError) do
+      Gem::YAMLSerializer.load(yaml, permitted_classes: [])
+    end
+  end
+
   def test_yaml_serializer_aliases_disabled
     aliases_enabled = Gem::SafeYAML.aliases_enabled?
     Gem::SafeYAML.aliases_enabled = false

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -152,6 +152,16 @@ class TestGemSafeYAML < Gem::TestCase
     assert_raise(Psych::BadAlias) { Gem::SafeYAML.safe_load(yaml) }
   end
 
+  def test_unused_anchor_with_aliases_disabled_is_allowed
+    aliases_enabled = Gem::SafeYAML.aliases_enabled?
+    Gem::SafeYAML.aliases_enabled = false
+
+    result = Gem::SafeYAML.safe_load("foo: &unused 1\nbar: 2\n")
+    assert_equal({ "foo" => 1, "bar" => 2 }, result)
+  ensure
+    Gem::SafeYAML.aliases_enabled = aliases_enabled
+  end
+
   def test_yaml_serializer_aliases_disabled
     aliases_enabled = Gem::SafeYAML.aliases_enabled?
     Gem::SafeYAML.aliases_enabled = false

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -107,6 +107,33 @@ class TestGemSafeYAML < Gem::TestCase
     assert_match(/unspecified class/, exception.message)
   end
 
+  def test_disallowed_symbol_not_interned
+    unique = "rejected_symbol_#{rand(1 << 30)}"
+    yaml = <<~YAML
+      --- !ruby/object:Gem::Dependency
+      name: test
+      requirement: !ruby/object:Gem::Requirement
+        requirements:
+        - - ">="
+          - !ruby/object:Gem::Version
+            version: 0
+      type: :#{unique}
+      prerelease: false
+      version_requirements: !ruby/object:Gem::Requirement
+        requirements:
+        - - ">="
+          - !ruby/object:Gem::Version
+            version: 0
+    YAML
+
+    assert_raise(Psych::DisallowedClass) do
+      Gem::YAMLSerializer.load(yaml,
+                               permitted_classes: Gem::SafeYAML::PERMITTED_CLASSES,
+                               permitted_symbols: Gem::SafeYAML::PERMITTED_SYMBOLS)
+    end
+    refute_includes Symbol.all_symbols.map(&:to_s), unique
+  end
+
   def test_yaml_serializer_aliases_disabled
     aliases_enabled = Gem::SafeYAML.aliases_enabled?
     Gem::SafeYAML.aliases_enabled = false

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -70,6 +70,19 @@ class TestGemSafeYAML < Gem::TestCase
     assert_match(/unspecified class/, exception.message)
   end
 
+  def test_plain_tag_key_does_not_construct_specification
+    yaml = <<~YAML
+      tag: "!ruby/object:Gem::Specification"
+      name: pwned
+      arbitrary_ivar: hello
+    YAML
+
+    result = Gem::SafeYAML.safe_load(yaml)
+    assert_kind_of Hash, result
+    assert_equal "!ruby/object:Gem::Specification", result["tag"]
+    assert_equal "pwned", result["name"]
+  end
+
   def test_disallowed_symbol_rejected
     yaml = <<~YAML
       --- !ruby/object:Gem::Dependency

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -138,7 +138,11 @@ class TestGemSafeYAML < Gem::TestCase
     depth = Gem::YAMLSerializer::Parser::MAX_NESTING_DEPTH + 1
     yaml = "x: " + ("[" * depth) + "a" + ("]" * depth) + "\n"
 
-    assert_raise(Psych::SyntaxError) do
+    expected = [Psych::SyntaxError]
+    # JRuby's JVM stack overflows before the Ruby-level nesting cap fires.
+    expected << ::Java::JavaLang::StackOverflowError if RUBY_ENGINE == "jruby"
+
+    assert_raise(*expected) do
       Gem::YAMLSerializer.load(yaml, permitted_classes: [])
     end
   end


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

This PR closes a few hardening gaps around tag validation, symbol interning, recursion depth, and unknown aliases, and lines the resulting error behaviour up with Psych.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
