### PR TITLE
POC For rubygems Content Addressable Changes

### DIFF
--- a/bundler/lib/bundler/compact_index_client.rb
+++ b/bundler/lib/bundler/compact_index_client.rb
@@ -36,6 +36,7 @@ module Bundler
     INFO_PLATFORM = 2
     INFO_DEPS = 3
     INFO_REQS = 4
+    INFO_ARTIFACT_ID = 5
 
     def self.debug
       return unless ENV["DEBUG_COMPACT_INDEX"]

--- a/bundler/lib/bundler/endpoint_specification.rb
+++ b/bundler/lib/bundler/endpoint_specification.rb
@@ -5,7 +5,7 @@ module Bundler
   class EndpointSpecification < Gem::Specification
     include MatchRemoteMetadata
 
-    attr_reader :name, :version, :platform, :checksum
+    attr_reader :name, :version, :platform, :checksum, :artifact_id
     attr_writer :dependencies
     attr_accessor :remote, :locked_platform
 
@@ -31,6 +31,36 @@ module Bundler
 
     def fetch_platform
       @platform
+    end
+
+    def index_key
+      return full_name unless artifact_id
+
+      "#{full_name}-#{artifact_id}"
+    end
+
+    def remote_file_name
+      return file_name unless artifact_id
+
+      artifact_id.end_with?(".gem") ? artifact_id : "#{artifact_id}.gem"
+    end
+
+    def cache_file_name
+      return file_name unless artifact_id
+
+      "#{full_name}-#{artifact_id.tr("/", "_")}.gem"
+    end
+
+    def ==(other)
+      super && artifact_id == (other.artifact_id if other.respond_to?(:artifact_id))
+    end
+
+    def eql?(other)
+      self == other
+    end
+
+    def hash
+      super ^ artifact_id.hash
     end
 
     def dependencies
@@ -145,6 +175,7 @@ module Bundler
       unless data
         @required_ruby_version = nil
         @required_rubygems_version = nil
+        @artifact_id = nil
         return
       end
 
@@ -161,6 +192,8 @@ module Bundler
           @required_rubygems_version = Gem::Requirement.new(v)
         when "ruby"
           @required_ruby_version = Gem::Requirement.new(v)
+        when "artifact", "artifact_id"
+          @artifact_id = v.last
         end
       end
     rescue StandardError => e

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -176,10 +176,11 @@ module Bundler
     def specs(gem_names, source)
       index = Bundler::Index.new
 
-      fetch_specs(gem_names).each do |name, version, platform, dependencies, metadata|
+      fetch_specs(gem_names).each do |name, version, platform, dependencies, metadata, artifact_id|
         spec = if dependencies
+          metadata << [-"artifact_id", [artifact_id]] if artifact_id && !metadata.any? {|key, _| key == "artifact_id" }
           EndpointSpecification.new(name, version, platform, self, dependencies, metadata).tap do |es|
-            source.checksum_store.replace(es, es.checksum)
+            source.checksum_store.replace(es, es.checksum) unless es.artifact_id
           end
         else
           RemoteSpecification.new(name, version, platform, self)

--- a/bundler/lib/bundler/index.rb
+++ b/bundler/lib/bundler/index.rb
@@ -55,7 +55,7 @@ module Bundler
       @sources.each do |source|
         results = safe_concat(results, source.search(query))
       end
-      results.uniq!(&:full_name) unless results.empty? # avoid modifying frozen EMPTY_SEARCH
+      results.uniq! {|spec| spec_key(spec) } unless results.empty? # avoid modifying frozen EMPTY_SEARCH
       results
     end
 
@@ -72,7 +72,7 @@ module Bundler
     end
 
     def add(spec)
-      (@specs[spec.name] ||= {}).store(spec.full_name, spec)
+      (@specs[spec.name] ||= {}).store(spec_key(spec), spec)
     end
     alias_method :<<, :add
 
@@ -193,11 +193,17 @@ module Bundler
     end
 
     def find_by_spec(spec)
-      @specs[spec.name]&.fetch(spec.full_name, nil)
+      @specs[spec.name]&.fetch(spec_key(spec), nil)
     end
 
     def exist?(spec)
-      @specs[spec.name]&.key?(spec.full_name)
+      @specs[spec.name]&.key?(spec_key(spec))
+    end
+
+    def spec_key(spec)
+      return spec.index_key if spec.respond_to?(:index_key)
+
+      spec.full_name
     end
   end
 end

--- a/bundler/lib/bundler/lazy_specification.rb
+++ b/bundler/lib/bundler/lazy_specification.rb
@@ -9,7 +9,8 @@ module Bundler
     include ForcePlatform
 
     attr_reader :name, :version, :platform, :materialization
-    attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version, :overrides
+    attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version,
+      :required_rubygems_version, :overrides, :artifact_id
 
     #
     # For backwards compatibility with existing lockfiles, if the most specific
@@ -31,6 +32,7 @@ module Bundler
       lazy_spec.required_ruby_version = s.required_ruby_version
       lazy_spec.required_rubygems_version = s.required_rubygems_version
       lazy_spec.overrides = s.overrides if s.is_a?(LazySpecification)
+      lazy_spec.artifact_id = s.artifact_id if s.respond_to?(:artifact_id)
       lazy_spec
     end
 
@@ -71,6 +73,12 @@ module Bundler
       end
     end
 
+    def index_key
+      return full_name unless artifact_id
+
+      "#{full_name}-#{artifact_id}"
+    end
+
     def lock_name
       @lock_name ||= name_tuple.lock_name
     end
@@ -80,15 +88,15 @@ module Bundler
     end
 
     def ==(other)
-      full_name == other.full_name
+      index_key == (other.respond_to?(:index_key) ? other.index_key : other.full_name)
     end
 
     def eql?(other)
-      full_name.eql?(other.full_name)
+      self == other
     end
 
     def hash
-      full_name.hash
+      index_key.hash
     end
 
     ##
@@ -236,9 +244,10 @@ module Bundler
     # bad gem.
     def choose_compatible(candidates, fallback_to_non_installable: Bundler.frozen_bundle?)
       override_list = overrides || []
-      search = candidates.reverse.find do |spec|
+      compatible = candidates.reverse.select do |spec|
         spec.is_a?(StubSpecification) || spec.matches_current_metadata_with_overrides?(override_list)
       end
+      search = most_specific_ruby_requirement(compatible)
       if search.nil? && fallback_to_non_installable
         search = candidates.last
       end
@@ -249,6 +258,46 @@ module Bundler
         search.locked_platform = platform if search.instance_of?(RemoteSpecification) || search.instance_of?(EndpointSpecification)
       end
       search
+    end
+
+    def most_specific_ruby_requirement(specs)
+      specs.max do |a, b|
+        compare_ruby_requirement_specificity(a.required_ruby_version, b.required_ruby_version)
+      end
+    end
+
+    def compare_ruby_requirement_specificity(a_requirement, b_requirement)
+      lower_comparison = lower_ruby_bound(a_requirement) <=> lower_ruby_bound(b_requirement)
+      return lower_comparison unless lower_comparison.zero?
+
+      a_upper = upper_ruby_bound(a_requirement)
+      b_upper = upper_ruby_bound(b_requirement)
+
+      upper_comparison =
+        if a_upper && b_upper
+          b_upper <=> a_upper
+        elsif a_upper
+          1
+        elsif b_upper
+          -1
+        else
+          0
+        end
+      return upper_comparison unless upper_comparison.zero?
+
+      a_requirement.requirements.length <=> b_requirement.requirements.length
+    end
+
+    def lower_ruby_bound(requirement)
+      requirement.requirements.map do |operator, version|
+        version if ["=", ">=", ">", "~>"].include?(operator)
+      end.compact.max || Gem::Version.new("0")
+    end
+
+    def upper_ruby_bound(requirement)
+      requirement.requirements.map do |operator, version|
+        version if ["=", "<=", "<"].include?(operator)
+      end.compact.min
     end
 
     # Validate dependencies of this locked spec are consistent with dependencies

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -47,7 +47,7 @@ module Bundler
           matches = filter_invalid_self_dependencies(matches, name)
         end
 
-        specs[name] = matches.sort_by {|s| [s.version, s.platform.to_s] }
+        specs[name] = matches.sort_by {|s| [s.version, s.platform.to_s, artifact_id_for(s)] }
       end
 
       @all_versions = Hash.new do |candidates, package|
@@ -264,7 +264,9 @@ module Bundler
 
     def all_versions_for(package)
       name = package.name
-      results = (@base[name] + filter_specs(@all_specs[name], package)).uniq {|spec| [spec.version.hash, spec.platform] }
+      results = (@base[name] + filter_specs(@all_specs[name], package)).uniq do |spec|
+        [spec.version.hash, spec.platform, artifact_id_for(spec)]
+      end
 
       if name == "bundler" && !bundler_pinned_to_current_version?
         bundler_spec = Gem.loaded_specs["bundler"]
@@ -302,7 +304,7 @@ module Bundler
           next groups if package.force_ruby_platform?
         end
 
-        platform_group = Resolver::SpecGroup.new(platform_specs.flatten.uniq)
+        platform_group = Resolver::SpecGroup.new(platform_specs.flatten.uniq {|spec| spec_identity(spec) })
         next groups if platform_group == ruby_group
 
         groups << Resolver::Candidate.new(version, group: platform_group, priority: 1)
@@ -338,6 +340,16 @@ module Bundler
     end
 
     private
+
+    def spec_identity(spec)
+      return spec.index_key if spec.respond_to?(:index_key)
+
+      [spec.name, spec.version, spec.platform]
+    end
+
+    def artifact_id_for(spec)
+      spec.respond_to?(:artifact_id) ? spec.artifact_id.to_s : ""
+    end
 
     def raise_not_found!(package)
       name = package.name

--- a/bundler/lib/bundler/resolver/spec_group.rb
+++ b/bundler/lib/bundler/resolver/spec_group.rb
@@ -49,7 +49,7 @@ module Bundler
       def merge(other)
         return false unless equivalent?(other)
 
-        @specs |= other.specs
+        @specs = (@specs + other.specs).uniq {|spec| spec_identity(spec) }
 
         true
       end
@@ -57,7 +57,7 @@ module Bundler
       protected
 
       def sorted_spec_names
-        @specs.map(&:full_name).sort
+        @specs.map {|spec| spec_identity(spec) }.sort
       end
 
       private
@@ -68,6 +68,12 @@ module Bundler
 
       def exemplary_spec
         @specs.first
+      end
+
+      def spec_identity(spec)
+        return spec.index_key if spec.respond_to?(:index_key)
+
+        spec.full_name
       end
     end
   end

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -457,8 +457,11 @@ module Gem
   unless Gem.rubygems_version >= Gem::Version.new("3.6.7")
     module UnfreezeCompactIndexParsedResponse
       def parse(line)
-        version, platform, dependencies, requirements = super
-        [version, platform, dependencies.frozen? ? dependencies.dup : dependencies, requirements.frozen? ? requirements.dup : requirements]
+        version, platform, dependencies, requirements, artifact_id = super
+        dependencies = dependencies.frozen? ? dependencies.dup : dependencies
+        requirements = requirements.frozen? ? requirements.dup : requirements
+
+        [version, platform, dependencies, requirements, artifact_id]
       end
     end
 

--- a/bundler/lib/bundler/rubygems_integration.rb
+++ b/bundler/lib/bundler/rubygems_integration.rb
@@ -382,8 +382,8 @@ module Bundler
       redacted_uri = Gem::Uri.redact(uri)
 
       Bundler::Retry.new("download gem from #{redacted_uri}").attempts do
-        gem_file_name = spec.file_name
-        local_gem_path = File.join cache_dir, gem_file_name
+        gem_file_name = gem_remote_file_name(spec)
+        local_gem_path = File.join cache_dir, gem_cache_file_name(spec)
         return if File.exist? local_gem_path
 
         begin
@@ -393,6 +393,7 @@ module Bundler
             fetcher.cache_update_path remote_gem_path, local_gem_path
           end
         rescue Gem::RemoteFetcher::FetchError
+          raise if content_addressed_gem?(spec)
           raise if spec.original_platform == spec.platform
 
           original_gem_file_name = "#{spec.original_name}.gem"
@@ -404,6 +405,22 @@ module Bundler
       end
     rescue Gem::RemoteFetcher::FetchError => e
       raise Bundler::HTTPError, "Could not download gem from #{redacted_uri} due to underlying error <#{e.message}>"
+    end
+
+    def gem_remote_file_name(spec)
+      return spec.remote_file_name if spec.respond_to?(:remote_file_name)
+
+      spec.file_name
+    end
+
+    def gem_cache_file_name(spec)
+      return spec.cache_file_name if spec.respond_to?(:cache_file_name)
+
+      spec.file_name
+    end
+
+    def content_addressed_gem?(spec)
+      spec.respond_to?(:artifact_id) && spec.artifact_id
     end
 
     def build(spec, skip_validation = false)

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -340,7 +340,13 @@ module Bundler
       end
 
       def package_path(cache_path, spec)
-        "#{cache_path}/#{spec.file_name}"
+        "#{cache_path}/#{gem_cache_file_name(spec)}"
+      end
+
+      def gem_cache_file_name(spec)
+        return spec.cache_file_name if spec.respond_to?(:cache_file_name)
+
+        spec.file_name
       end
 
       def normalize_uri(uri)

--- a/lib/rubygems/resolver/api_set.rb
+++ b/lib/rubygems/resolver/api_set.rb
@@ -111,13 +111,20 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
       @data[name] = []
     else
       lines(str).each do |ver|
-        number, platform, dependencies, requirements = parse_gem(ver)
+        number, platform, dependencies, requirements, artifact_id = parse_gem(ver)
 
         platform ||= "ruby"
         dependencies = dependencies.map {|dep_name, reqs| [dep_name, reqs.join(", ")] }
         requirements = requirements.map {|req_name, reqs| [req_name.to_sym, reqs] }.to_h
 
-        @data[name] << { name: name, number: number, platform: platform, dependencies: dependencies, requirements: requirements }
+        @data[name] << {
+          name: name,
+          number: number,
+          platform: platform,
+          dependencies: dependencies,
+          requirements: requirements,
+          artifact_id: artifact_id,
+        }
       end
     end
 

--- a/lib/rubygems/resolver/api_set/gem_parser.rb
+++ b/lib/rubygems/resolver/api_set/gem_parser.rb
@@ -7,10 +7,24 @@ class Gem::Resolver::APISet::GemParser
     dependencies, requirements = rest.split("|", 2).map! {|s| s.split(",") } if rest
     dependencies = dependencies ? dependencies.map! {|d| parse_dependency(d) } : []
     requirements = requirements ? requirements.map! {|d| parse_dependency(d) } : []
-    [version, platform, dependencies, requirements]
+
+    artifact_id = nil
+    explicit_platform = find_requirement(requirements, "platform")
+    if explicit_platform && platform
+      artifact_id = platform
+      platform = explicit_platform
+      requirements << [-"artifact_id", [artifact_id]]
+    end
+
+    [version, platform, dependencies, requirements, artifact_id]
   end
 
   private
+
+  def find_requirement(requirements, name)
+    requirement = requirements.find {|key, _| key == name }
+    requirement&.last&.last
+  end
 
   def parse_dependency(string)
     dependency = string.split(":")

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -7,6 +7,8 @@
 # is the name, version, and dependencies.
 
 class Gem::Resolver::APISpecification < Gem::Resolver::Specification
+  attr_reader :artifact_id
+
   ##
   # We assume that all instances of this class are immutable;
   # so avoid duplicated generation for performance.
@@ -33,6 +35,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
     @version = Gem::Version.new(api_data[:number]).freeze
     @platform = Gem::Platform.new(api_data[:platform]).freeze
     @original_platform = api_data[:platform].freeze
+    @artifact_id = api_data[:artifact_id]&.freeze
     @dependencies = api_data[:dependencies].map do |name, ver|
       Gem::Dependency.new(name, ver.split(/\s*,\s*/)).freeze
     end.freeze
@@ -45,11 +48,12 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
       @set          == other.set &&
       @name         == other.name &&
       @version      == other.version &&
-      @platform     == other.platform
+      @platform     == other.platform &&
+      @artifact_id  == other.artifact_id
   end
 
   def hash
-    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash
+    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash ^ @artifact_id.hash
   end
 
   def fetch_development_dependencies # :nodoc:


### PR DESCRIPTION
 ## Summary

This is a rough POC for supporting content-addressed gem artifacts in Bundler/RubyGems.

The goal is to let Bundler see, keep, choose, and download multiple gem artifacts that may share the same gem name, version, and platform, but differ by Ruby support and artifact id.

## File-by-file changes

### `lib/rubygems/resolver/api_set/gem_parser.rb`

Updates compact index parsing.

If an entry has an explicit `platform:` metadata value, Bundler treats the suffix after the version as an artifact id instead of as the platform.

For example, this kind of entry:

```text
  1.0.0-abc123 |platform:x86_64-linux,ruby:>= 3.3
```

is parsed as:

  - version: 1.0.0
  - platform: x86_64-linux
  - artifact id: abc123

Old-style entries still work as before.

### lib/rubygems/resolver/api_set.rb

Carries the parsed artifact_id into the API data hash used by RubyGems resolver specs.

### lib/rubygems/resolver/api_specification.rb

Stores artifact_id on API specifications.

Also includes artifact_id in equality and hash behavior so two specs with the same name, version, and platform can still be treated as different artifacts.

### bundler/lib/bundler/compact_index_client.rb

Adds a new compact index array slot for INFO_ARTIFACT_ID.

This lets Bundler pass artifact identity through compact index results.

### bundler/lib/bundler/rubygems_ext.rb

Updates the compatibility wrapper around compact index parsing so it preserves the new artifact_id value.

### bundler/lib/bundler/fetcher.rb

Passes parsed artifact_id metadata into EndpointSpecification.

Also avoids pre-registering compact-index checksums for content-addressed artifacts, because multiple CA artifacts may share the same lockfile name but have different checksums.

### bundler/lib/bundler/endpoint_specification.rb

Stores artifact_id on endpoint specs.

Adds helper methods for:

  - unique index identity
  - remote artifact filename
  - local cache filename

This lets Bundler distinguish artifacts internally while still keeping the normal gem name/version/platform behavior for old gems.

### bundler/lib/bundler/index.rb

Changes Bundler’s index keying so it can keep multiple specs with the same full_name when they have different artifact ids. Without this, one artifact could overwrite another.

### bundler/lib/bundler/lazy_specification.rb

Carries artifact_id into lazy specs.

Also updates equality/hash behavior to include artifact identity when present.

Adds selection logic so that when multiple compatible artifacts match, Bundler prefers the artifact with the narrower Ruby requirement.

For example, if both of these match the current Ruby:

  ruby: >= 3.0
  ruby: >= 3.3

Bundler prefers >= 3.3.

### bundler/lib/bundler/resolver.rb

Updates resolver sorting and deduping so artifacts are not collapsed just because they share the same version and platform.

Artifact id is now considered when preserving resolver candidates.

### bundler/lib/bundler/resolver/spec_group.rb

Updates spec grouping so grouped specs preserve artifact identity.

This prevents resolver groups from accidentally treating different CA artifacts as the same spec.

### bundler/lib/bundler/source/rubygems.rb

Uses an artifact-specific cache filename when a spec has an artifact id.

This prevents two artifacts with the same legacy gem filename from overwriting each other locally.

### bundler/lib/bundler/rubygems_integration.rb

Updates gem downloading so content-addressed artifacts are fetched by artifact id instead of reconstructing the old gem filename.

Also keeps local cache filenames artifact-specific.

## Notes

This PR does not add tests yet.

I did run syntax checks on the modified files and small smoke checks for:

  - parsing a content-addressed compact index entry
  - keeping duplicate artifacts in Bundler::Index
  - preferring the narrower Ruby requirement