### PR TITLE
Vendor `compact_index` from rubygems.org for the artifice

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,11 +9,39 @@ require "rake/testtask"
 require_relative "spec/support/rubygems_ext"
 
 desc "Setup Rubygems dev environment"
-task setup: [:"dev:deps"] do
+task setup: [:"dev:deps", "vendor:compact_index"] do
   Dir.glob("tool/bundler/*_gems.rb").each do |file|
     name = File.basename(file, ".rb")
     next if name == "dev_gems"
     Spec::Rubygems.dev_bundle "lock", gemfile: file
+  end
+end
+
+namespace :vendor do
+  desc "Sync vendored compact_index from rubygems/rubygems.org (REF=master)"
+  task :compact_index do
+    require "open-uri"
+    require "fileutils"
+
+    ref = ENV["REF"] || "master"
+    repo = "rubygems/rubygems.org"
+    paths = %w[
+      lib/compact_index.rb
+      lib/compact_index/dependency.rb
+      lib/compact_index/gem.rb
+      lib/compact_index/gem_version.rb
+      lib/compact_index/versions_file.rb
+    ]
+
+    target_root = "tmp/compact_index"
+    paths.each do |path|
+      url = "https://raw.githubusercontent.com/#{repo}/#{ref}/#{path}"
+      puts "Fetching #{url}"
+      content = URI.parse(url).open(&:read)
+      target = File.join(target_root, path)
+      FileUtils.mkdir_p(File.dirname(target))
+      File.write(target, content)
+    end
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -18,12 +18,14 @@ task setup: [:"dev:deps", "vendor:compact_index"] do
 end
 
 namespace :vendor do
-  desc "Sync vendored compact_index from rubygems/rubygems.org (REF=master)"
+  # Pinned to rubygems/rubygems.org#6504 so `rake setup` stays reproducible.
+  # Override with REF=<sha> to test against a newer compact_index.
+  desc "Sync vendored compact_index from rubygems/rubygems.org"
   task :compact_index do
     require "open-uri"
     require "fileutils"
 
-    ref = ENV["REF"] || "master"
+    ref = ENV["REF"] || "7c68a7b39761c61a66f9299f85b889ec39afc02c"
     repo = "rubygems/rubygems.org"
     paths = %w[
       lib/compact_index.rb

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ namespace :vendor do
       lib/compact_index/versions_file.rb
     ]
 
-    target_root = "tmp/compact_index"
+    target_root = Spec::Path.tmp_root.join("compact_index")
     paths.each do |path|
       url = "https://raw.githubusercontent.com/#{repo}/#{ref}/#{path}"
       puts "Fetching #{url}"

--- a/spec/support/artifice/helpers/compact_index.rb
+++ b/spec/support/artifice/helpers/compact_index.rb
@@ -2,7 +2,7 @@
 
 require_relative "endpoint"
 
-$LOAD_PATH.unshift Dir[Spec::Path.scoped_base_system_gem_path.join("gems/compact_index*/lib")].first.to_s
+$LOAD_PATH.unshift Spec::Path.tmp_root.join("compact_index/lib").to_s
 require "compact_index"
 require "digest"
 
@@ -90,12 +90,16 @@ class CompactIndexAPI < Endpoint
             rescue StandardError
               checksum = nil
             end
-            CompactIndex::GemVersion.new(spec.version.version, spec.platform.to_s, checksum, nil,
-              deps, spec.required_ruby_version.to_s, spec.required_rubygems_version.to_s)
+            build_gem_version(spec, deps, checksum)
           end
           CompactIndex::Gem.new(name, gem_versions)
         end
       end
+    end
+
+    def build_gem_version(spec, deps, checksum)
+      CompactIndex::GemVersion.new(spec.version.version, spec.platform.to_s, checksum, nil,
+        deps, spec.required_ruby_version.to_s, spec.required_rubygems_version.to_s)
     end
   end
 

--- a/tool/bundler/test_gems.rb
+++ b/tool/bundler/test_gems.rb
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "rack", "~> 3.1"
 gem "rack-test", "~> 2.1"
-gem "compact_index", "~> 0.15.0"
 gem "sinatra", "~> 4.1"
 gem "rake", "~> 13.1"
 gem "builder", "~> 3.2"

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -57,7 +57,6 @@ PLATFORMS
 
 DEPENDENCIES
   builder (~> 3.2)
-  compact_index (~> 0.15.0)
   concurrent-ruby
   etc
   fiddle


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

The external compact_index gem is no longer developed; its source now lives in rubygems/rubygems.org. 

This is preparation of roll-out for `created_at` column provided by rubygems.org.

## What is your fix for the problem, implemented in this PR?

Replace the runtime gem dependency with a rake task that fetches compact_index files into `tmp/compact_index/` when `rake setup` runs.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
