### PR TITLE
Lock compact_index vendoring against parallel races

### DIFF
--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -84,26 +84,34 @@ module Spec
     def install_vendored_compact_index
       target_root = Path.tmp_root.join("compact_index")
       require "fileutils"
+      FileUtils.mkdir_p(Path.tmp_root)
 
-      if ENV["COMPACT_INDEX_REF"]
-        FileUtils.rm_rf(target_root)
-      elsif File.exist?(target_root.join("lib/compact_index.rb"))
-        return
-      end
-
-      require "open-uri"
-      ref = ENV["COMPACT_INDEX_REF"] || "7c68a7b39761c61a66f9299f85b889ec39afc02c"
-      %w[
+      files = %w[
         lib/compact_index.rb
         lib/compact_index/dependency.rb
         lib/compact_index/gem.rb
         lib/compact_index/gem_version.rb
         lib/compact_index/versions_file.rb
-      ].each do |path|
-        url = "https://raw.githubusercontent.com/rubygems/rubygems.org/#{ref}/#{path}"
-        target = target_root.join(path)
-        FileUtils.mkdir_p(File.dirname(target))
-        File.write(target, URI.parse(url).open(&:read))
+      ]
+
+      # Serialize installs so parallel test setups don't race on the same
+      # vendor tree, and only skip the download when every file is present so
+      # an interrupted run can't leave a partial copy behind.
+      File.open(Path.tmp_root.join("compact_index.lock"), File::CREAT | File::RDWR) do |lock|
+        lock.flock(File::LOCK_EX)
+
+        FileUtils.rm_rf(target_root) if ENV["COMPACT_INDEX_REF"]
+
+        next if files.all? {|path| File.exist?(target_root.join(path)) }
+
+        require "open-uri"
+        ref = ENV["COMPACT_INDEX_REF"] || "7c68a7b39761c61a66f9299f85b889ec39afc02c"
+        files.each do |path|
+          url = "https://raw.githubusercontent.com/rubygems/rubygems.org/#{ref}/#{path}"
+          target = target_root.join(path)
+          FileUtils.mkdir_p(File.dirname(target))
+          File.write(target, URI.parse(url).open(&:read))
+        end
       end
     end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Following #9578, the vendored `compact_index` install runs as part of `install_test_deps` with no coordination between processes.

Under `make test-bundler-parallel`, where each worker can reach this path independently, two setups starting at once can write into `tmp/compact_index/` simultaneously.

## What is your fix for the problem, implemented in this PR?

Take an exclusive file lock around the install and only skip the download once every expected file is present, removing the tree under the same lock when `COMPACT_INDEX_REF` forces a refresh.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write tests for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the current code style and write meaningful commit messages without tags
