### PR TITLE
Write vendored compact_index files atomically

### DIFF
--- a/spec/support/rubygems_ext.rb
+++ b/spec/support/rubygems_ext.rb
@@ -110,7 +110,9 @@ module Spec
           url = "https://raw.githubusercontent.com/rubygems/rubygems.org/#{ref}/#{path}"
           target = target_root.join(path)
           FileUtils.mkdir_p(File.dirname(target))
-          File.write(target, URI.parse(url).open(&:read))
+          tmp = "#{target}.tmp"
+          File.write(tmp, URI.parse(url).open(&:read))
+          File.rename(tmp, target)
         end
       end
     end


### PR DESCRIPTION


## What was the end-user or developer problem that led to this PR?

The completeness check skips the download once every expected file exists, but File.write truncates before writing, so an install interrupted partway leaves a half-written file in place. 

## What is your fix for the problem, implemented in this PR?


Download each file to a sibling .tmp path and rename it into place. The rename stays within the vendor tree, so it is atomic and a target file is only ever observed fully written.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
