### PR TITLE
Split `macos-15-intel` bundler tests into four shards

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -40,8 +40,12 @@ jobs:
           - { os: { name: macOS, value: macos-26 }, ruby: { name: ruby-3.4, value: 3.4.9 }, timeout: 90 }
           - { os: { name: macOS, value: macos-26 }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90 }
 
-          # Regression coverage for the Intel architecture with the latest Ruby only
-          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90 }
+          # Regression coverage for the Intel architecture with the latest Ruby only.
+          # Split across runners using the Windows tag groups to keep each run reasonable.
+          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: a }
+          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: b }
+          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: c }
+          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: d }
 
           # Ruby 3.2 is about 20 minutes slower than 3.3/3.4, so it will be excluded from testing.
           - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.3, value: 3.3.11 }, timeout: 150, group: a }
@@ -129,11 +133,15 @@ jobs:
       - name: Run Test (CRuby)
         run: |
           bin/parallel_rspec
-        if: matrix.ruby.name != 'jruby' && matrix.ruby.name != 'truffleruby' && matrix.os.name != 'Windows'
+        if: matrix.ruby.name != 'jruby' && matrix.ruby.name != 'truffleruby' && matrix.os.name != 'Windows' && matrix.os.name != 'macOS-intel'
       - name: Run Test (CRuby on Windows - Group ${{ matrix.group }})
         run: |
           bin/parallel_rspec --tag windows_${{ matrix.group }}
         if: matrix.ruby.name != 'jruby' && matrix.ruby.name != 'truffleruby' && matrix.os.name == 'Windows'
+      - name: Run Test (CRuby on macOS Intel - Group ${{ matrix.group }})
+        run: |
+          bin/parallel_rspec --tag windows_${{ matrix.group }}
+        if: matrix.ruby.name != 'jruby' && matrix.ruby.name != 'truffleruby' && matrix.os.name == 'macOS-intel'
       - name: Run Test (JRuby)
         run: |
           bin/parallel_rspec --tag jruby_only --tag jruby

--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -41,7 +41,7 @@ jobs:
           - { os: { name: macOS, value: macos-26 }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90 }
 
           # Regression coverage for the Intel architecture with the latest Ruby only.
-          # Split across runners using the Windows tag groups to keep each run reasonable.
+          # Split across runners using the test shards to keep each run reasonable.
           - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: a }
           - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: b }
           - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: c }
@@ -136,11 +136,11 @@ jobs:
         if: matrix.ruby.name != 'jruby' && matrix.ruby.name != 'truffleruby' && matrix.os.name != 'Windows' && matrix.os.name != 'macOS-intel'
       - name: Run Test (CRuby on Windows - Group ${{ matrix.group }})
         run: |
-          bin/parallel_rspec --tag windows_${{ matrix.group }}
+          bin/parallel_rspec --tag shard_${{ matrix.group }}
         if: matrix.ruby.name != 'jruby' && matrix.ruby.name != 'truffleruby' && matrix.os.name == 'Windows'
       - name: Run Test (CRuby on macOS Intel - Group ${{ matrix.group }})
         run: |
-          bin/parallel_rspec --tag windows_${{ matrix.group }}
+          bin/parallel_rspec --tag shard_${{ matrix.group }}
         if: matrix.ruby.name != 'jruby' && matrix.ruby.name != 'truffleruby' && matrix.os.name == 'macOS-intel'
       - name: Run Test (JRuby)
         run: |

--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -42,24 +42,24 @@ jobs:
 
           # Regression coverage for the Intel architecture with the latest Ruby only.
           # Split across runners using the test shards to keep each run reasonable.
-          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: a }
-          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: b }
-          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: c }
-          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, group: d }
+          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, shard: a }
+          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, shard: b }
+          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, shard: c }
+          - { os: { name: macOS-intel, value: macos-15-intel }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 90, shard: d }
 
           # Ruby 3.2 is about 20 minutes slower than 3.3/3.4, so it will be excluded from testing.
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.3, value: 3.3.11 }, timeout: 150, group: a }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.3, value: 3.3.11 }, timeout: 150, group: b }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.3, value: 3.3.11 }, timeout: 150, group: c }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.3, value: 3.3.11 }, timeout: 150, group: d }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.4, value: 3.4.9 }, timeout: 150, group: a }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.4, value: 3.4.9 }, timeout: 150, group: b }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.4, value: 3.4.9 }, timeout: 150, group: c }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.4, value: 3.4.9 }, timeout: 150, group: d }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 150, group: a }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 150, group: b }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 150, group: c }
-          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 150, group: d }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.3, value: 3.3.11 }, timeout: 150, shard: a }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.3, value: 3.3.11 }, timeout: 150, shard: b }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.3, value: 3.3.11 }, timeout: 150, shard: c }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.3, value: 3.3.11 }, timeout: 150, shard: d }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.4, value: 3.4.9 }, timeout: 150, shard: a }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.4, value: 3.4.9 }, timeout: 150, shard: b }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.4, value: 3.4.9 }, timeout: 150, shard: c }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-3.4, value: 3.4.9 }, timeout: 150, shard: d }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 150, shard: a }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 150, shard: b }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 150, shard: c }
+          - { os: { name: Windows, value: windows-2025 }, ruby: { name: ruby-4.0, value: 4.0.5 }, timeout: 150, shard: d }
 
           - { os: { name: Ubuntu, value: ubuntu-24.04 }, ruby: { name: jruby, value: jruby-10.1.0.0 } }
           - { os: { name: macOS, value: macos-26 }, ruby: { name: jruby, value: jruby-10.1.0.0 } }
@@ -134,13 +134,13 @@ jobs:
         run: |
           bin/parallel_rspec
         if: matrix.ruby.name != 'jruby' && matrix.ruby.name != 'truffleruby' && matrix.os.name != 'Windows' && matrix.os.name != 'macOS-intel'
-      - name: Run Test (CRuby on Windows - Group ${{ matrix.group }})
+      - name: Run Test (CRuby on Windows - Shard ${{ matrix.shard }})
         run: |
-          bin/parallel_rspec --tag shard_${{ matrix.group }}
+          bin/parallel_rspec --tag shard_${{ matrix.shard }}
         if: matrix.ruby.name != 'jruby' && matrix.ruby.name != 'truffleruby' && matrix.os.name == 'Windows'
-      - name: Run Test (CRuby on macOS Intel - Group ${{ matrix.group }})
+      - name: Run Test (CRuby on macOS Intel - Shard ${{ matrix.shard }})
         run: |
-          bin/parallel_rspec --tag shard_${{ matrix.group }}
+          bin/parallel_rspec --tag shard_${{ matrix.shard }}
         if: matrix.ruby.name != 'jruby' && matrix.ruby.name != 'truffleruby' && matrix.os.name == 'macOS-intel'
       - name: Run Test (JRuby)
         run: |

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ require_relative "support/indexes"
 require_relative "support/matchers"
 require_relative "support/permissions"
 require_relative "support/platforms"
-require_relative "support/windows_tag_group"
+require_relative "support/shards"
 
 begin
   raise LoadError if File.exist?(File.expand_path("../../lib/bundler/bundler.gemspec", __dir__))
@@ -88,7 +88,7 @@ RSpec.configure do |config|
   config.include Spec::Path
   config.include Spec::Platforms
   config.include Spec::Permissions
-  config.include Spec::WindowsTagGroup
+  config.include Spec::Shards
 
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
@@ -175,7 +175,7 @@ RSpec.configure do |config|
     reset!
   end
 
-  Spec::WindowsTagGroup::EXAMPLE_MAPPINGS.each do |tag, file_paths|
+  Spec::Shards::EXAMPLE_MAPPINGS.each do |tag, file_paths|
     file_pattern = Regexp.union(file_paths.map {|path| Regexp.new(Regexp.escape(path) + "$") })
 
     config.define_derived_metadata(file_path: file_pattern) do |metadata|
@@ -185,8 +185,8 @@ RSpec.configure do |config|
 
   config.before(:context) do |example|
     metadata = example.class.metadata
-    if metadata[:type] != :aruba && !metadata[:realworld] && metadata.keys.none? {|k| Spec::WindowsTagGroup::EXAMPLE_MAPPINGS.keys.include?(k) }
-      warn "#{metadata[:file_path]} is not assigned to any Windows runner group. see spec/support/windows_tag_group.rb for details."
+    if metadata[:type] != :aruba && !metadata[:realworld] && metadata.keys.none? {|k| Spec::Shards::EXAMPLE_MAPPINGS.keys.include?(k) }
+      warn "#{metadata[:file_path]} is not assigned to any shard. see spec/support/shards.rb for details."
     end
   end unless Spec::Path.ruby_core?
 end

--- a/spec/support/shards.rb
+++ b/spec/support/shards.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-# This group classifies test files into 4 groups by running `bin/rspec --profile 10000`
+# This classifies test files into 4 shards by running `bin/rspec --profile 10000`
 # to ensure balanced execution times. When adding new test files, it is recommended to
-# re-aggregate and adjust the groups to keep them balanced.
-# For now, please add new files to group 'windows_d'.
+# re-aggregate and adjust the shards to keep them balanced.
+# For now, please add new files to shard 'shard_d'.
 
 module Spec
-  module WindowsTagGroup
+  module Shards
     EXAMPLE_MAPPINGS = {
-      windows_a: [
+      shard_a: [
         "spec/runtime/setup_spec.rb",
         "spec/commands/install_spec.rb",
         "spec/commands/add_spec.rb",
@@ -53,7 +53,7 @@ module Spec
         "spec/bundler/plugin/source_list_spec.rb",
         "spec/bundler/source/path_spec.rb",
       ],
-      windows_b: [
+      shard_b: [
         "spec/install/gemfile/git_spec.rb",
         "spec/install/gems/standalone_spec.rb",
         "spec/commands/lock_spec.rb",
@@ -97,7 +97,7 @@ module Spec
         "spec/bundler/index_spec.rb",
         "spec/other/cli_man_pages_spec.rb",
       ],
-      windows_c: [
+      shard_c: [
         "spec/commands/newgem_spec.rb",
         "spec/commands/exec_spec.rb",
         "spec/commands/clean_spec.rb",
@@ -142,7 +142,7 @@ module Spec
         "spec/bundler/cli_common_spec.rb",
         "spec/bundler/ci_detector_spec.rb",
       ],
-      windows_d: [
+      shard_d: [
         "spec/commands/outdated_spec.rb",
         "spec/commands/update_spec.rb",
         "spec/lock/lockfile_spec.rb",


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The `macos-15-intel` runner added in #9573 ran the full bundler suite in around 40 minutes, which is too long for regression coverage.

## What is your fix for the problem, implemented in this PR?

It now splits across four runners using the same example grouping that Windows already relies on, bringing each run down to roughly ten minutes.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
