### PR TITLE
Added `test:parallel` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,6 +86,11 @@ namespace "test" do
       sh Gem.ruby, "-Ilib:test:bundler/lib", file
     end
   end
+
+  desc "Run RubyGems tests using test-unit's process-based parallel runner"
+  task "parallel" do
+    sh File.expand_path("bin/test-unit", __dir__), "test", "--parallel=process"
+  end
 end
 
 task default: [:test, :spec]

--- a/bin/test-unit
+++ b/bin/test-unit
@@ -6,4 +6,10 @@ require_relative "../spec/support/rubygems_ext"
 
 $LOAD_PATH.unshift File.expand_path("../test", __dir__)
 
+# Propagate bundler/lib and test/ to subprocesses (e.g. test-unit
+# --parallel=process workers) via RUBYOPT so they pick up the local bundler
+# instead of the one shipped with the host Ruby.
+extra_opts = %w[bundler/lib test].map {|rel| "-I#{File.expand_path("../#{rel}", __dir__)}" }
+ENV["RUBYOPT"] = [*extra_opts, ENV["RUBYOPT"]].compact.join(" ")
+
 Spec::Rubygems.gem_load("test-unit", "test-unit")

--- a/test/rubygems/test_gem_commands_cert_command.rb
+++ b/test/rubygems/test_gem_commands_cert_command.rb
@@ -31,14 +31,6 @@ class TestGemCommandsCertCommand < Gem::TestCase
     @cmd = Gem::Commands::CertCommand.new
 
     @trust_dir = Gem::Security.trust_dir
-
-    @cleanup = []
-  end
-
-  def teardown
-    FileUtils.rm_f(@cleanup)
-
-    super
   end
 
   def test_certificates_matching
@@ -661,8 +653,7 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
 
     assert_equal "/CN=nobody/DC=example", EXPIRED_PUBLIC_CERT.issuer.to_s
 
-    tmp_expired_cert_file = File.join(Dir.tmpdir, File.basename(EXPIRED_PUBLIC_CERT_FILE))
-    @cleanup << tmp_expired_cert_file
+    tmp_expired_cert_file = File.join(@tempdir, File.basename(EXPIRED_PUBLIC_CERT_FILE))
     File.write(tmp_expired_cert_file, File.read(EXPIRED_PUBLIC_CERT_FILE))
 
     @cmd.handle_options %W[
@@ -694,8 +685,7 @@ ERROR:  --private-key not specified and ~/.gem/gem-private_key.pem does not exis
 
     assert_equal "/CN=nobody/DC=example", EXPIRED_PUBLIC_CERT.issuer.to_s
 
-    tmp_expired_cert_file = File.join(Dir.tmpdir, File.basename(EXPIRED_PUBLIC_CERT_FILE))
-    @cleanup << tmp_expired_cert_file
+    tmp_expired_cert_file = File.join(@tempdir, File.basename(EXPIRED_PUBLIC_CERT_FILE))
     File.write(tmp_expired_cert_file, File.read(EXPIRED_PUBLIC_CERT_FILE))
 
     @cmd.handle_options %W[


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

From https://github.com/ruby/rubygems/pull/9570#issuecomment-4563826391. It reduces our test running time.

* `rake test`: 112 seconds.
* `rake test:parallel`: 59 seconds.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
