### PR TITLE
Install compact_index on `test_setup`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,41 +9,11 @@ require "rake/testtask"
 require_relative "spec/support/rubygems_ext"
 
 desc "Setup Rubygems dev environment"
-task setup: [:"dev:deps", "vendor:compact_index"] do
+task setup: [:"dev:deps"] do
   Dir.glob("tool/bundler/*_gems.rb").each do |file|
     name = File.basename(file, ".rb")
     next if name == "dev_gems"
     Spec::Rubygems.dev_bundle "lock", gemfile: file
-  end
-end
-
-namespace :vendor do
-  # Pinned to rubygems/rubygems.org#6504 so `rake setup` stays reproducible.
-  # Override with REF=<sha> to test against a newer compact_index.
-  desc "Sync vendored compact_index from rubygems/rubygems.org"
-  task :compact_index do
-    require "open-uri"
-    require "fileutils"
-
-    ref = ENV["REF"] || "7c68a7b39761c61a66f9299f85b889ec39afc02c"
-    repo = "rubygems/rubygems.org"
-    paths = %w[
-      lib/compact_index.rb
-      lib/compact_index/dependency.rb
-      lib/compact_index/gem.rb
-      lib/compact_index/gem_version.rb
-      lib/compact_index/versions_file.rb
-    ]
-
-    target_root = Spec::Path.tmp_root.join("compact_index")
-    paths.each do |path|
-      url = "https://raw.githubusercontent.com/#{repo}/#{ref}/#{path}"
-      puts "Fetching #{url}"
-      content = URI.parse(url).open(&:read)
-      target = File.join(target_root, path)
-      FileUtils.mkdir_p(File.dirname(target))
-      File.write(target, content)
-    end
   end
 end
 

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -73,6 +73,33 @@ module Spec
 
       require_relative "helpers"
       Helpers.install_dev_bundler
+
+      install_vendored_compact_index
+    end
+
+    # Vendor `rubygems/rubygems.org#lib/compact_index/` under `tmp/compact_index/`
+    # so the artifice can serve compact-index responses without a runtime gem
+    # dependency. Pinned to a reviewed commit; override with COMPACT_INDEX_REF.
+    def install_vendored_compact_index
+      target_root = Path.tmp_root.join("compact_index")
+      return if File.exist?(target_root.join("lib/compact_index.rb"))
+
+      require "open-uri"
+      require "fileutils"
+
+      ref = ENV["COMPACT_INDEX_REF"] || "7c68a7b39761c61a66f9299f85b889ec39afc02c"
+      %w[
+        lib/compact_index.rb
+        lib/compact_index/dependency.rb
+        lib/compact_index/gem.rb
+        lib/compact_index/gem_version.rb
+        lib/compact_index/versions_file.rb
+      ].each do |path|
+        url = "https://raw.githubusercontent.com/rubygems/rubygems.org/#{ref}/#{path}"
+        target = target_root.join(path)
+        FileUtils.mkdir_p(File.dirname(target))
+        File.write(target, URI.parse(url).open(&:read))
+      end
     end
 
     def check_source_control_changes(success_message:, error_message:)

--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -79,14 +79,19 @@ module Spec
 
     # Vendor `rubygems/rubygems.org#lib/compact_index/` under `tmp/compact_index/`
     # so the artifice can serve compact-index responses without a runtime gem
-    # dependency. Pinned to a reviewed commit; override with COMPACT_INDEX_REF.
+    # dependency. Pinned to a reviewed commit; override with COMPACT_INDEX_REF
+    # to refresh against another ref (the existing vendor copy is discarded).
     def install_vendored_compact_index
       target_root = Path.tmp_root.join("compact_index")
-      return if File.exist?(target_root.join("lib/compact_index.rb"))
-
-      require "open-uri"
       require "fileutils"
 
+      if ENV["COMPACT_INDEX_REF"]
+        FileUtils.rm_rf(target_root)
+      elsif File.exist?(target_root.join("lib/compact_index.rb"))
+        return
+      end
+
+      require "open-uri"
       ref = ENV["COMPACT_INDEX_REF"] || "7c68a7b39761c61a66f9299f85b889ec39afc02c"
       %w[
         lib/compact_index.rb


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Move `compact_index` vendoring from the `vendor:compact_index` rake task into `install_test_deps` so it runs uniformly across local rspec, bundler.yml, and ruby/ruby's `make test-bundler-parallel`, which does not invoke our `Rakefile.

The follow-up makes `COMPACT_INDEX_REF=<sha>` refresh the vendor tree instead of reusing the stale copy.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
