### PR TITLE
Fixed flaky tests

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -432,9 +432,14 @@ module Bundler
         end
 
         def capture3_args_for(cmd, dir)
-          return ["git", *cmd] unless dir
+          # Disable automatic maintenance so a background commit-graph write in
+          # the source repo can't race the hardlinking local clone and fail with
+          # "hardlink different from source".
+          opts = ["-c", "gc.auto=0", "-c", "maintenance.auto=false"]
 
-          ["git", "-C", dir.to_s, *cmd]
+          return ["git", *opts, *cmd] unless dir
+
+          ["git", "-C", dir.to_s, *opts, *cmd]
         end
 
         def extra_clone_args

--- a/spec/support/command_execution.rb
+++ b/spec/support/command_execution.rb
@@ -72,7 +72,7 @@ module Spec
     attr_reader :failure_reason
 
     def normalize(string)
-      string.force_encoding(Encoding::UTF_8).strip.gsub("\r\n", "\n")
+      string.dup.force_encoding(Encoding::UTF_8).scrub.strip.gsub("\r\n", "\n")
     end
   end
 end

--- a/test/rubygems/test_gem_commands_owner_command.rb
+++ b/test/rubygems/test_gem_commands_owner_command.rb
@@ -399,7 +399,6 @@ EOF
   end
 
   def test_with_webauthn_enabled_failure
-    pend "Flaky on TruffleRuby" if RUBY_ENGINE == "truffleruby"
     response_success = "Owner added successfully."
     server = Gem::MockTCPServer.new
     error = Gem::WebauthnVerificationError.new("Something went wrong")
@@ -417,7 +416,8 @@ EOF
       end
     end
 
-    assert_match @stub_fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
+    webauthn_verification_request = @stub_fetcher.requests.find {|req| req.path == "/api/v1/webauthn_verification" }
+    assert_match webauthn_verification_request["Authorization"], Gem.configuration.rubygems_api_key
     assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
       "you can re-run the gem signin command with the `--otp [your_code]` option.", @stub_ui.output


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?


### Non-GIL implementation returns unexpected header

```
Failure: test_with_webauthn_enabled_failure(TestGemCommandsOwnerCommand):
  <nil> was expected to be =~
  <"ed244fbf2b1a52e012da8616c512fa47f9aa5250">.
/home/runner/work/rubygems/rubygems/test/rubygems/test_gem_commands_owner_command.rb:420:in 'test_with_webauthn_enabled_failure'
     417:       end
     418:     end
     419: 
  => 420:     assert_match @stub_fetcher.last_request["Authorization"], Gem.configuration.rubygems_api_key
     421:     assert_match "You have enabled multi-factor authentication. Please visit the following URL " \
     422:       "to authenticate via security device. If you can't verify using WebAuthn but have OTP enabled, " \
     423:       "you can re-run the gem signin command with the `--otp [your_code]` option.", @stub_ui.output
```

### Git auto maintenance conflicts other process

```
  1) the lockfile format successfully updates the lockfile when a new gem is added in the Gemfile includes a gem that shouldn't be included
     Failure/Error:
             raise <<~ERROR
               #{error_header}
       
               ----------------------------------------------------------------------
               #{stdboth}
               ----------------------------------------------------------------------
             ERROR

     RuntimeError:
       Invoking `/Users/runner/hostedtoolcache/Ruby/3.3.11/arm64/bin/ruby /Users/runner/work/rubygems/rubygems/tmp/2.3/gems/system/bin/bundle install` failed with output:
```

### Scrub invalid bytes when normalizing command output

```
  1) bundle list with without-group option when group is present prints the gems not in the specified group with json
     Failure/Error: Unable to find matching line from backtrace

       invalid byte sequence in UTF-8

       invalid byte sequence in UTF-8
```

## What is your fix for the problem, implemented in this PR?

1. Detect `Authorization` header before assertion
1. Disable git auto maintenance 
1. Scrub the string after forcing the encoding so normalize never raises on malformed bytes, and dup it first so forcing the encoding no longer mutates the stored capture buffer.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
