### PR TITLE
Add `cooldown` to delay newly published gem

### DIFF
--- a/bundler/lib/bundler/cli.rb
+++ b/bundler/lib/bundler/cli.rb
@@ -274,6 +274,7 @@ module Bundler
     method_option "target-rbconfig", type: :string, banner: "Path to rbconfig.rb for the deployment target platform"
     method_option "without", type: :array, banner: "Exclude gems that are part of the specified named group (removed)."
     method_option "with", type: :array, banner: "Include gems that are part of the specified named group (removed)."
+    method_option "cooldown", type: :numeric, banner: "Only consider gem versions published at least N days ago. Use 0 to disable."
     def install
       %w[clean deployment frozen no-prune path shebang without with].each do |option|
         remembered_flag_deprecation(option)
@@ -324,6 +325,7 @@ module Bundler
     method_option "strict", type: :boolean, banner: "Do not allow any gem to be updated past latest --patch | --minor | --major"
     method_option "conservative", type: :boolean, banner: "Use bundle install conservative update behavior and do not allow shared dependencies to be updated."
     method_option "all", type: :boolean, banner: "Update everything."
+    method_option "cooldown", type: :numeric, banner: "Only consider gem versions published at least N days ago. Use 0 to disable."
     def update(*gems)
       require_relative "cli/update"
       Bundler.settings.temporary(no_install: false) do
@@ -406,6 +408,7 @@ module Bundler
     method_option "optimistic", type: :boolean, banner: "Ignored (now default behavior)"
     method_option "pessimistic", type: :boolean, banner: "Adds pessimistic declaration of version to gem"
     method_option "strict", type: :boolean, banner: "Adds strict declaration of version to gem"
+    method_option "cooldown", type: :numeric, banner: "Only consider gem versions published at least N days ago. Use 0 to disable."
     def add(*gems)
       require_relative "cli/add"
       Add.new(options.dup, gems).run
@@ -436,6 +439,7 @@ module Bundler
     method_option "filter-patch", type: :boolean, banner: "Only list patch newer versions"
     method_option "parseable", aliases: "--porcelain", type: :boolean, banner: "Use minimal formatting for more parseable output"
     method_option "only-explicit", type: :boolean, banner: "Only list gems specified in your Gemfile, not their dependencies"
+    method_option "cooldown", type: :numeric, banner: "Only consider gem versions published at least N days ago. Use 0 to disable."
     def outdated(*gems)
       require_relative "cli/outdated"
       Outdated.new(options, gems).run

--- a/bundler/lib/bundler/cli/add.rb
+++ b/bundler/lib/bundler/cli/add.rb
@@ -14,6 +14,7 @@ module Bundler
     def run
       Bundler.ui.level = "warn" if options[:quiet]
 
+      Bundler::CLI::Common.validate_cooldown!(options[:cooldown])
       Bundler.settings.set_command_option_if_given :cooldown, options[:cooldown]
 
       validate_options!

--- a/bundler/lib/bundler/cli/add.rb
+++ b/bundler/lib/bundler/cli/add.rb
@@ -14,6 +14,8 @@ module Bundler
     def run
       Bundler.ui.level = "warn" if options[:quiet]
 
+      Bundler.settings.set_command_option_if_given :cooldown, options[:cooldown]
+
       validate_options!
       inject_dependencies
       perform_bundle_install unless options["skip-install"]

--- a/bundler/lib/bundler/cli/common.rb
+++ b/bundler/lib/bundler/cli/common.rb
@@ -2,6 +2,12 @@
 
 module Bundler
   module CLI::Common
+    def self.validate_cooldown!(value)
+      return if value.nil?
+      return if value.is_a?(Integer) && value >= 0
+      raise InvalidOption, "Expected `--cooldown` to be a non-negative integer, got #{value.inspect}"
+    end
+
     def self.output_post_install_messages(messages)
       return if Bundler.settings["ignore_messages"]
       messages.to_a.each do |name, msg|

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -112,6 +112,7 @@ module Bundler
 
       Bundler.settings.set_command_option_if_given :jobs, options["jobs"]
 
+      Bundler::CLI::Common.validate_cooldown!(options["cooldown"])
       Bundler.settings.set_command_option_if_given :cooldown, options["cooldown"]
 
       Bundler.settings.set_command_option_if_given :no_prune, options["no-prune"]

--- a/bundler/lib/bundler/cli/install.rb
+++ b/bundler/lib/bundler/cli/install.rb
@@ -112,6 +112,8 @@ module Bundler
 
       Bundler.settings.set_command_option_if_given :jobs, options["jobs"]
 
+      Bundler.settings.set_command_option_if_given :cooldown, options["cooldown"]
+
       Bundler.settings.set_command_option_if_given :no_prune, options["no-prune"]
 
       Bundler.settings.set_command_option_if_given :no_install, options["no-install"]

--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -26,6 +26,7 @@ module Bundler
     def run
       check_for_deployment_mode!
 
+      Bundler::CLI::Common.validate_cooldown!(options[:cooldown])
       Bundler.settings.set_command_option_if_given :cooldown, options[:cooldown]
 
       Bundler.definition.validate_runtime!

--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -26,6 +26,8 @@ module Bundler
     def run
       check_for_deployment_mode!
 
+      Bundler.settings.set_command_option_if_given :cooldown, options[:cooldown]
+
       Bundler.definition.validate_runtime!
       current_specs = Bundler.ui.silence { Bundler.definition.resolve }
 

--- a/bundler/lib/bundler/cli/outdated.rb
+++ b/bundler/lib/bundler/cli/outdated.rb
@@ -205,6 +205,10 @@ module Bundler
 
       release_date = release_date_for(active_spec)
       spec_outdated_info += ", released #{release_date}" unless release_date.empty?
+
+      remaining = cooldown_days_remaining(active_spec)
+      spec_outdated_info += ", in cooldown for #{remaining} more day#{"s" if remaining > 1}" if remaining
+
       spec_outdated_info += ")"
 
       output_message = if options[:parseable]
@@ -221,12 +225,23 @@ module Bundler
     def gem_column_for(current_spec, active_spec, dependency, groups)
       current_version = "#{current_spec.version}#{current_spec.git_version}"
       spec_version = "#{active_spec.version}#{active_spec.git_version}"
+      remaining = cooldown_days_remaining(active_spec)
+      spec_version += " (cooldown #{remaining}d)" if remaining
       dependency = dependency.requirement if dependency
 
       ret_val = [active_spec.name, current_version, spec_version, dependency.to_s, groups.to_s]
       ret_val << release_date_for(active_spec)
       ret_val << loaded_from_for(active_spec).to_s if Bundler.ui.debug?
       ret_val
+    end
+
+    def cooldown_days_remaining(spec, now = Time.now)
+      return nil unless spec.respond_to?(:created_at) && spec.created_at
+      return nil unless spec.respond_to?(:remote) && spec.remote
+      days = spec.remote.effective_cooldown
+      return nil if days.nil? || days <= 0
+      remaining = days - ((now - spec.created_at) / 86_400.0)
+      remaining > 0 ? remaining.ceil : nil
     end
 
     def check_for_deployment_mode!

--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -66,6 +66,7 @@ module Bundler
       opts["force"] = options[:redownload] if options[:redownload]
 
       Bundler.settings.set_command_option_if_given :jobs, opts["jobs"]
+      Bundler.settings.set_command_option_if_given :cooldown, options[:cooldown]
 
       Bundler.definition.validate_runtime!
 

--- a/bundler/lib/bundler/cli/update.rb
+++ b/bundler/lib/bundler/cli/update.rb
@@ -66,6 +66,7 @@ module Bundler
       opts["force"] = options[:redownload] if options[:redownload]
 
       Bundler.settings.set_command_option_if_given :jobs, opts["jobs"]
+      Bundler::CLI::Common.validate_cooldown!(options[:cooldown])
       Bundler.settings.set_command_option_if_given :cooldown, options[:cooldown]
 
       Bundler.definition.validate_runtime!

--- a/bundler/lib/bundler/dsl.rb
+++ b/bundler/lib/bundler/dsl.rb
@@ -117,6 +117,10 @@ module Bundler
       options = args.last.is_a?(Hash) ? args.pop.dup : {}
       options = normalize_hash(options)
       source = normalize_source(source)
+      cooldown = options["cooldown"]
+      if cooldown && !(cooldown.is_a?(Integer) && cooldown >= 0)
+        raise InvalidOption, "Expected `cooldown` to be a non-negative integer, got #{cooldown.inspect}"
+      end
 
       if options.key?("type")
         options["type"] = options["type"].to_s
@@ -131,9 +135,9 @@ module Bundler
         source_opts = options.merge("uri" => source)
         with_source(@sources.add_plugin_source(options["type"], source_opts), &blk)
       elsif block_given?
-        with_source(@sources.add_rubygems_source("remotes" => source), &blk)
+        with_source(@sources.add_rubygems_source("remotes" => source, "cooldown" => cooldown), &blk)
       else
-        @sources.add_global_rubygems_remote(source)
+        @sources.add_global_rubygems_remote(source, cooldown: cooldown)
       end
     end
 

--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -5,7 +5,7 @@ module Bundler
   class EndpointSpecification < Gem::Specification
     include MatchRemoteMetadata
 
-    attr_reader :name, :version, :platform, :checksum
+    attr_reader :name, :version, :platform, :checksum, :created_at
     attr_writer :dependencies
     attr_accessor :remote, :locked_platform
 
@@ -145,6 +145,7 @@ module Bundler
       unless data
         @required_ruby_version = nil
         @required_rubygems_version = nil
+        @created_at = nil
         return
       end
 
@@ -161,6 +162,16 @@ module Bundler
           @required_rubygems_version = Gem::Requirement.new(v)
         when "ruby"
           @required_ruby_version = Gem::Requirement.new(v)
+        when "created_at"
+          value = v.is_a?(Array) ? v.last : v
+          if value.is_a?(String)
+            require "time"
+            begin
+              @created_at = Time.iso8601(value)
+            rescue ArgumentError
+              @created_at = nil
+            end
+          end
         end
       end
     rescue StandardError => e

--- a/bundler/lib/bundler/man/bundle-add.1
+++ b/bundler/lib/bundler/man/bundle-add.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-add\fR \- Add gem to the Gemfile and run bundle install
 .SH "SYNOPSIS"
-\fBbundle add\fR \fIGEM_NAME\fR [\-\-group=GROUP] [\-\-version=VERSION] [\-\-source=SOURCE] [\-\-path=PATH] [\-\-git=GIT|\-\-github=GITHUB] [\-\-branch=BRANCH] [\-\-ref=REF] [\-\-quiet] [\-\-skip\-install] [\-\-strict|\-\-optimistic]
+\fBbundle add\fR \fIGEM_NAME\fR [\-\-group=GROUP] [\-\-version=VERSION] [\-\-source=SOURCE] [\-\-path=PATH] [\-\-git=GIT|\-\-github=GITHUB] [\-\-branch=BRANCH] [\-\-ref=REF] [\-\-cooldown=NUMBER] [\-\-quiet] [\-\-skip\-install] [\-\-strict|\-\-optimistic]
 .SH "DESCRIPTION"
 Adds the named gem to the [\fBGemfile(5)\fR][Gemfile(5)] and run \fBbundle install\fR\. \fBbundle install\fR can be avoided by using the flag \fB\-\-skip\-install\fR\.
 .SH "OPTIONS"
@@ -53,6 +53,9 @@ Adds pessimistic declaration of version\.
 .TP
 \fB\-\-strict\fR
 Adds strict declaration of version\.
+.TP
+\fB\-\-cooldown=<number>\fR
+Only consider gem versions published at least \fInumber\fR days ago when resolving\. Pass \fB0\fR to disable cooldown for this run\. See \fBcooldown\fR in bundle\-config(1) for precedence rules\.
 .SH "EXAMPLES"
 .IP "1." 4
 You can add the \fBrails\fR gem to the Gemfile without any version restriction\. The source of the gem will be the global source\.

--- a/bundler/lib/bundler/man/bundle-add.1.ronn
+++ b/bundler/lib/bundler/man/bundle-add.1.ronn
@@ -5,7 +5,7 @@ bundle-add(1) -- Add gem to the Gemfile and run bundle install
 
 `bundle add` <GEM_NAME> [--group=GROUP] [--version=VERSION] [--source=SOURCE]
            [--path=PATH] [--git=GIT|--github=GITHUB] [--branch=BRANCH] [--ref=REF]
-           [--quiet] [--skip-install] [--strict|--optimistic]
+           [--cooldown=NUMBER] [--quiet] [--skip-install] [--strict|--optimistic]
 
 ## DESCRIPTION
 
@@ -58,6 +58,11 @@ Adds the named gem to the [`Gemfile(5)`][Gemfile(5)] and run `bundle install`.
 
 * `--strict`:
   Adds strict declaration of version.
+
+* `--cooldown=<number>`:
+  Only consider gem versions published at least <number> days ago when
+  resolving. Pass `0` to disable cooldown for this run. See `cooldown`
+  in bundle-config(1) for precedence rules.
 
 ## EXAMPLES
 

--- a/bundler/lib/bundler/man/bundle-config.1
+++ b/bundler/lib/bundler/man/bundle-config.1
@@ -69,168 +69,130 @@ The canonical form of this configuration is \fB"without"\fR\. To convert the can
 Any periods in the configuration keys must be replaced with two underscores when setting it via environment variables\. The configuration key \fBlocal\.rack\fR becomes the environment variable \fBBUNDLE_LOCAL__RACK\fR\.
 .SH "LIST OF AVAILABLE KEYS"
 The following is a list of all configuration keys and their purpose\. You can learn more about their operation in bundle install(1) \fIbundle\-install\.1\.html\fR\.
-.TP
-\fBapi_request_size\fR (\fBBUNDLE_API_REQUEST_SIZE\fR)
-Configure how many dependencies to fetch when resolving the specifications\. This configuration is only used when fetching specifications from RubyGems servers that didn't implement the Compact Index API\. Defaults to 100\.
-.TP
-\fBauto_install\fR (\fBBUNDLE_AUTO_INSTALL\fR)
-Automatically run \fBbundle install\fR when gems are missing\.
-.TP
-\fBbin\fR (\fBBUNDLE_BIN\fR)
-If configured, \fBbundle binstubs\fR will install executables from gems in the bundle to the specified directory\. Otherwise it will create them in a \fBbin\fR directory relative to the Gemfile directory\. These executables run in Bundler's context\. If used, you might add this directory to your environment's \fBPATH\fR variable\. For instance, if the \fBrails\fR gem comes with a \fBrails\fR executable, \fBbundle binstubs\fR will create a \fBbin/rails\fR executable that ensures that all referred dependencies will be resolved using the bundled gems\.
-.TP
-\fBcache_all\fR (\fBBUNDLE_CACHE_ALL\fR)
-Cache all gems, including path and git gems\. This needs to be explicitly before bundler 4, but will be the default on bundler 4\.
-.TP
-\fBcache_all_platforms\fR (\fBBUNDLE_CACHE_ALL_PLATFORMS\fR)
-Cache gems for all platforms\.
-.TP
-\fBcache_path\fR (\fBBUNDLE_CACHE_PATH\fR)
-The directory that bundler will place cached gems in when running \fBbundle package\fR, and that bundler will look in when installing gems\. Defaults to \fBvendor/cache\fR\.
-.TP
-\fBclean\fR (\fBBUNDLE_CLEAN\fR)
-Whether Bundler should run \fBbundle clean\fR automatically after \fBbundle install\fR\. Defaults to \fBtrue\fR in Bundler 4, as long as \fBpath\fR is not explicitly configured\.
-.TP
-\fBconsole\fR (\fBBUNDLE_CONSOLE\fR)
-The console that \fBbundle console\fR starts\. Defaults to \fBirb\fR\.
-.TP
-\fBdefault_cli_command\fR (\fBBUNDLE_DEFAULT_CLI_COMMAND\fR)
-The command that running \fBbundle\fR without arguments should run\. Defaults to \fBcli_help\fR since Bundler 4, but can also be \fBinstall\fR which was the previous default\.
-.TP
-\fBdeployment\fR (\fBBUNDLE_DEPLOYMENT\fR)
-Equivalent to setting \fBfrozen\fR to \fBtrue\fR and \fBpath\fR to \fBvendor/bundle\fR\.
-.TP
-\fBdisable_checksum_validation\fR (\fBBUNDLE_DISABLE_CHECKSUM_VALIDATION\fR)
-Allow installing gems even if they do not match the checksum provided by RubyGems\.
-.TP
-\fBdisable_exec_load\fR (\fBBUNDLE_DISABLE_EXEC_LOAD\fR)
-Stop Bundler from using \fBload\fR to launch an executable in\-process in \fBbundle exec\fR\.
-.TP
-\fBdisable_local_branch_check\fR (\fBBUNDLE_DISABLE_LOCAL_BRANCH_CHECK\fR)
-Allow Bundler to use a local git override without a branch specified in the Gemfile\.
-.TP
-\fBdisable_local_revision_check\fR (\fBBUNDLE_DISABLE_LOCAL_REVISION_CHECK\fR)
-Allow Bundler to use a local git override without checking if the revision present in the lockfile is present in the repository\.
-.TP
-\fBdisable_shared_gems\fR (\fBBUNDLE_DISABLE_SHARED_GEMS\fR)
-Stop Bundler from accessing gems installed to RubyGems' normal location\.
-.TP
-\fBdisable_version_check\fR (\fBBUNDLE_DISABLE_VERSION_CHECK\fR)
-Stop Bundler from checking if a newer Bundler version is available on rubygems\.org\.
-.TP
-\fBforce_ruby_platform\fR (\fBBUNDLE_FORCE_RUBY_PLATFORM\fR)
-Ignore the current machine's platform and install only \fBruby\fR platform gems\. As a result, gems with native extensions will be compiled from source\.
-.TP
-\fBfrozen\fR (\fBBUNDLE_FROZEN\fR)
-Disallow any automatic changes to \fBGemfile\.lock\fR\. Bundler commands will be blocked unless the lockfile can be installed exactly as written\. Usually this will happen when changing the \fBGemfile\fR manually and forgetting to update the lockfile through \fBbundle lock\fR or \fBbundle install\fR\.
-.TP
-\fBgem\.github_username\fR (\fBBUNDLE_GEM__GITHUB_USERNAME\fR)
-Sets a GitHub username or organization to be used in the \fBREADME\fR and \fB\.gemspec\fR files when you create a new gem via \fBbundle gem\fR command\. It can be overridden by passing an explicit \fB\-\-github\-username\fR flag to \fBbundle gem\fR\.
-.TP
-\fBgem\.push_key\fR (\fBBUNDLE_GEM__PUSH_KEY\fR)
-Sets the \fB\-\-key\fR parameter for \fBgem push\fR when using the \fBrake release\fR command with a private gemstash server\.
-.TP
-\fBgemfile\fR (\fBBUNDLE_GEMFILE\fR)
-The name of the file that bundler should use as the \fBGemfile\fR\. This location of this file also sets the root of the project, which is used to resolve relative paths in the \fBGemfile\fR, among other things\. By default, bundler will search up from the current working directory until it finds a \fBGemfile\fR\.
-.TP
-\fBglobal_gem_cache\fR (\fBBUNDLE_GLOBAL_GEM_CACHE\fR)
-Whether Bundler should cache all gems and compiled extensions globally, rather than locally to the configured installation path\.
-.TP
-\fBignore_funding_requests\fR (\fBBUNDLE_IGNORE_FUNDING_REQUESTS\fR)
-When set, no funding requests will be printed\.
-.TP
-\fBignore_messages\fR (\fBBUNDLE_IGNORE_MESSAGES\fR)
-When set, no post install messages will be printed\. To silence a single gem, use dot notation like \fBignore_messages\.httparty true\fR\.
-.TP
-\fBinit_gems_rb\fR (\fBBUNDLE_INIT_GEMS_RB\fR)
-Generate a \fBgems\.rb\fR instead of a \fBGemfile\fR when running \fBbundle init\fR\.
-.TP
-\fBjobs\fR (\fBBUNDLE_JOBS\fR)
-The number of gems Bundler can download and install in parallel\. Defaults to the number of available processors\.
-.TP
-\fBlockfile\fR (\fBBUNDLE_LOCKFILE\fR)
-The path to the lockfile that bundler should use\. By default, Bundler adds \fB\.lock\fR to the end of the \fBgemfile\fR entry\. Can be set to \fBfalse\fR in the Gemfile to disable lockfile creation entirely (see gemfile(5))\.
-.TP
-\fBlockfile_checksums\fR (\fBBUNDLE_LOCKFILE_CHECKSUMS\fR)
-Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources\. Defaults to true\.
-.TP
-\fBno_build_extension\fR (\fBBUNDLE_NO_BUILD_EXTENSION\fR)
-Whether Bundler should skip building native extensions during installation\. When set, gems are installed without compiling their C extensions\. To build extensions later, unset this setting and run \fBbundle pristine <gem>\fR\.
-.TP
-\fBno_install\fR (\fBBUNDLE_NO_INSTALL\fR)
-Whether \fBbundle package\fR should skip installing gems\.
-.TP
-\fBno_install_plugin\fR (\fBBUNDLE_NO_INSTALL_PLUGIN\fR)
-Whether Bundler should skip installing RubyGems plugins during installation\. When set, plugin files are not written to the plugins directory\. To install plugins later, unset this setting and run \fBbundle pristine <gem>\fR\.
-.TP
-\fBno_prune\fR (\fBBUNDLE_NO_PRUNE\fR)
-Whether Bundler should leave outdated gems unpruned when caching\.
-.TP
-\fBonly\fR (\fBBUNDLE_ONLY\fR)
-A space\-separated list of groups to install only gems of the specified groups\. Please check carefully if you want to install also gems without a group, because they get put inside \fBdefault\fR group\. For example \fBonly test:default\fR will install all gems specified in test group and without one\.
-.TP
-\fBpath\fR (\fBBUNDLE_PATH\fR)
-The location on disk where all gems in your bundle will be located regardless of \fB$GEM_HOME\fR or \fB$GEM_PATH\fR values\. Bundle gems not found in this location will be installed by \fBbundle install\fR\. When not set, Bundler install by default to a \fB\.bundle\fR directory relative to repository root in Bundler 4, and to the default system path (\fBGem\.dir\fR) before Bundler 4\. That means that before Bundler 4, Bundler shares this location with Rubygems, and \fBgem install \|\.\|\.\|\.\fR will have gems installed in the same location and therefore, gems installed without \fBpath\fR set will show up by calling \fBgem list\fR\. This will not be the case in Bundler 4\.
-.TP
-\fBpath\.system\fR (\fBBUNDLE_PATH__SYSTEM\fR)
-Whether Bundler will install gems into the default system path (\fBGem\.dir\fR)\.
-.TP
-\fBplugins\fR (\fBBUNDLE_PLUGINS\fR)
-Enable Bundler's experimental plugin system\.
-.TP
-\fBprefer_patch\fR (\fBBUNDLE_PREFER_PATCH\fR)
-Prefer updating only to next patch version during updates\. Makes \fBbundle update\fR calls equivalent to \fBbundler update \-\-patch\fR\.
-.TP
-\fBredirect\fR (\fBBUNDLE_REDIRECT\fR)
-The number of redirects allowed for network requests\. Defaults to \fB5\fR\.
-.TP
-\fBretry\fR (\fBBUNDLE_RETRY\fR)
-The number of times to retry failed network requests\. Defaults to \fB3\fR\.
-.TP
-\fBshebang\fR (\fBBUNDLE_SHEBANG\fR)
-The program name that should be invoked for generated binstubs\. Defaults to the ruby install name used to generate the binstub\.
-.TP
-\fBsilence_deprecations\fR (\fBBUNDLE_SILENCE_DEPRECATIONS\fR)
-Whether Bundler should silence deprecation warnings for behavior that will be changed in the next major version\.
-.TP
-\fBsilence_root_warning\fR (\fBBUNDLE_SILENCE_ROOT_WARNING\fR)
-Silence the warning Bundler prints when installing gems as root\.
-.TP
-\fBsimulate_version\fR (\fBBUNDLE_SIMULATE_VERSION\fR)
-The virtual version Bundler should use for activating feature flags\. Can be used to simulate all the new functionality that will be enabled in a future major version\.
-.TP
-\fBssl_ca_cert\fR (\fBBUNDLE_SSL_CA_CERT\fR)
-Path to a designated CA certificate file or folder containing multiple certificates for trusted CAs in PEM format\.
-.TP
-\fBssl_client_cert\fR (\fBBUNDLE_SSL_CLIENT_CERT\fR)
-Path to a designated file containing a X\.509 client certificate and key in PEM format\.
-.TP
-\fBssl_verify_mode\fR (\fBBUNDLE_SSL_VERIFY_MODE\fR)
-The SSL verification mode Bundler uses when making HTTPS requests\. Defaults to verify peer\.
-.TP
-\fBsystem_bindir\fR (\fBBUNDLE_SYSTEM_BINDIR\fR)
-The location where RubyGems installs binstubs\. Defaults to \fBGem\.bindir\fR\.
-.TP
-\fBtimeout\fR (\fBBUNDLE_TIMEOUT\fR)
-The seconds allowed before timing out for network requests\. Defaults to \fB10\fR\.
-.TP
-\fBupdate_requires_all_flag\fR (\fBBUNDLE_UPDATE_REQUIRES_ALL_FLAG\fR)
-Require passing \fB\-\-all\fR to \fBbundle update\fR when everything should be updated, and disallow passing no options to \fBbundle update\fR\.
-.TP
-\fBuser_agent\fR (\fBBUNDLE_USER_AGENT\fR)
-The custom user agent fragment Bundler includes in API requests\.
-.TP
-\fBverbose\fR (\fBBUNDLE_VERBOSE\fR)
-Whether Bundler should print verbose output\. Defaults to \fBfalse\fR, unless the \fB\-\-verbose\fR CLI flag is used\.
-.TP
-\fBversion\fR (\fBBUNDLE_VERSION\fR)
-The version of Bundler to use when running under Bundler environment\. Defaults to \fBlockfile\fR\. You can also specify \fBsystem\fR or \fBx\.y\.z\fR\. \fBlockfile\fR will use the Bundler version specified in the \fBGemfile\.lock\fR, \fBsystem\fR will use the system version of Bundler, and \fBx\.y\.z\fR will use the specified version of Bundler\.
-.TP
-\fBwith\fR (\fBBUNDLE_WITH\fR)
-A space\-separated or \fB:\fR\-separated list of groups whose gems bundler should install\.
-.TP
-\fBwithout\fR (\fBBUNDLE_WITHOUT\fR)
-A space\-separated or \fB:\fR\-separated list of groups whose gems bundler should not install\.
+.IP "\(bu" 4
+\fBapi_request_size\fR (\fBBUNDLE_API_REQUEST_SIZE\fR): Configure how many dependencies to fetch when resolving the specifications\. This configuration is only used when fetching specifications from RubyGems servers that didn't implement the Compact Index API\. Defaults to 100\.
+.IP "\(bu" 4
+\fBauto_install\fR (\fBBUNDLE_AUTO_INSTALL\fR): Automatically run \fBbundle install\fR when gems are missing\.
+.IP "\(bu" 4
+\fBbin\fR (\fBBUNDLE_BIN\fR): If configured, \fBbundle binstubs\fR will install executables from gems in the bundle to the specified directory\. Otherwise it will create them in a \fBbin\fR directory relative to the Gemfile directory\. These executables run in Bundler's context\. If used, you might add this directory to your environment's \fBPATH\fR variable\. For instance, if the \fBrails\fR gem comes with a \fBrails\fR executable, \fBbundle binstubs\fR will create a \fBbin/rails\fR executable that ensures that all referred dependencies will be resolved using the bundled gems\.
+.IP "\(bu" 4
+\fBcache_all\fR (\fBBUNDLE_CACHE_ALL\fR): Cache all gems, including path and git gems\. This needs to be explicitly before bundler 4, but will be the default on bundler 4\.
+.IP "\(bu" 4
+\fBcache_all_platforms\fR (\fBBUNDLE_CACHE_ALL_PLATFORMS\fR): Cache gems for all platforms\.
+.IP "\(bu" 4
+\fBcache_path\fR (\fBBUNDLE_CACHE_PATH\fR): The directory that bundler will place cached gems in when running \fBbundle package\fR, and that bundler will look in when installing gems\. Defaults to \fBvendor/cache\fR\.
+.IP "\(bu" 4
+\fBclean\fR (\fBBUNDLE_CLEAN\fR): Whether Bundler should run \fBbundle clean\fR automatically after \fBbundle install\fR\. Defaults to \fBtrue\fR in Bundler 4, as long as \fBpath\fR is not explicitly configured\.
+.IP "\(bu" 4
+\fBconsole\fR (\fBBUNDLE_CONSOLE\fR): The console that \fBbundle console\fR starts\. Defaults to \fBirb\fR\.
+.IP "\(bu" 4
+\fBcooldown\fR (\fBBUNDLE_COOLDOWN\fR): Number of days a published gem version must age before bundler will resolve to it\. Defaults to unset (no cooldown)\. Pass \fB0\fR to disable cooldown for an individual run\.
+.IP
+The effective cooldown for any given gem is resolved from three layers, highest precedence first:
+.IP "1." 4
+CLI flag \fB\-\-cooldown N\fR on \fBinstall\fR, \fBupdate\fR, \fBadd\fR, and \fBoutdated\fR\.
+.IP "2." 4
+This setting (\fBbundle config set cooldown N\fR or \fBBUNDLE_COOLDOWN=N\fR)\.
+.IP "3." 4
+The per\-source \fBcooldown:\fR keyword in the Gemfile, such as \fBsource "https://rubygems\.org", cooldown: 7\fR\.
+.IP "" 0
+.IP
+The CLI flag and this setting apply uniformly to every source, including ones declared with their own \fBcooldown:\fR value\. To keep a private registry permanently exempt while still cooling down public gems, declare \fBsource "https://internal", cooldown: 0\fR in the Gemfile; remember that \fB\-\-cooldown N\fR on the command line will still override it for that single run\.
+.IP
+Cooldown filtering depends on the gem server providing a per\-version \fBcreated_at\fR timestamp in the v2 compact\-index format\. Versions without that metadata \- older gem servers, historical entries that predate the v2 cutover on \fBrubygems\.org\fR, or private registries that still emit the v1 format \- are treated as outside the cooldown window and remain resolvable\. If you rely on cooldown for supply\-chain protection, confirm that the gem server emits \fBcreated_at\fR in its \fB/info/<gem>\fR responses\.
+.IP "\(bu" 4
+\fBdefault_cli_command\fR (\fBBUNDLE_DEFAULT_CLI_COMMAND\fR): The command that running \fBbundle\fR without arguments should run\. Defaults to \fBcli_help\fR since Bundler 4, but can also be \fBinstall\fR which was the previous default\.
+.IP "\(bu" 4
+\fBdeployment\fR (\fBBUNDLE_DEPLOYMENT\fR): Equivalent to setting \fBfrozen\fR to \fBtrue\fR and \fBpath\fR to \fBvendor/bundle\fR\.
+.IP "\(bu" 4
+\fBdisable_checksum_validation\fR (\fBBUNDLE_DISABLE_CHECKSUM_VALIDATION\fR): Allow installing gems even if they do not match the checksum provided by RubyGems\.
+.IP "\(bu" 4
+\fBdisable_exec_load\fR (\fBBUNDLE_DISABLE_EXEC_LOAD\fR): Stop Bundler from using \fBload\fR to launch an executable in\-process in \fBbundle exec\fR\.
+.IP "\(bu" 4
+\fBdisable_local_branch_check\fR (\fBBUNDLE_DISABLE_LOCAL_BRANCH_CHECK\fR): Allow Bundler to use a local git override without a branch specified in the Gemfile\.
+.IP "\(bu" 4
+\fBdisable_local_revision_check\fR (\fBBUNDLE_DISABLE_LOCAL_REVISION_CHECK\fR): Allow Bundler to use a local git override without checking if the revision present in the lockfile is present in the repository\.
+.IP "\(bu" 4
+\fBdisable_shared_gems\fR (\fBBUNDLE_DISABLE_SHARED_GEMS\fR): Stop Bundler from accessing gems installed to RubyGems' normal location\.
+.IP "\(bu" 4
+\fBdisable_version_check\fR (\fBBUNDLE_DISABLE_VERSION_CHECK\fR): Stop Bundler from checking if a newer Bundler version is available on rubygems\.org\.
+.IP "\(bu" 4
+\fBforce_ruby_platform\fR (\fBBUNDLE_FORCE_RUBY_PLATFORM\fR): Ignore the current machine's platform and install only \fBruby\fR platform gems\. As a result, gems with native extensions will be compiled from source\.
+.IP "\(bu" 4
+\fBfrozen\fR (\fBBUNDLE_FROZEN\fR): Disallow any automatic changes to \fBGemfile\.lock\fR\. Bundler commands will be blocked unless the lockfile can be installed exactly as written\. Usually this will happen when changing the \fBGemfile\fR manually and forgetting to update the lockfile through \fBbundle lock\fR or \fBbundle install\fR\.
+.IP "\(bu" 4
+\fBgem\.github_username\fR (\fBBUNDLE_GEM__GITHUB_USERNAME\fR): Sets a GitHub username or organization to be used in the \fBREADME\fR and \fB\.gemspec\fR files when you create a new gem via \fBbundle gem\fR command\. It can be overridden by passing an explicit \fB\-\-github\-username\fR flag to \fBbundle gem\fR\.
+.IP "\(bu" 4
+\fBgem\.push_key\fR (\fBBUNDLE_GEM__PUSH_KEY\fR): Sets the \fB\-\-key\fR parameter for \fBgem push\fR when using the \fBrake release\fR command with a private gemstash server\.
+.IP "\(bu" 4
+\fBgemfile\fR (\fBBUNDLE_GEMFILE\fR): The name of the file that bundler should use as the \fBGemfile\fR\. This location of this file also sets the root of the project, which is used to resolve relative paths in the \fBGemfile\fR, among other things\. By default, bundler will search up from the current working directory until it finds a \fBGemfile\fR\.
+.IP "\(bu" 4
+\fBglobal_gem_cache\fR (\fBBUNDLE_GLOBAL_GEM_CACHE\fR): Whether Bundler should cache all gems and compiled extensions globally, rather than locally to the configured installation path\.
+.IP "\(bu" 4
+\fBignore_funding_requests\fR (\fBBUNDLE_IGNORE_FUNDING_REQUESTS\fR): When set, no funding requests will be printed\.
+.IP "\(bu" 4
+\fBignore_messages\fR (\fBBUNDLE_IGNORE_MESSAGES\fR): When set, no post install messages will be printed\. To silence a single gem, use dot notation like \fBignore_messages\.httparty true\fR\.
+.IP "\(bu" 4
+\fBinit_gems_rb\fR (\fBBUNDLE_INIT_GEMS_RB\fR): Generate a \fBgems\.rb\fR instead of a \fBGemfile\fR when running \fBbundle init\fR\.
+.IP "\(bu" 4
+\fBjobs\fR (\fBBUNDLE_JOBS\fR): The number of gems Bundler can download and install in parallel\. Defaults to the number of available processors\.
+.IP "\(bu" 4
+\fBlockfile\fR (\fBBUNDLE_LOCKFILE\fR): The path to the lockfile that bundler should use\. By default, Bundler adds \fB\.lock\fR to the end of the \fBgemfile\fR entry\. Can be set to \fBfalse\fR in the Gemfile to disable lockfile creation entirely (see gemfile(5))\.
+.IP "\(bu" 4
+\fBlockfile_checksums\fR (\fBBUNDLE_LOCKFILE_CHECKSUMS\fR): Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources\. Defaults to true\.
+.IP "\(bu" 4
+\fBno_build_extension\fR (\fBBUNDLE_NO_BUILD_EXTENSION\fR): Whether Bundler should skip building native extensions during installation\. When set, gems are installed without compiling their C extensions\. To build extensions later, unset this setting and run \fBbundle pristine <gem>\fR\.
+.IP "\(bu" 4
+\fBno_install\fR (\fBBUNDLE_NO_INSTALL\fR): Whether \fBbundle package\fR should skip installing gems\.
+.IP "\(bu" 4
+\fBno_install_plugin\fR (\fBBUNDLE_NO_INSTALL_PLUGIN\fR): Whether Bundler should skip installing RubyGems plugins during installation\. When set, plugin files are not written to the plugins directory\. To install plugins later, unset this setting and run \fBbundle pristine <gem>\fR\.
+.IP "\(bu" 4
+\fBno_prune\fR (\fBBUNDLE_NO_PRUNE\fR): Whether Bundler should leave outdated gems unpruned when caching\.
+.IP "\(bu" 4
+\fBonly\fR (\fBBUNDLE_ONLY\fR): A space\-separated list of groups to install only gems of the specified groups\. Please check carefully if you want to install also gems without a group, because they get put inside \fBdefault\fR group\. For example \fBonly test:default\fR will install all gems specified in test group and without one\.
+.IP "\(bu" 4
+\fBpath\fR (\fBBUNDLE_PATH\fR): The location on disk where all gems in your bundle will be located regardless of \fB$GEM_HOME\fR or \fB$GEM_PATH\fR values\. Bundle gems not found in this location will be installed by \fBbundle install\fR\. When not set, Bundler install by default to a \fB\.bundle\fR directory relative to repository root in Bundler 4, and to the default system path (\fBGem\.dir\fR) before Bundler 4\. That means that before Bundler 4, Bundler shares this location with Rubygems, and \fBgem install \|\.\|\.\|\.\fR will have gems installed in the same location and therefore, gems installed without \fBpath\fR set will show up by calling \fBgem list\fR\. This will not be the case in Bundler 4\.
+.IP "\(bu" 4
+\fBpath\.system\fR (\fBBUNDLE_PATH__SYSTEM\fR): Whether Bundler will install gems into the default system path (\fBGem\.dir\fR)\.
+.IP "\(bu" 4
+\fBplugins\fR (\fBBUNDLE_PLUGINS\fR): Enable Bundler's experimental plugin system\.
+.IP "\(bu" 4
+\fBprefer_patch\fR (\fBBUNDLE_PREFER_PATCH\fR): Prefer updating only to next patch version during updates\. Makes \fBbundle update\fR calls equivalent to \fBbundler update \-\-patch\fR\.
+.IP "\(bu" 4
+\fBredirect\fR (\fBBUNDLE_REDIRECT\fR): The number of redirects allowed for network requests\. Defaults to \fB5\fR\.
+.IP "\(bu" 4
+\fBretry\fR (\fBBUNDLE_RETRY\fR): The number of times to retry failed network requests\. Defaults to \fB3\fR\.
+.IP "\(bu" 4
+\fBshebang\fR (\fBBUNDLE_SHEBANG\fR): The program name that should be invoked for generated binstubs\. Defaults to the ruby install name used to generate the binstub\.
+.IP "\(bu" 4
+\fBsilence_deprecations\fR (\fBBUNDLE_SILENCE_DEPRECATIONS\fR): Whether Bundler should silence deprecation warnings for behavior that will be changed in the next major version\.
+.IP "\(bu" 4
+\fBsilence_root_warning\fR (\fBBUNDLE_SILENCE_ROOT_WARNING\fR): Silence the warning Bundler prints when installing gems as root\.
+.IP "\(bu" 4
+\fBsimulate_version\fR (\fBBUNDLE_SIMULATE_VERSION\fR): The virtual version Bundler should use for activating feature flags\. Can be used to simulate all the new functionality that will be enabled in a future major version\.
+.IP "\(bu" 4
+\fBssl_ca_cert\fR (\fBBUNDLE_SSL_CA_CERT\fR): Path to a designated CA certificate file or folder containing multiple certificates for trusted CAs in PEM format\.
+.IP "\(bu" 4
+\fBssl_client_cert\fR (\fBBUNDLE_SSL_CLIENT_CERT\fR): Path to a designated file containing a X\.509 client certificate and key in PEM format\.
+.IP "\(bu" 4
+\fBssl_verify_mode\fR (\fBBUNDLE_SSL_VERIFY_MODE\fR): The SSL verification mode Bundler uses when making HTTPS requests\. Defaults to verify peer\.
+.IP "\(bu" 4
+\fBsystem_bindir\fR (\fBBUNDLE_SYSTEM_BINDIR\fR): The location where RubyGems installs binstubs\. Defaults to \fBGem\.bindir\fR\.
+.IP "\(bu" 4
+\fBtimeout\fR (\fBBUNDLE_TIMEOUT\fR): The seconds allowed before timing out for network requests\. Defaults to \fB10\fR\.
+.IP "\(bu" 4
+\fBupdate_requires_all_flag\fR (\fBBUNDLE_UPDATE_REQUIRES_ALL_FLAG\fR): Require passing \fB\-\-all\fR to \fBbundle update\fR when everything should be updated, and disallow passing no options to \fBbundle update\fR\.
+.IP "\(bu" 4
+\fBuser_agent\fR (\fBBUNDLE_USER_AGENT\fR): The custom user agent fragment Bundler includes in API requests\.
+.IP "\(bu" 4
+\fBverbose\fR (\fBBUNDLE_VERBOSE\fR): Whether Bundler should print verbose output\. Defaults to \fBfalse\fR, unless the \fB\-\-verbose\fR CLI flag is used\.
+.IP "\(bu" 4
+\fBversion\fR (\fBBUNDLE_VERSION\fR): The version of Bundler to use when running under Bundler environment\. Defaults to \fBlockfile\fR\. You can also specify \fBsystem\fR or \fBx\.y\.z\fR\. \fBlockfile\fR will use the Bundler version specified in the \fBGemfile\.lock\fR, \fBsystem\fR will use the system version of Bundler, and \fBx\.y\.z\fR will use the specified version of Bundler\.
+.IP "\(bu" 4
+\fBwith\fR (\fBBUNDLE_WITH\fR): A space\-separated or \fB:\fR\-separated list of groups whose gems bundler should install\.
+.IP "\(bu" 4
+\fBwithout\fR (\fBBUNDLE_WITHOUT\fR): A space\-separated or \fB:\fR\-separated list of groups whose gems bundler should not install\.
+.IP "" 0
 .SH "BUILD OPTIONS"
 You can use \fBbundle config\fR to give Bundler the flags to pass to the gem installer every time bundler tries to install a particular gem\.
 .P

--- a/bundler/lib/bundler/man/bundle-config.1.ronn
+++ b/bundler/lib/bundler/man/bundle-config.1.ronn
@@ -137,6 +137,36 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    explicitly configured.
 * `console` (`BUNDLE_CONSOLE`):
    The console that `bundle console` starts. Defaults to `irb`.
+* `cooldown` (`BUNDLE_COOLDOWN`):
+   Number of days a published gem version must age before bundler will
+   resolve to it. Defaults to unset (no cooldown). Pass `0` to disable
+   cooldown for an individual run.
+
+   The effective cooldown for any given gem is resolved from three
+   layers, highest precedence first:
+
+     1. CLI flag `--cooldown N` on `install`, `update`, `add`, and
+        `outdated`.
+     2. This setting (`bundle config set cooldown N` or
+        `BUNDLE_COOLDOWN=N`).
+     3. The per-source `cooldown:` keyword in the Gemfile, such as
+        `source "https://rubygems.org", cooldown: 7`.
+
+   The CLI flag and this setting apply uniformly to every source,
+   including ones declared with their own `cooldown:` value. To keep a
+   private registry permanently exempt while still cooling down public
+   gems, declare `source "https://internal", cooldown: 0` in the
+   Gemfile; remember that `--cooldown N` on the command line will
+   still override it for that single run.
+
+   Cooldown filtering depends on the gem server providing a per-version
+   `created_at` timestamp in the v2 compact-index format. Versions
+   without that metadata - older gem servers, historical entries that
+   predate the v2 cutover on `rubygems.org`, or private registries that
+   still emit the v1 format - are treated as outside the cooldown
+   window and remain resolvable. If you rely on cooldown for
+   supply-chain protection, confirm that the gem server emits
+   `created_at` in its `/info/<gem>` responses.
 * `default_cli_command` (`BUNDLE_DEFAULT_CLI_COMMAND`):
    The command that running `bundle` without arguments should run. Defaults to
    `cli_help` since Bundler 4, but can also be `install` which was the previous

--- a/bundler/lib/bundler/man/bundle-install.1
+++ b/bundler/lib/bundler/man/bundle-install.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-install\fR \- Install the dependencies specified in your Gemfile
 .SH "SYNOPSIS"
-\fBbundle install\fR [\-\-force] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-local] [\-\-lockfile=LOCKFILE] [\-\-no\-cache] [\-\-no\-lock] [\-\-prefer\-local] [\-\-quiet] [\-\-retry=NUMBER] [\-\-standalone[=GROUP[ GROUP\|\.\|\.\|\.]]] [\-\-trust\-policy=TRUST\-POLICY] [\-\-target\-rbconfig=TARGET\-RBCONFIG]
+\fBbundle install\fR [\-\-cooldown=NUMBER] [\-\-force] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-local] [\-\-lockfile=LOCKFILE] [\-\-no\-cache] [\-\-no\-lock] [\-\-prefer\-local] [\-\-quiet] [\-\-retry=NUMBER] [\-\-standalone[=GROUP[ GROUP\|\.\|\.\|\.]]] [\-\-trust\-policy=TRUST\-POLICY] [\-\-target\-rbconfig=TARGET\-RBCONFIG]
 .SH "DESCRIPTION"
 Install the gems specified in your Gemfile(5)\. If this is the first time you run bundle install (and a \fBGemfile\.lock\fR does not exist), Bundler will fetch all remote sources, resolve dependencies and install all needed gems\.
 .P
@@ -12,6 +12,9 @@ If a \fBGemfile\.lock\fR does exist, and you have not updated your Gemfile(5), B
 .P
 If a \fBGemfile\.lock\fR does exist, and you have updated your Gemfile(5), Bundler will use the dependencies in the \fBGemfile\.lock\fR for all gems that you did not update, but will re\-resolve the dependencies of gems that you did update\. You can find more information about this update process below under \fICONSERVATIVE UPDATING\fR\.
 .SH "OPTIONS"
+.TP
+\fB\-\-cooldown=<number>\fR
+Only consider gem versions published at least \fInumber\fR days ago when resolving\. Pass \fB0\fR to disable cooldown for this run, overriding any per\-source or global configuration\. See \fBcooldown\fR in bundle\-config(1) for details on the precedence between the CLI flag, Bundler config, and Gemfile per\-source settings\.
 .TP
 \fB\-\-force\fR, \fB\-\-redownload\fR
 Force reinstalling every gem, even if already installed\.

--- a/bundler/lib/bundler/man/bundle-install.1.ronn
+++ b/bundler/lib/bundler/man/bundle-install.1.ronn
@@ -3,7 +3,8 @@ bundle-install(1) -- Install the dependencies specified in your Gemfile
 
 ## SYNOPSIS
 
-`bundle install` [--force]
+`bundle install` [--cooldown=NUMBER]
+                 [--force]
                  [--full-index]
                  [--gemfile=GEMFILE]
                  [--jobs=NUMBER]
@@ -36,6 +37,13 @@ gems that you did update. You can find more information about this
 update process below under [CONSERVATIVE UPDATING][].
 
 ## OPTIONS
+
+* `--cooldown=<number>`:
+  Only consider gem versions published at least <number> days ago when
+  resolving. Pass `0` to disable cooldown for this run, overriding any
+  per-source or global configuration. See `cooldown` in bundle-config(1)
+  for details on the precedence between the CLI flag, Bundler config,
+  and Gemfile per-source settings.
 
 * `--force`, `--redownload`:
   Force reinstalling every gem, even if already installed.

--- a/bundler/lib/bundler/man/bundle-outdated.1
+++ b/bundler/lib/bundler/man/bundle-outdated.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-outdated\fR \- List installed gems with newer versions available
 .SH "SYNOPSIS"
-\fBbundle outdated\fR [GEM] [\-\-local] [\-\-pre] [\-\-source] [\-\-filter\-strict | \-\-strict] [\-\-update\-strict] [\-\-parseable | \-\-porcelain] [\-\-group=GROUP] [\-\-groups] [\-\-patch|\-\-minor|\-\-major] [\-\-filter\-major] [\-\-filter\-minor] [\-\-filter\-patch] [\-\-only\-explicit]
+\fBbundle outdated\fR [GEM] [\-\-local] [\-\-pre] [\-\-source] [\-\-filter\-strict | \-\-strict] [\-\-update\-strict] [\-\-parseable | \-\-porcelain] [\-\-group=GROUP] [\-\-groups] [\-\-patch|\-\-minor|\-\-major] [\-\-filter\-major] [\-\-filter\-minor] [\-\-filter\-patch] [\-\-only\-explicit] [\-\-cooldown=NUMBER]
 .SH "DESCRIPTION"
 Outdated lists the names and versions of gems that have a newer version available in the given source\. Calling outdated with [GEM [GEM]] will only check for newer versions of the given gems\. Prerelease gems are ignored by default\. If your gems are up to date, Bundler will exit with a status of 0\. Otherwise, it will exit 1\.
 .SH "OPTIONS"
@@ -53,6 +53,9 @@ Only list patch newer versions\.
 .TP
 \fB\-\-only\-explicit\fR
 Only list gems specified in your Gemfile, not their dependencies\.
+.TP
+\fB\-\-cooldown=<number>\fR
+Annotate (rather than hide) versions that are still inside the cooldown window of \fInumber\fR days\. The prose output appends "in cooldown for Nd more days" and the table form adds "(cooldown Nd)" to the Latest column\. See \fBcooldown\fR in bundle\-config(1)\.
 .SH "PATCH LEVEL OPTIONS"
 See bundle update(1) \fIbundle\-update\.1\.html\fR for details\.
 .SH "FILTERING OUTPUT"

--- a/bundler/lib/bundler/man/bundle-outdated.1.ronn
+++ b/bundler/lib/bundler/man/bundle-outdated.1.ronn
@@ -16,6 +16,7 @@ bundle-outdated(1) -- List installed gems with newer versions available
                         [--filter-minor]
                         [--filter-patch]
                         [--only-explicit]
+                        [--cooldown=NUMBER]
 
 ## DESCRIPTION
 
@@ -70,6 +71,12 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
 
 * `--only-explicit`:
   Only list gems specified in your Gemfile, not their dependencies.
+
+* `--cooldown=<number>`:
+  Annotate (rather than hide) versions that are still inside the
+  cooldown window of <number> days. The prose output appends "in
+  cooldown for Nd more days" and the table form adds "(cooldown Nd)" to
+  the Latest column. See `cooldown` in bundle-config(1).
 
 ## PATCH LEVEL OPTIONS
 

--- a/bundler/lib/bundler/man/bundle-update.1
+++ b/bundler/lib/bundler/man/bundle-update.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBbundle\-update\fR \- Update your gems to the latest available versions
 .SH "SYNOPSIS"
-\fBbundle update\fR \fI*gems\fR [\-\-all] [\-\-group=NAME] [\-\-source=NAME] [\-\-local] [\-\-ruby] [\-\-bundler[=VERSION]] [\-\-force] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-quiet] [\-\-patch|\-\-minor|\-\-major] [\-\-pre] [\-\-strict] [\-\-conservative]
+\fBbundle update\fR \fI*gems\fR [\-\-all] [\-\-group=NAME] [\-\-source=NAME] [\-\-local] [\-\-ruby] [\-\-bundler[=VERSION]] [\-\-cooldown=NUMBER] [\-\-force] [\-\-full\-index] [\-\-gemfile=GEMFILE] [\-\-jobs=NUMBER] [\-\-quiet] [\-\-patch|\-\-minor|\-\-major] [\-\-pre] [\-\-strict] [\-\-conservative]
 .SH "DESCRIPTION"
 Update the gems specified (all gems, if \fB\-\-all\fR flag is used), ignoring the previously installed gems specified in the \fBGemfile\.lock\fR\. In general, you should use bundle install(1) \fIbundle\-install\.1\.html\fR to install the same exact gems and versions across machines\.
 .P
@@ -64,6 +64,9 @@ Do not allow any gem to be updated past latest \fB\-\-patch\fR | \fB\-\-minor\fR
 .TP
 \fB\-\-conservative\fR
 Use bundle install conservative update behavior and do not allow indirect dependencies to be updated\.
+.TP
+\fB\-\-cooldown=<number>\fR
+Only consider gem versions published at least \fInumber\fR days ago when resolving\. Pass \fB0\fR to disable cooldown for this run, overriding any per\-source or global configuration\. Combine with \fB\-\-conservative\fR to minimize transitive churn when bypassing cooldown for an urgent update\. See \fBcooldown\fR in bundle\-config(1)\.
 .SH "UPDATING ALL GEMS"
 If you run \fBbundle update \-\-all\fR, bundler will ignore any previously installed gems and resolve all dependencies again based on the latest versions of all gems available in the sources\.
 .P

--- a/bundler/lib/bundler/man/bundle-update.1.ronn
+++ b/bundler/lib/bundler/man/bundle-update.1.ronn
@@ -9,6 +9,7 @@ bundle-update(1) -- Update your gems to the latest available versions
                         [--local]
                         [--ruby]
                         [--bundler[=VERSION]]
+                        [--cooldown=NUMBER]
                         [--force]
                         [--full-index]
                         [--gemfile=GEMFILE]
@@ -90,6 +91,13 @@ gem.
 
 * `--conservative`:
   Use bundle install conservative update behavior and do not allow indirect dependencies to be updated.
+
+* `--cooldown=<number>`:
+  Only consider gem versions published at least <number> days ago when
+  resolving. Pass `0` to disable cooldown for this run, overriding any
+  per-source or global configuration. Combine with `--conservative` to
+  minimize transitive churn when bypassing cooldown for an urgent
+  update. See `cooldown` in bundle-config(1).
 
 ## UPDATING ALL GEMS
 

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -203,6 +203,9 @@ module Bundler
 
         platforms_explanation = specs_matching_other_platforms.any? ? " for any resolution platforms (#{package.platforms.join(", ")})" : ""
         custom_explanation = "#{constraint} could not be found in #{repository_for(package)}#{platforms_explanation}"
+        if hint = cooldown_hint(specs_matching_other_platforms)
+          custom_explanation += " (#{hint})"
+        end
 
         label = "#{name} (#{constraint_string})"
         extended_explanation = other_specs_matching_message(specs_matching_other_platforms, label) if specs_matching_other_platforms.any?
@@ -372,6 +375,10 @@ module Bundler
         message << "\n#{other_specs_matching_message(specs, matching_part)}"
       end
 
+      if hint = cooldown_hint(specs_matching_requirement)
+        message << "\n\n#{hint}."
+      end
+
       if specs_matching_requirement.any? && (hint = platform_mismatch_hint)
         message << "\n\n#{hint}"
       end
@@ -415,13 +422,42 @@ module Bundler
     end
 
     def filter_specs(specs, package)
-      filter_remote_specs(filter_prereleases(specs, package), package)
+      filter_cooldown(filter_remote_specs(filter_prereleases(specs, package), package))
     end
 
     def filter_prereleases(specs, package)
       return specs unless package.ignores_prereleases? && specs.size > 1
 
       specs.reject {|s| s.version.prerelease? }
+    end
+
+    def filter_cooldown(specs)
+      return specs if specs.empty?
+      excluded = cooldown_excluded_specs(specs)
+      return specs if excluded.empty?
+      specs - excluded
+    end
+
+    def cooldown_excluded_specs(specs)
+      specs.select {|spec| cooldown_excluded?(spec) }
+    end
+
+    def cooldown_hint(specs)
+      excluded = cooldown_excluded_specs(specs)
+      return nil if excluded.empty?
+      "#{excluded.size} version#{"s" if excluded.size > 1} excluded by the cooldown setting; pass `--cooldown 0` to bypass"
+    end
+
+    def cooldown_excluded?(spec)
+      return false unless spec.respond_to?(:created_at) && spec.created_at
+      return false unless spec.respond_to?(:remote) && spec.remote
+      days = spec.remote.effective_cooldown
+      return false if days.nil? || days <= 0
+      (cooldown_now - spec.created_at) < (days * 86_400)
+    end
+
+    def cooldown_now
+      @cooldown_now ||= Time.now
     end
 
     def filter_remote_specs(specs, package)

--- a/bundler/lib/bundler/settings.rb
+++ b/bundler/lib/bundler/settings.rb
@@ -44,6 +44,7 @@ module Bundler
     ].freeze
 
     NUMBER_KEYS = %w[
+      cooldown
       jobs
       redirect
       retry

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -16,6 +16,7 @@ module Bundler
       def initialize(options = {})
         @options = options
         @remotes = []
+        @remote_cooldowns = {}
         @dependency_names = []
         @allow_remote = false
         @allow_cached = false
@@ -25,7 +26,8 @@ module Bundler
         @gem_installers = {}
         @gem_installers_mutex = Mutex.new
 
-        Array(options["remotes"]).reverse_each {|r| add_remote(r) }
+        cooldown = options["cooldown"]
+        Array(options["remotes"]).reverse_each {|r| add_remote(r, cooldown: cooldown) }
 
         @lockfile_remotes = @remotes if options["from_lockfile"]
       end
@@ -243,9 +245,14 @@ module Bundler
         cached_path
       end
 
-      def add_remote(source)
+      def add_remote(source, cooldown: nil)
         uri = normalize_uri(source)
         @remotes.unshift(uri) unless @remotes.include?(uri)
+        @remote_cooldowns[uri] = cooldown if cooldown
+      end
+
+      def cooldown_for(uri)
+        @remote_cooldowns[uri]
       end
 
       def spec_names
@@ -266,7 +273,7 @@ module Bundler
 
       def remote_fetchers
         @remote_fetchers ||= remotes.to_h do |uri|
-          remote = Source::Rubygems::Remote.new(uri)
+          remote = Source::Rubygems::Remote.new(uri, cooldown: cooldown_for(uri))
           [remote, Bundler::Fetcher.new(remote)]
         end.freeze
       end

--- a/bundler/lib/bundler/source/rubygems/remote.rb
+++ b/bundler/lib/bundler/source/rubygems/remote.rb
@@ -4,9 +4,9 @@ module Bundler
   class Source
     class Rubygems
       class Remote
-        attr_reader :uri, :anonymized_uri, :original_uri
+        attr_reader :uri, :anonymized_uri, :original_uri, :cooldown
 
-        def initialize(uri)
+        def initialize(uri, cooldown: nil)
           orig_uri = uri
           uri = Bundler.settings.mirror_for(uri)
           @original_uri = orig_uri if orig_uri != uri
@@ -14,6 +14,16 @@ module Bundler
 
           @uri = apply_auth(uri, fallback_auth).freeze
           @anonymized_uri = remove_auth(@uri).freeze
+          @cooldown = cooldown
+        end
+
+        # Returns the cooldown days that apply to this remote, resolving the
+        # precedence CLI > config > Gemfile per-source. Returns nil if no
+        # cooldown applies.
+        def effective_cooldown
+          override = Bundler.settings[:cooldown]
+          return override if override
+          @cooldown
         end
 
         MAX_CACHE_SLUG_HOST_SIZE = 255 - 1 - 32 # 255 minus dot minus MD5 length

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -59,8 +59,8 @@ module Bundler
       add_source_to_list Plugin.source(source).new(options), @plugin_sources
     end
 
-    def add_global_rubygems_remote(uri)
-      global_rubygems_source.add_remote(uri)
+    def add_global_rubygems_remote(uri, cooldown: nil)
+      global_rubygems_source.add_remote(uri, cooldown: cooldown)
       global_rubygems_source
     end
 

--- a/lib/rubygems/resolver/api_set/gem_parser.rb
+++ b/lib/rubygems/resolver/api_set/gem_parser.rb
@@ -13,7 +13,7 @@ class Gem::Resolver::APISet::GemParser
   private
 
   def parse_dependency(string)
-    dependency = string.split(":")
+    dependency = string.split(":", 2)
     dependency[-1] = dependency[-1].split("&") if dependency.size > 1
     dependency[0] = -dependency[0]
     dependency

--- a/spec/bundler/compact_index_client/parser_spec.rb
+++ b/spec/bundler/compact_index_client/parser_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Bundler::CompactIndexClient::Parser do
   INFO
   let(:c_info) { <<~INFO }
     3.0.0 a:= 1.0.0,b:~> 2.0|checksum:ccc1,ruby:>= 2.7.0,rubygems:>= 3.0.0
-    3.3.3 a:>= 1.1.0,b:~> 2.0|checksum:ccc3,ruby:>= 3.0.0,rubygems:>= 3.2.3
+    3.3.3 a:>= 1.1.0,b:~> 2.0|checksum:ccc3,ruby:>= 3.0.0,rubygems:>= 3.2.3,created_at:2026-05-12T10:00:00Z
   INFO
 
   describe "#available?" do
@@ -195,7 +195,7 @@ RSpec.describe Bundler::CompactIndexClient::Parser do
           "3.3.3",
           nil,
           [["a", [">= 1.1.0"]], ["b", ["~> 2.0"]]],
-          [["checksum", ["ccc3"]], ["ruby", [">= 3.0.0"]], ["rubygems", [">= 3.2.3"]]],
+          [["checksum", ["ccc3"]], ["ruby", [">= 3.0.0"]], ["rubygems", [">= 3.2.3"]], ["created_at", ["2026-05-12T10:00:00Z"]]],
         ],
       ]
     end

--- a/spec/bundler/dsl_spec.rb
+++ b/spec/bundler/dsl_spec.rb
@@ -367,6 +367,48 @@ RSpec.describe Bundler::Dsl do
     end
   end
 
+  describe "#source with cooldown" do
+    before do
+      allow(@rubygems).to receive(:add_remote)
+    end
+
+    it "accepts a non-negative integer" do
+      expect do
+        subject.source("https://rubygems.org", cooldown: 7)
+      end.not_to raise_error
+    end
+
+    it "accepts 0 as an explicit disable" do
+      expect do
+        subject.source("https://rubygems.org", cooldown: 0)
+      end.not_to raise_error
+    end
+
+    it "rejects a string" do
+      expect do
+        subject.source("https://rubygems.org", cooldown: "7")
+      end.to raise_error(Bundler::InvalidOption, /non-negative integer/)
+    end
+
+    it "rejects a float" do
+      expect do
+        subject.source("https://rubygems.org", cooldown: 7.5)
+      end.to raise_error(Bundler::InvalidOption, /non-negative integer/)
+    end
+
+    it "rejects a negative integer" do
+      expect do
+        subject.source("https://rubygems.org", cooldown: -7)
+      end.to raise_error(Bundler::InvalidOption, /non-negative integer/)
+    end
+
+    it "rejects an array" do
+      expect do
+        subject.source("https://rubygems.org", cooldown: [7])
+      end.to raise_error(Bundler::InvalidOption, /non-negative integer/)
+    end
+  end
+
   describe "#override" do
     it "stores an Override for a gem with a version: operation" do
       subject.override("rails", version: ">= 8.0")

--- a/spec/bundler/endpoint_specification_spec.rb
+++ b/spec/bundler/endpoint_specification_spec.rb
@@ -46,6 +46,46 @@ RSpec.describe Bundler::EndpointSpecification do
         )
       end
     end
+
+    context "when the metadata has created_at" do
+      let(:metadata) { { "created_at" => ["2026-05-12T10:00:00Z"] } }
+
+      it "parses created_at as a Time" do
+        expect(subject.created_at).to eq(Time.utc(2026, 5, 12, 10, 0, 0))
+      end
+    end
+
+    context "when the metadata has a string created_at (older rubygems shape)" do
+      let(:metadata) { { "created_at" => "2026-05-12T10:00:00Z" } }
+
+      it "still parses created_at" do
+        expect(subject.created_at).to eq(Time.utc(2026, 5, 12, 10, 0, 0))
+      end
+    end
+
+    context "when created_at is truncated (older rubygems splits on colons)" do
+      let(:metadata) { { "created_at" => "2026-05-12T10" } }
+
+      it "leaves created_at as nil instead of raising" do
+        expect(subject.created_at).to be_nil
+      end
+    end
+
+    context "when the metadata has no created_at" do
+      let(:metadata) { { "checksum" => ["abc"] } }
+      let(:spec_fetcher) { double(:spec_fetcher, uri: "https://rubygems.org") }
+
+      it "leaves created_at as nil" do
+        allow(Bundler::Checksum).to receive(:from_api).and_return(nil)
+        expect(subject.created_at).to be_nil
+      end
+    end
+
+    context "when the metadata is nil" do
+      it "leaves created_at as nil" do
+        expect(subject.created_at).to be_nil
+      end
+    end
   end
 
   describe "#required_ruby_version" do

--- a/spec/bundler/resolver/cooldown_spec.rb
+++ b/spec/bundler/resolver/cooldown_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::Resolver do
+  let(:resolver) { described_class.allocate }
+
+  def remote(cooldown:)
+    instance_double(Bundler::Source::Rubygems::Remote, effective_cooldown: cooldown)
+  end
+
+  def spec(created_at:, remote:)
+    Struct.new(:created_at, :remote).new(created_at, remote)
+  end
+
+  describe "#filter_cooldown" do
+    let(:now) { Time.now }
+
+    context "with a 7-day cooldown" do
+      let(:r) { remote(cooldown: 7) }
+
+      it "rejects versions published within the window" do
+        recent = spec(created_at: now - (2 * 86_400), remote: r)
+        old = spec(created_at: now - (30 * 86_400), remote: r)
+
+        expect(resolver.send(:filter_cooldown, [recent, old])).to eq([old])
+      end
+
+      it "keeps versions published exactly at the threshold" do
+        boundary = spec(created_at: now - (7 * 86_400), remote: r)
+
+        expect(resolver.send(:filter_cooldown, [boundary])).to eq([boundary])
+      end
+
+      it "leaves rolling-delay history intact" do
+        # 7-day cooldown with frequent releases must still expose an older candidate.
+        in_cooldown = spec(created_at: now - 86_400, remote: r)
+        also_in_cooldown = spec(created_at: now - (3 * 86_400), remote: r)
+        eligible = spec(created_at: now - (10 * 86_400), remote: r)
+
+        result = resolver.send(:filter_cooldown, [in_cooldown, also_in_cooldown, eligible])
+
+        expect(result).to eq([eligible])
+      end
+    end
+
+    context "when created_at is missing (blank metadata)" do
+      it "keeps the spec regardless of cooldown" do
+        s = spec(created_at: nil, remote: remote(cooldown: 7))
+
+        expect(resolver.send(:filter_cooldown, [s])).to eq([s])
+      end
+    end
+
+    context "when the remote has no cooldown" do
+      it "keeps every spec" do
+        s = spec(created_at: now - 3600, remote: remote(cooldown: nil))
+
+        expect(resolver.send(:filter_cooldown, [s])).to eq([s])
+      end
+    end
+
+    context "when cooldown is 0" do
+      it "keeps every spec (escape hatch)" do
+        s = spec(created_at: now - 3600, remote: remote(cooldown: 0))
+
+        expect(resolver.send(:filter_cooldown, [s])).to eq([s])
+      end
+    end
+
+    context "when the spec does not respond to created_at" do
+      it "keeps the spec" do
+        bare = Struct.new(:version).new("1.0.0")
+
+        expect(resolver.send(:filter_cooldown, [bare])).to eq([bare])
+      end
+    end
+
+    context "when the spec has no remote" do
+      it "keeps the spec" do
+        s = spec(created_at: now - 86_400, remote: nil)
+
+        expect(resolver.send(:filter_cooldown, [s])).to eq([s])
+      end
+    end
+
+    it "returns the same array when input is empty" do
+      expect(resolver.send(:filter_cooldown, [])).to eq([])
+    end
+  end
+
+  describe "#cooldown_hint" do
+    let(:now) { Time.now }
+    let(:r) { remote(cooldown: 7) }
+
+    it "returns nil when no spec is excluded" do
+      expect(resolver.send(:cooldown_hint, [])).to be_nil
+    end
+
+    it "returns nil when every spec is outside the cooldown window" do
+      eligible = [spec(created_at: now - (30 * 86_400), remote: r)]
+
+      expect(resolver.send(:cooldown_hint, eligible)).to be_nil
+    end
+
+    it "mentions the count and the bypass flag for one excluded version" do
+      excluded = [spec(created_at: now - 86_400, remote: r)]
+
+      hint = resolver.send(:cooldown_hint, excluded)
+
+      expect(hint).to match(/1 version excluded by the cooldown setting/)
+      expect(hint).to match(/--cooldown 0/)
+    end
+
+    it "uses plural wording when multiple versions are excluded" do
+      excluded = Array.new(3) { spec(created_at: now - 86_400, remote: r) }
+
+      expect(resolver.send(:cooldown_hint, excluded)).to match(/3 versions excluded/)
+    end
+  end
+end

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -119,6 +119,11 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
         settings.set_local :ssl_verify_mode, "1"
         expect(settings[:ssl_verify_mode]).to be 1
       end
+
+      it "coerces cooldown to integer" do
+        settings.set_local :cooldown, "7"
+        expect(settings[:cooldown]).to be 7
+      end
     end
 
     context "when it's not possible to create the settings directory" do

--- a/spec/bundler/source/rubygems/remote_spec.rb
+++ b/spec/bundler/source/rubygems/remote_spec.rb
@@ -169,4 +169,39 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
       end
     end
   end
+
+  describe "#cooldown" do
+    it "is nil by default" do
+      expect(remote(uri_no_auth).cooldown).to be_nil
+    end
+
+    it "returns the value passed to the constructor" do
+      r = Bundler::Source::Rubygems::Remote.new(uri_no_auth, cooldown: 7)
+      expect(r.cooldown).to eq(7)
+    end
+  end
+
+  describe "#effective_cooldown" do
+    it "returns the per-remote value when no override is set" do
+      r = Bundler::Source::Rubygems::Remote.new(uri_no_auth, cooldown: 7)
+      expect(r.effective_cooldown).to eq(7)
+    end
+
+    it "returns nil when neither override nor per-remote value is set" do
+      expect(remote(uri_no_auth).effective_cooldown).to be_nil
+    end
+
+    it "settings override per-remote value" do
+      r = Bundler::Source::Rubygems::Remote.new(uri_no_auth, cooldown: 7)
+      Bundler.settings.temporary(cooldown: 14) do
+        expect(r.effective_cooldown).to eq(14)
+      end
+    end
+
+    it "settings override even when per-remote value is absent" do
+      Bundler.settings.temporary(cooldown: 14) do
+        expect(remote(uri_no_auth).effective_cooldown).to eq(14)
+      end
+    end
+  end
 end

--- a/spec/bundler/source_list_spec.rb
+++ b/spec/bundler/source_list_spec.rb
@@ -129,6 +129,12 @@ RSpec.describe Bundler::SourceList do
           Gem::URI("https://rubygems.org/"),
         ]
       end
+
+      it "records the per-remote cooldown when supplied" do
+        source_list.add_global_rubygems_remote("https://othersource.org", cooldown: 7)
+        expect(returned_source.cooldown_for(Gem::URI("https://othersource.org/"))).to eq(7)
+        expect(returned_source.cooldown_for(Gem::URI("https://rubygems.org/"))).to be_nil
+      end
     end
 
     describe "#add_plugin_source" do

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe "bundle install with the cooldown setting" do
 
       expect(the_bundle).to include_gems("myrack 1.0.0")
     end
+
+    it "rejects a negative --cooldown value" do
+      bundle "install --cooldown=-7", artifice: "compact_index", raise_on_error: false
+
+      expect(err).to match(/non-negative integer/)
+    end
   end
 
   context "configuration" do
@@ -153,6 +159,88 @@ RSpec.describe "bundle install with the cooldown setting" do
       bundle "install --cooldown 7", artifice: "compact_index_cooldown"
 
       expect(the_bundle).to include_gems("ripe_gem 2.0.0")
+    end
+
+    it "annotates in-cooldown versions in bundle outdated table output" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem", "1.0.0"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem (= 1.0.0)
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "outdated --cooldown 7", artifice: "compact_index_cooldown", raise_on_error: false
+
+      expect(out).to match(/ripe_gem.*\(cooldown \d+d\)/)
+    end
+
+    it "annotates in-cooldown versions in bundle outdated --parseable output" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem", "1.0.0"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem (= 1.0.0)
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "outdated --cooldown 7 --parseable", artifice: "compact_index_cooldown", raise_on_error: false
+
+      expect(out).to match(/ripe_gem.*in cooldown for \d+ more day/)
+    end
+
+    it "surfaces a cooldown hint when bundle update filters every candidate" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "update ripe_gem --cooldown 99999", artifice: "compact_index_cooldown", raise_on_error: false
+
+      expect(err).to match(/excluded by the cooldown setting/)
+      expect(err).to match(/--cooldown 0/)
     end
   end
 end

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+RSpec.describe "bundle install with the cooldown setting" do
+  before do
+    build_repo2
+  end
+
+  context "Gemfile DSL" do
+    it "accepts `source ..., cooldown: N` without error" do
+      install_gemfile <<-G, artifice: "compact_index"
+        source "https://gem.repo2", cooldown: 5
+        gem "myrack"
+      G
+
+      expect(the_bundle).to include_gems("myrack 1.0.0")
+    end
+
+    it "accepts `cooldown: 0` to disable cooldown for a source" do
+      install_gemfile <<-G, artifice: "compact_index"
+        source "https://gem.repo2", cooldown: 0
+        gem "myrack"
+      G
+
+      expect(the_bundle).to include_gems("myrack 1.0.0")
+    end
+  end
+
+  context "CLI flag" do
+    before do
+      gemfile <<-G
+        source "https://gem.repo2"
+        gem "myrack"
+      G
+    end
+
+    it "accepts --cooldown N on install" do
+      bundle "install --cooldown 7", artifice: "compact_index"
+
+      expect(the_bundle).to include_gems("myrack 1.0.0")
+    end
+
+    it "accepts --cooldown 0 as an escape hatch" do
+      bundle "install --cooldown 0", artifice: "compact_index"
+
+      expect(the_bundle).to include_gems("myrack 1.0.0")
+    end
+  end
+
+  context "configuration" do
+    it "reads BUNDLE_COOLDOWN as an integer" do
+      gemfile <<-G
+        source "https://gem.repo2"
+        gem "myrack"
+      G
+
+      bundle "install", env: { "BUNDLE_COOLDOWN" => "7" }, artifice: "compact_index"
+
+      expect(the_bundle).to include_gems("myrack 1.0.0")
+    end
+
+    it "reads `bundle config set cooldown N`" do
+      gemfile <<-G
+        source "https://gem.repo2"
+        gem "myrack"
+      G
+
+      bundle "config set cooldown 7"
+      bundle "install", artifice: "compact_index"
+
+      expect(the_bundle).to include_gems("myrack 1.0.0")
+    end
+  end
+
+  context "end-to-end with v2 compact index" do
+    before do
+      now = Time.now.utc
+      build_repo3 do
+        build_gem "ripe_gem", "1.0.0" do |s|
+          s.date = now - (30 * 86_400)
+        end
+        build_gem "ripe_gem", "2.0.0" do |s|
+          s.date = now - (1 * 86_400)
+        end
+      end
+    end
+
+    it "excludes versions within the cooldown window" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem"
+      G
+
+      bundle "install --cooldown 7", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0")
+    end
+
+    it "selects the latest version when --cooldown 0 is passed" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem"
+      G
+
+      bundle "install --cooldown 0", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("ripe_gem 2.0.0")
+    end
+
+    it "applies cooldown declared per-source in the Gemfile" do
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+      G
+
+      bundle "install", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0")
+    end
+
+    it "is overridden by CLI --cooldown when Gemfile sets a different per-source value" do
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 0
+        gem "ripe_gem"
+      G
+
+      bundle "install --cooldown 7", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0")
+    end
+
+    it "bypasses cooldown when bundle install uses an existing lockfile" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (2.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "install --cooldown 7", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("ripe_gem 2.0.0")
+    end
+  end
+end

--- a/spec/support/artifice/compact_index_cooldown.rb
+++ b/spec/support/artifice/compact_index_cooldown.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative "helpers/compact_index_cooldown"
+require_relative "helpers/artifice"
+
+Artifice.activate_with(CompactIndexCooldownAPI)

--- a/spec/support/artifice/helpers/compact_index_cooldown.rb
+++ b/spec/support/artifice/helpers/compact_index_cooldown.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "compact_index"
+
+class CompactIndexCooldownAPI < CompactIndexAPI
+  helpers do
+    def build_gem_version(spec, deps, checksum)
+      created_at = spec.date&.utc&.iso8601
+      CompactIndex::GemVersionV2.new(spec.version.version, spec.platform.to_s, checksum, nil,
+        deps, spec.required_ruby_version.to_s, spec.required_rubygems_version.to_s, created_at)
+    end
+  end
+end

--- a/spec/support/shards.rb
+++ b/spec/support/shards.rb
@@ -144,6 +144,7 @@ module Spec
       ],
       shard_d: [
         "spec/bundler/resolver/cooldown_spec.rb",
+        "spec/install/cooldown_spec.rb",
         "spec/commands/outdated_spec.rb",
         "spec/commands/update_spec.rb",
         "spec/lock/lockfile_spec.rb",

--- a/spec/support/shards.rb
+++ b/spec/support/shards.rb
@@ -143,6 +143,7 @@ module Spec
         "spec/bundler/ci_detector_spec.rb",
       ],
       shard_d: [
+        "spec/bundler/resolver/cooldown_spec.rb",
         "spec/commands/outdated_spec.rb",
         "spec/commands/update_spec.rb",
         "spec/lock/lockfile_spec.rb",


### PR DESCRIPTION
Adds the `cooldown` setting discussed at #9113, mirroring npm's `min-release-age`, pnpm's `minimumReleaseAge`, and Dependabot's `cooldown` to mitigate freshly published supply-chain attacks.

Users opt in through:

* `--cooldown N` on `install`, `update`, `add`, and `outdated`
* `bundle config set cooldown N` or `BUNDLE_COOLDOWN`
* per-source via `source "URL", cooldown: N` in the Gemfile

Design decisions adopted from #9113 and the follow-up review:

- The value is a non-negative `Integer` day count. Strings, floats, arrays, and negative numbers raise `InvalidOption` from both the Gemfile DSL and the CLI handlers, so a typo can't silently disable the filter.
- Precedence is CLI > config > Gemfile per-source, applied uniformly to every source — not just ones that declare their own `cooldown:` value.
- `--cooldown 0` is the global escape hatch and applies to the whole resolve including transitive dependencies; combine with `--conservative` to minimize churn during urgent updates.
- Per-gem cooldown is out of scope; private registries opt out by declaring `source "URL", cooldown: 0` in the Gemfile.
- The filter runs per-version (rolling delay) rather than from the latest release timestamp.
- Lockfile-pinned versions bypass the filter, and `bundle install` against an existing lockfile short-circuits the resolver entirely, so a cooldown setting never invalidates a working lock.
- `bundle update` filters and falls back to the newest version satisfying cooldown; `bundle outdated` annotates the latest-but-cooled version (`(cooldown Nd)` in the table form, `in cooldown for N more days` in `--parseable`) rather than hiding it.
- When the resolver fails because every matching version is in cooldown, both error paths surface the same hint suggesting `--cooldown 0` to bypass.
- Specs whose `created_at` is absent are treated as outside the window and remain resolvable.
- Out of scope: CVE-aware bypass (Dependabot/Renovate territory), semver-level differentiation, `gem install -v X` exact-version cooldown errors (deferred), and a dedicated exit code for cooldownfailures.

The `EndpointSpecification` parses `created_at` defensively against older rubygems whose `APISet::GemParser` splits ISO8601 on every colon and the flat String shape are accepted, malformed values become nil.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
