### PR TITLE
Add executables and bindir validation to the gem installer

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -713,9 +713,11 @@ class Gem::Installer
       raise Gem::InstallError, "#{spec} has an invalid dependencies"
     end
 
-    if spec.executables.any? {|name| name != File.basename(name) || /\A\.\.?\z|\R/.match?(name) }
+    if spec.executables.any? {|name| !name.is_a?(String) || name != File.basename(name) || /\A\.\.?\z|\R/.match?(name) }
       raise Gem::InstallError, "#{spec} has an invalid executable"
     end
+
+    raise Gem::InstallError, "#{spec} has an invalid bindir" unless spec.bindir.is_a?(String)
 
     expanded_gem_dir = File.expand_path(gem_dir)
     expanded_bindir = File.expand_path(File.join(gem_dir, spec.bindir))

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -716,6 +716,12 @@ class Gem::Installer
     if spec.executables.any? {|name| name != File.basename(name) || /\A\.\.?\z|\R/.match?(name) }
       raise Gem::InstallError, "#{spec} has an invalid executable"
     end
+
+    expanded_gem_dir = File.expand_path(gem_dir)
+    expanded_bindir = File.expand_path(File.join(gem_dir, spec.bindir))
+    unless expanded_bindir == expanded_gem_dir || expanded_bindir.start_with?("#{expanded_gem_dir}/")
+      raise Gem::InstallError, "#{spec} has an invalid bindir"
+    end
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -712,6 +712,10 @@ class Gem::Installer
     if spec.dependencies.any? {|dep| dep.name =~ /(?:\R|[<>])/ }
       raise Gem::InstallError, "#{spec} has an invalid dependencies"
     end
+
+    if spec.executables.any? {|name| name != File.basename(name) || /\A\.\.?\z|\R/.match?(name) }
+      raise Gem::InstallError, "#{spec} has an invalid executable"
+    end
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -730,6 +730,7 @@ class Gem::Installer
   def app_script_text(bin_file_name)
     # NOTE: that the `load` lines cannot be indented, as old RG versions match
     # against the beginning of the line
+    escaped_bin_file_name = bin_file_name.gsub(/[\\']/) {|c| "\\#{c}" }
     <<~TEXT
       #{shebang bin_file_name}
       #
@@ -753,9 +754,9 @@ class Gem::Installer
       end
 
       if Gem.respond_to?(:activate_and_load_bin_path)
-        Gem.activate_and_load_bin_path('#{spec.name}', '#{bin_file_name}', version)
+        Gem.activate_and_load_bin_path('#{spec.name}', '#{escaped_bin_file_name}', version)
       else
-        load Gem.activate_bin_path('#{spec.name}', '#{bin_file_name}', version)
+        load Gem.activate_bin_path('#{spec.name}', '#{escaped_bin_file_name}', version)
       end
     TEXT
   end

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -60,6 +60,21 @@ class TestGemInstaller < Gem::InstallerTestCase
     end
   end
 
+  def test_app_script_text_escapes_executable_name
+    installer = setup_base_installer
+
+    malicious = "evil');system('id');#"
+    @spec.bindir = "bin"
+    write_file @spec.bin_file(malicious) do |io|
+      io.puts "#!/usr/bin/ruby"
+    end
+
+    wrapper = installer.app_script_text malicious
+
+    assert_includes wrapper, %q{Gem.activate_and_load_bin_path('a', 'evil\');system(\'id\');#', version)}
+    assert_includes wrapper, %q{load Gem.activate_bin_path('a', 'evil\');system(\'id\');#', version)}
+  end
+
   def test_check_executable_overwrite
     installer = setup_base_installer
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1943,6 +1943,28 @@ class TestGemInstaller < Gem::InstallerTestCase
     end
   end
 
+  def test_pre_install_checks_malicious_bindir_before_eval
+    spec = util_spec "malicious", "1"
+    def spec.full_name # so the spec is buildable
+      "malicious-1"
+    end
+
+    def spec.validate(*args); end
+    spec.bindir = "../../../tmp/malicious"
+
+    util_build_gem spec
+
+    gem = File.join(@gemhome, "cache", spec.file_name)
+
+    use_ui @ui do
+      installer = Gem::Installer.at gem
+      e = assert_raise Gem::InstallError do
+        installer.pre_install_checks
+      end
+      assert_equal "#<Gem::Specification name=malicious version=1> has an invalid bindir", e.message
+    end
+  end
+
   def test_pre_install_checks_malicious_platform_before_eval
     gem_with_ill_formatted_platform = File.expand_path("packages/ill-formatted-platform-1.0.0.10.gem", __dir__)
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1921,6 +1921,28 @@ class TestGemInstaller < Gem::InstallerTestCase
     end
   end
 
+  def test_pre_install_checks_malicious_executables_before_eval
+    spec = util_spec "malicious", "1"
+    def spec.full_name # so the spec is buildable
+      "malicious-1"
+    end
+
+    def spec.validate(*args); end
+    spec.executables = ["../../../tmp/malicious"]
+
+    util_build_gem spec
+
+    gem = File.join(@gemhome, "cache", spec.file_name)
+
+    use_ui @ui do
+      installer = Gem::Installer.at gem
+      e = assert_raise Gem::InstallError do
+        installer.pre_install_checks
+      end
+      assert_equal "#<Gem::Specification name=malicious version=1> has an invalid executable", e.message
+    end
+  end
+
   def test_pre_install_checks_malicious_platform_before_eval
     gem_with_ill_formatted_platform = File.expand_path("packages/ill-formatted-platform-1.0.0.10.gem", __dir__)
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1980,6 +1980,38 @@ class TestGemInstaller < Gem::InstallerTestCase
     end
   end
 
+  def test_pre_install_checks_non_string_executable
+    spec = util_spec "malicious", "1"
+    def spec.validate(*args); end
+    spec.executables = [nil]
+
+    installer = Gem::Installer.for_spec spec
+    installer.gem_home = @gemhome
+
+    use_ui @ui do
+      e = assert_raise Gem::InstallError do
+        installer.pre_install_checks
+      end
+      assert_equal "#<Gem::Specification name=malicious version=1> has an invalid executable", e.message
+    end
+  end
+
+  def test_pre_install_checks_non_string_bindir
+    spec = util_spec "malicious", "1"
+    def spec.validate(*args); end
+    spec.bindir = true
+
+    installer = Gem::Installer.for_spec spec
+    installer.gem_home = @gemhome
+
+    use_ui @ui do
+      e = assert_raise Gem::InstallError do
+        installer.pre_install_checks
+      end
+      assert_equal "#<Gem::Specification name=malicious version=1> has an invalid bindir", e.message
+    end
+  end
+
   def test_pre_install_checks_malicious_platform_before_eval
     gem_with_ill_formatted_platform = File.expand_path("packages/ill-formatted-platform-1.0.0.10.gem", __dir__)
 


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

`Gem::Installer#verify_spec` now validates `spec.executables` and `spec.bindir` during pre-install checks, requiring executables to be plain basenames and bindir to stay within the gem directory.

The generated wrapper script also escapes the executable name so quotes in the name cannot change the generated Ruby.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
