### PR TITLE
Silence coverage report output from `coverage:report` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -136,6 +136,7 @@ task "coverage:report" do
     next
   end
 
+  $stdout = File.open(File::NULL, "w")
   SimpleCov.collate Dir[resultset] do
     coverage_dir "coverage"
     add_filter "/test/"
@@ -153,6 +154,8 @@ task "coverage:report" do
       src.filename.include?("/lib/bundler/") || src.filename.end_with?("/lib/bundler.rb")
     end
   end
+ensure
+  $stdout = STDOUT
 end
 
 spec = Gem::Specification.load(File.expand_path("rubygems-update.gemspec", __dir__))


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

Surpressed the following output:

```
Coverage report generated for bundler:11374, bundler:11374, bundler:12417, bundler:12600, bundler:14613, bundler:15090, bundler:15831, bundler:15831, bundler:15831, bundler:15831, bundler:15831, bundler:15831, bundler:15832, bundler:15833, bundler:15834, bundler:15835, bundler:15836, bundler:15837, bundler:15838, bundler:15839, bundler:15840, bundler:44939, bundler:44939, bundler:44939, bundler:44939, bundler:44939, bundler:50991, bundler:51182, bundler:51329, bundler:52462, bundler:53319, bundler:78081, bundler:80866, bundler:82379, bundler:83500, rubygems, bundler:50991, bundler:51182, bundler:51329, bundler:52462, bundler:53319, ...
```


## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
