### PR TITLE
Parse `created_at` via `Time.new` instead of `Time.iso8601`

### DIFF
--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -165,11 +165,10 @@ module Bundler
         when "created_at"
           value = v.is_a?(Array) ? v.last : v
           if value.is_a?(String)
-            require "time"
-            begin
-              @created_at = Time.iso8601(value)
+            @created_at = begin
+              Time.new(value)
             rescue ArgumentError
-              @created_at = nil
+              nil
             end
           end
         end


### PR DESCRIPTION
From @nobu's suggestion


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
