### PR TITLE
Remove external tool version checks from `bundle env`

### DIFF
--- a/bundler/lib/bundler/env.rb
+++ b/bundler/lib/bundler/env.rb
@@ -78,17 +78,6 @@ module Bundler
       "not installed"
     end
 
-    def self.version_of(script)
-      return "not installed" unless Bundler.which(script)
-      `#{script} --version`.chomp
-    end
-
-    def self.chruby_version
-      return "not installed" unless Bundler.which("chruby-exec")
-      `chruby-exec -- chruby --version`.
-        sub(/.*^chruby: (#{Gem::Version::VERSION_PATTERN}).*/m, '\1')
-    end
-
     def self.environment
       out = []
 
@@ -110,16 +99,8 @@ module Bundler
         out << ["  Cert File", OpenSSL::X509::DEFAULT_CERT_FILE] if defined?(OpenSSL::X509::DEFAULT_CERT_FILE)
         out << ["  Cert Dir", OpenSSL::X509::DEFAULT_CERT_DIR] if defined?(OpenSSL::X509::DEFAULT_CERT_DIR)
       end
-      out << ["Tools"]
-      out << ["  Git", git_version]
-      out << ["  RVM", ENV.fetch("rvm_version") { version_of("rvm") }]
-      out << ["  rbenv", version_of("rbenv")]
-      out << ["  chruby", chruby_version]
+      out << ["Git", git_version]
 
-      %w[rubygems-bundler open_gem].each do |name|
-        specs = Bundler.rubygems.find_name(name)
-        out << ["  #{name}", "(#{specs.map(&:version).join(",")})"] unless specs.empty?
-      end
       if (exe = caller_locations.last.absolute_path)&.match? %r{(exe|bin)/bundler?\z}
         shebang = File.read(exe).lines.first
         shebang.sub!(/^#!\s*/, "")
@@ -143,6 +124,6 @@ module Bundler
       out << "```\n"
     end
 
-    private_class_method :read_file, :ruby_version, :git_version, :append_formatted_table, :version_of, :chruby_version
+    private_class_method :read_file, :ruby_version, :git_version, :append_formatted_table
   end
 end

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -59,7 +59,10 @@ If these instructions don't work, or you can't find any appropriate instructions
     # Remove the saved resolve of the Gemfile
     rm -rf Gemfile.lock
 
-    # Uninstall the rubygems-bundler and open_gem gems
+    # Check whether the known-problematic rubygems-bundler and open_gem gems are installed
+    gem list rubygems-bundler open_gem
+
+    # Uninstall them if present
     rvm gemset use global # if using rvm
     gem uninstall rubygems-bundler open_gem
 

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -225,5 +225,13 @@ RSpec.describe Bundler::Env do
         expect(described_class.report).to include("Git           1.2.3 (Apple Git-BS)")
       end
     end
+
+    it "no longer reports the Tools section or external tool versions" do
+      report = described_class.report
+      expect(report).not_to include("Tools")
+      ["rbenv", "RVM", "chruby"].each do |tool|
+        expect(report).not_to include(tool)
+      end
+    end
   end
 end

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -222,16 +222,8 @@ RSpec.describe Bundler::Env do
           and_return(["git version 1.2.3 (Apple Git-BS)", "", status])
         expect(Bundler::Source::Git::GitProxy).to receive(:new).and_return(git_proxy_stub)
 
-        expect(described_class.report).to include("Git         1.2.3 (Apple Git-BS)")
+        expect(described_class.report).to include("Git           1.2.3 (Apple Git-BS)")
       end
-    end
-  end
-
-  describe ".version_of" do
-    let(:parsed_version) { described_class.send(:version_of, "ruby") }
-
-    it "strips version of new line characters" do
-      expect(parsed_version).to_not end_with("\n")
     end
   end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Keeping up with each version manager's invocation convention is not worth the maintenance cost. 

Fixed https://github.com/ruby/rubygems/issues/9528

If someone still need this, I will create `bundle tool-env` plugin or something.

## What is your fix for the problem, implemented in this PR?

Removed that category and move `Git` version to main section.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
