### PR TITLE
Split compact index entries on the first colon on older RubyGems

### DIFF
--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -469,16 +469,21 @@ module Gem
   # on every colon, which mangles metadata values that contain colons such as
   # the `created_at` timestamps the cooldown feature relies on. Split only on
   # the first colon so those values survive on older RubyGems.
-  unless Gem.rubygems_version >= Gem::Version.new("4.0.13")
-    module SplitCompactIndexEntryOnFirstColon
-      def parse_dependency(string)
-        dependency = string.split(":", 2)
-        dependency[-1] = dependency[-1].split("&") if dependency.size > 1
-        dependency[0] = -dependency[0]
-        dependency
-      end
-    end
+  #
+  # The module is defined unconditionally so it stays testable on any RubyGems,
+  # but only prepended when the host RubyGems still has the buggy behavior.
+  module SplitCompactIndexEntryOnFirstColon
+    private
 
+    def parse_dependency(string)
+      dependency = string.split(":", 2)
+      dependency[-1] = dependency[-1].split("&") if dependency.size > 1
+      dependency[0] = -dependency[0]
+      dependency
+    end
+  end
+
+  unless Gem.rubygems_version >= Gem::Version.new("4.0.13")
     Resolver::APISet::GemParser.prepend(SplitCompactIndexEntryOnFirstColon)
   end
 

--- a/bundler/lib/bundler/rubygems_ext.rb
+++ b/bundler/lib/bundler/rubygems_ext.rb
@@ -465,6 +465,23 @@ module Gem
     Resolver::APISet::GemParser.prepend(UnfreezeCompactIndexParsedResponse)
   end
 
+  # RubyGems before 4.0.13 split compact index dependency/requirement entries
+  # on every colon, which mangles metadata values that contain colons such as
+  # the `created_at` timestamps the cooldown feature relies on. Split only on
+  # the first colon so those values survive on older RubyGems.
+  unless Gem.rubygems_version >= Gem::Version.new("4.0.13")
+    module SplitCompactIndexEntryOnFirstColon
+      def parse_dependency(string)
+        dependency = string.split(":", 2)
+        dependency[-1] = dependency[-1].split("&") if dependency.size > 1
+        dependency[0] = -dependency[0]
+        dependency
+      end
+    end
+
+    Resolver::APISet::GemParser.prepend(SplitCompactIndexEntryOnFirstColon)
+  end
+
   if Gem.rubygems_version < Gem::Version.new("3.6.0")
     class Package; end
     require "rubygems/package/tar_reader"

--- a/spec/bundler/rubygems_ext_spec.rb
+++ b/spec/bundler/rubygems_ext_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "bundler/rubygems_ext"
+
+RSpec.describe Gem::SplitCompactIndexEntryOnFirstColon do
+  # Reproduces the RubyGems < 4.0.13 `Gem::Resolver::APISet::GemParser` that
+  # split each compact index entry on every colon, corrupting metadata values
+  # that themselves contain colons.
+  let(:legacy_parser_class) do
+    Class.new do
+      def parse_dependency(string)
+        dependency = string.split(":")
+        dependency[-1] = dependency[-1].split("&") if dependency.size > 1
+        dependency[0] = -dependency[0]
+        dependency
+      end
+    end
+  end
+
+  before { legacy_parser_class.prepend(described_class) }
+
+  it "preserves colon-bearing metadata values such as created_at timestamps" do
+    parser = legacy_parser_class.new
+
+    expect(parser.send(:parse_dependency, "created_at:2026-05-12T10:00:00Z")).to eq(["created_at", ["2026-05-12T10:00:00Z"]])
+  end
+
+  it "still parses ordinary name:requirement entries" do
+    parser = legacy_parser_class.new
+
+    expect(parser.send(:parse_dependency, "myrack:>= 1.0")).to eq(["myrack", [">= 1.0"]])
+  end
+
+  it "keeps parse_dependency private" do
+    parser = legacy_parser_class.new
+
+    expect { parser.parse_dependency("created_at:x") }.to raise_error(NoMethodError, /private method/)
+  end
+end

--- a/spec/support/shards.rb
+++ b/spec/support/shards.rb
@@ -143,6 +143,7 @@ module Spec
         "spec/bundler/ci_detector_spec.rb",
       ],
       shard_d: [
+        "spec/bundler/rubygems_ext_spec.rb",
         "spec/bundler/resolver/cooldown_spec.rb",
         "spec/install/cooldown_spec.rb",
         "spec/commands/outdated_spec.rb",


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Bundler delegates compact index parsing to the host RubyGems' `Gem::Resolver::APISet::GemParser`. Before RubyGems 4.0.13 that splits each entry on every colon, mangling metadata values that contain colons such as the `created_at` timestamps the cooldown feature reads, so cooldown silently stops filtering when Bundler runs on an older RubyGems.

## What is your fix for the problem, implemented in this PR?

Shim parse_dependency to split only on the first colon in that case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
