### PR TITLE
Apply cooldown to locally installed gem versions

### DIFF
--- a/bundler/lib/bundler/remote_specification.rb
+++ b/bundler/lib/bundler/remote_specification.rb
@@ -12,7 +12,7 @@ module Bundler
 
     attr_reader :name, :version, :platform
     attr_writer :dependencies
-    attr_accessor :source, :remote, :locked_platform
+    attr_accessor :source, :remote, :locked_platform, :created_at
 
     def initialize(name, version, platform, spec_fetcher)
       @name         = name

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -422,7 +422,7 @@ module Bundler
     end
 
     def filter_specs(specs, package)
-      filter_cooldown(filter_remote_specs(filter_prereleases(specs, package), package))
+      filter_remote_specs(filter_cooldown(filter_prereleases(specs, package)), package)
     end
 
     def filter_prereleases(specs, package)
@@ -433,19 +433,19 @@ module Bundler
 
     def filter_cooldown(specs)
       return specs if specs.empty?
-      excluded = cooldown_excluded_specs(specs)
-      return specs if excluded.empty?
-      specs - excluded
+      excluded_versions = cooldown_excluded_versions(specs)
+      return specs if excluded_versions.empty?
+      specs.reject {|s| excluded_versions.include?([s.name, s.version]) }
     end
 
-    def cooldown_excluded_specs(specs)
-      specs.select {|spec| cooldown_excluded?(spec) }
+    def cooldown_excluded_versions(specs)
+      specs.select {|spec| cooldown_excluded?(spec) }.map {|spec| [spec.name, spec.version] }.uniq
     end
 
     def cooldown_hint(specs)
-      excluded = cooldown_excluded_specs(specs)
-      return nil if excluded.empty?
-      "#{excluded.size} version#{"s" if excluded.size > 1} excluded by the cooldown setting; pass `--cooldown 0` to bypass"
+      excluded_versions = cooldown_excluded_versions(specs)
+      return nil if excluded_versions.empty?
+      "#{excluded_versions.size} version#{"s" if excluded_versions.size > 1} excluded by the cooldown setting; pass `--cooldown 0` to bypass"
     end
 
     def cooldown_excluded?(spec)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -439,7 +439,12 @@ module Bundler
     end
 
     def cooldown_excluded_versions(specs)
-      specs.select {|spec| cooldown_excluded?(spec) }.map {|spec| [spec.name, spec.version] }.uniq
+      excluded = {}
+      specs.each do |spec|
+        next unless cooldown_excluded?(spec)
+        excluded[[spec.name, spec.version]] = true
+      end
+      excluded
     end
 
     def cooldown_hint(specs)

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -150,6 +150,13 @@ module Bundler
           # sources, and large_idx.merge! small_idx is way faster than
           # small_idx.merge! large_idx.
           index = @allow_remote ? remote_specs.dup : Index.new
+
+          # Snapshot per-version `created_at` from the remote info before installed
+          # / cached specs overwrite the EndpointSpecification objects that carry
+          # it. The cooldown filter consults `created_at` on every candidate, so
+          # local stubs need the published date back-filled to participate.
+          remote_created_at = collect_remote_created_at(index)
+
           index.merge!(cached_specs) if @allow_cached
           index.merge!(installed_specs) if @allow_local
 
@@ -162,6 +169,8 @@ module Bundler
               index.use(default_specs)
             end
           end
+
+          backfill_created_at(index, remote_created_at) unless remote_created_at.empty?
 
           index
         end
@@ -469,6 +478,34 @@ module Bundler
       end
 
       private
+
+      def collect_remote_created_at(index)
+        return {} unless @allow_remote
+
+        snapshot = {}
+        index.each do |spec|
+          next unless spec.respond_to?(:created_at) && spec.created_at
+          snapshot[[spec.name, spec.version]] = spec.created_at
+        end
+        snapshot
+      end
+
+      def backfill_created_at(index, snapshot)
+        first_remote = remote_fetchers.keys.first
+        index.each do |spec|
+          next unless spec.respond_to?(:created_at=)
+          next if spec.created_at
+          remote_created_at = snapshot[[spec.name, spec.version]]
+          next unless remote_created_at
+          spec.created_at = remote_created_at
+          # The cooldown filter consults `spec.remote.effective_cooldown`, so a
+          # backfilled stub also needs a Source::Rubygems::Remote reference. Any
+          # remote on the source carries the right `effective_cooldown` because
+          # the setting is source-wide and `Bundler.settings[:cooldown]`
+          # overrides per-source.
+          spec.remote ||= first_remote if first_remote && spec.respond_to?(:remote=)
+        end
+      end
 
       def lockfile_remotes
         @lockfile_remotes || credless_remotes

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -485,25 +485,22 @@ module Bundler
         snapshot = {}
         index.each do |spec|
           next unless spec.respond_to?(:created_at) && spec.created_at
-          snapshot[[spec.name, spec.version]] = spec.created_at
+          # Remember the remote that supplied the date too: when a source has
+          # several remotes with different per-URI cooldown settings we must
+          # restore the same one during backfill so `effective_cooldown` agrees.
+          snapshot[[spec.name, spec.version]] = [spec.created_at, spec.remote]
         end
         snapshot
       end
 
       def backfill_created_at(index, snapshot)
-        first_remote = remote_fetchers.keys.first
         index.each do |spec|
           next unless spec.respond_to?(:created_at=)
           next if spec.created_at
-          remote_created_at = snapshot[[spec.name, spec.version]]
+          remote_created_at, remote = snapshot[[spec.name, spec.version]]
           next unless remote_created_at
           spec.created_at = remote_created_at
-          # The cooldown filter consults `spec.remote.effective_cooldown`, so a
-          # backfilled stub also needs a Source::Rubygems::Remote reference. Any
-          # remote on the source carries the right `effective_cooldown` because
-          # the setting is source-wide and `Bundler.settings[:cooldown]`
-          # overrides per-source.
-          spec.remote ||= first_remote if first_remote && spec.respond_to?(:remote=)
+          spec.remote ||= remote if remote && spec.respond_to?(:remote=)
         end
       end
 

--- a/spec/bundler/resolver/cooldown_spec.rb
+++ b/spec/bundler/resolver/cooldown_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Bundler::Resolver do
     instance_double(Bundler::Source::Rubygems::Remote, effective_cooldown: cooldown)
   end
 
-  def spec(created_at:, remote:)
-    Struct.new(:created_at, :remote).new(created_at, remote)
+  def spec(created_at:, remote:, name: "myrack", version: "1.0.0")
+    Struct.new(:name, :version, :created_at, :remote).new(name, Gem::Version.new(version), created_at, remote)
   end
 
   describe "#filter_cooldown" do
@@ -18,8 +18,8 @@ RSpec.describe Bundler::Resolver do
       let(:r) { remote(cooldown: 7) }
 
       it "rejects versions published within the window" do
-        recent = spec(created_at: now - (2 * 86_400), remote: r)
-        old = spec(created_at: now - (30 * 86_400), remote: r)
+        recent = spec(version: "1.1.0", created_at: now - (2 * 86_400), remote: r)
+        old = spec(version: "1.0.0", created_at: now - (30 * 86_400), remote: r)
 
         expect(resolver.send(:filter_cooldown, [recent, old])).to eq([old])
       end
@@ -32,13 +32,36 @@ RSpec.describe Bundler::Resolver do
 
       it "leaves rolling-delay history intact" do
         # 7-day cooldown with frequent releases must still expose an older candidate.
-        in_cooldown = spec(created_at: now - 86_400, remote: r)
-        also_in_cooldown = spec(created_at: now - (3 * 86_400), remote: r)
-        eligible = spec(created_at: now - (10 * 86_400), remote: r)
+        in_cooldown = spec(version: "1.2.0", created_at: now - 86_400, remote: r)
+        also_in_cooldown = spec(version: "1.1.0", created_at: now - (3 * 86_400), remote: r)
+        eligible = spec(version: "1.0.0", created_at: now - (10 * 86_400), remote: r)
 
         result = resolver.send(:filter_cooldown, [in_cooldown, also_in_cooldown, eligible])
 
         expect(result).to eq([eligible])
+      end
+
+      it "drops every spec sharing an excluded [name, version] tuple" do
+        # The cooldown check is by version, not per-spec: a StubSpecification for an
+        # in-cooldown release would otherwise slip through on local install paths.
+        endpoint = spec(version: "2.0.0", created_at: now - 86_400, remote: r)
+        local_stub = Struct.new(:name, :version).new("myrack", Gem::Version.new("2.0.0"))
+        eligible = spec(version: "1.0.0", created_at: now - (30 * 86_400), remote: r)
+
+        result = resolver.send(:filter_cooldown, [endpoint, local_stub, eligible])
+
+        expect(result).to eq([eligible])
+      end
+
+      it "keeps stub-only versions that no endpoint marks as in cooldown" do
+        # If no remote spec carries created_at for a version, cooldown cannot judge it;
+        # the stub stays in.
+        local_only = Struct.new(:name, :version).new("myrack", Gem::Version.new("2.0.0"))
+        eligible = spec(version: "1.0.0", created_at: now - (30 * 86_400), remote: r)
+
+        result = resolver.send(:filter_cooldown, [local_only, eligible])
+
+        expect(result).to eq([local_only, eligible])
       end
     end
 
@@ -111,9 +134,15 @@ RSpec.describe Bundler::Resolver do
     end
 
     it "uses plural wording when multiple versions are excluded" do
-      excluded = Array.new(3) { spec(created_at: now - 86_400, remote: r) }
+      excluded = %w[1.0.0 1.1.0 1.2.0].map {|v| spec(version: v, created_at: now - 86_400, remote: r) }
 
       expect(resolver.send(:cooldown_hint, excluded)).to match(/3 versions excluded/)
+    end
+
+    it "counts each unique version once even when multiple spec instances share it" do
+      duplicates = Array.new(3) { spec(created_at: now - 86_400, remote: r) }
+
+      expect(resolver.send(:cooldown_hint, duplicates)).to match(/1 version excluded/)
     end
   end
 end

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -215,6 +215,32 @@ RSpec.describe "bundle install with the cooldown setting" do
       expect(out).to match(/ripe_gem.*in cooldown for \d+ more day/)
     end
 
+    it "excludes a locally-installed version that is still within the cooldown window" do
+      system_gems "ripe_gem-2.0.0", gem_repo: gem_repo3
+
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem"
+      G
+
+      bundle "install --cooldown 7", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0")
+    end
+
+    it "selects a locally-installed in-cooldown version when --cooldown 0 bypasses the filter" do
+      system_gems "ripe_gem-2.0.0", gem_repo: gem_repo3
+
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem"
+      G
+
+      bundle "install --cooldown 0", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("ripe_gem 2.0.0")
+    end
+
     it "surfaces a cooldown hint when bundle update filters every candidate" do
       gemfile <<-G
         source "https://gem.repo3"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle install --cooldown N` was supposed to exclude versions published less than N days ago, but a version already installed locally slipped through.

EX. `ruby/rdoc` with `rubocop 1.87.0` already on disk (published 2026-05-30), `bundle install --cooldown 7` on 2026-06-02 still picked `1.87.0`.


When a version was already installed locally, Bundler dropped the remote publish date for that version, so the cooldown filter had no way to judge it and let the local copy through.

## What is your fix for the problem, implemented in this PR?

The fix makes the cooldown decision a property of the version itself: remember the publish date the remote reported, then apply it regardless of whether the version is also installed locally, so a fresh release in cooldown is filtered out whether it sits on disk or not.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
