### PR TITLE
Avoid duplicate relative path prefix in bundle exec

### DIFF
--- a/lib/bundler/cli/exec.rb
+++ b/lib/bundler/cli/exec.rb
@@ -23,7 +23,7 @@ module Bundler
           bin_path.delete_suffix!(".bat") if Gem.win_platform?
           kernel_load(bin_path, *args)
         else
-          bin_path = "./" + bin_path unless File.absolute_path?(bin_path)
+          bin_path = explicit_path(bin_path)
           kernel_exec(bin_path, *args)
         end
       else
@@ -69,6 +69,20 @@ module Bundler
 
     def process_title(file, args)
       "#{file} #{args.join(" ")}".strip
+    end
+
+    def explicit_path(path)
+      if File.absolute_path?(path) || explicit_relative_path?(path)
+        path
+      else
+        ".#{File::SEPARATOR}#{path}"
+      end
+    end
+
+    def explicit_relative_path?(path)
+      [File::SEPARATOR, File::ALT_SEPARATOR].compact.any? do |separator|
+        path.start_with?(".#{separator}", "..#{separator}")
+      end
     end
 
     def directly_loadable?(file)

--- a/spec/bundler/cli/exec_spec.rb
+++ b/spec/bundler/cli/exec_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "bundler/cli"
+require "bundler/cli/exec"
+
+RSpec.describe Bundler::CLI::Exec do
+  subject(:command) { described_class.new(options, ["script"]) }
+
+  let(:options) { double("options", keep_file_descriptors?: false) }
+
+  before do
+    allow(Bundler.current_ruby).to receive(:jruby?).and_return(false)
+    allow(Bundler::SharedHelpers).to receive(:set_bundle_environment)
+    allow(Bundler).to receive(:settings).and_return({ disable_exec_load: true })
+  end
+
+  def expect_exec_path(path, expected_path)
+    allow(Bundler).to receive(:which).with("script").and_return(path)
+    expect(command).to receive(:kernel_exec).with(expected_path, kind_of(Hash))
+    command.run
+  end
+
+  it "preserves explicit relative paths using the primary path separator" do
+    path = ".#{File::SEPARATOR}script"
+    expect_exec_path(path, path)
+  end
+
+  it "preserves parent-relative paths using the primary path separator" do
+    path = "..#{File::SEPARATOR}script"
+    expect_exec_path(path, path)
+  end
+
+  it "preserves explicit relative paths using the alternative path separator" do
+    stub_const("File::ALT_SEPARATOR", "\\")
+
+    expect_exec_path(".\\script", ".\\script")
+  end
+
+  it "preserves parent-relative paths using the alternative path separator" do
+    stub_const("File::ALT_SEPARATOR", "\\")
+
+    expect_exec_path("..\\script", "..\\script")
+  end
+
+  it "prepends the primary path separator to other relative paths" do
+    expect_exec_path(".script", ".#{File::SEPARATOR}.script")
+  end
+
+  it "treats a backslash as part of a filename when it is not a path separator" do
+    stub_const("File::ALT_SEPARATOR", nil)
+
+    expect_exec_path(".\\script", ".#{File::SEPARATOR}.\\script")
+  end
+end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -343,6 +343,32 @@ RSpec.describe "bundle exec" do
     expect(out).to include(rubylib)
   end
 
+  it "does not duplicate a relative path prefix when exec'ing to a relative path" do
+    skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+
+    create_file("script", "#!/usr/bin/env ruby\nputs $0")
+
+    install_gemfile <<-G
+      source "https://gem.repo1"
+    G
+
+    bundle "exec ./script", env: { "BUNDLE_DISABLE_EXEC_LOAD" => "true" }
+    expect(out).to eq("./script")
+  end
+
+  it "prepends a relative path prefix when exec'ing to a hidden file in the current directory" do
+    skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+
+    create_file(".script", "#!/usr/bin/env ruby\nputs $0")
+
+    install_gemfile <<-G
+      source "https://gem.repo1"
+    G
+
+    bundle "exec .script", env: { "BUNDLE_DISABLE_EXEC_LOAD" => "true" }
+    expect(out).to eq("./.script")
+  end
+
   it "errors nicely when the argument doesn't exist" do
     install_gemfile <<-G
       source "https://gem.repo1"

--- a/spec/support/shards.rb
+++ b/spec/support/shards.rb
@@ -144,6 +144,7 @@ module Spec
         "spec/bundler/ci_detector_spec.rb",
       ],
       shard_d: [
+        "spec/bundler/cli/exec_spec.rb",
         "spec/bundler/rubygems_ext_spec.rb",
         "spec/bundler/resolver/cooldown_spec.rb",
         "spec/install/cooldown_spec.rb",


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle exec ./script` can currently execute the script as `././script` when Bundler resolves the command to a relative path and then uses `Kernel.exec`. This happens because Bundler prepends `./` to every non-absolute resolved path, including paths that already explicitly start with `./`.

That makes explicit relative paths look different to the executed process than the user-provided command, and it is the duplicate-prefix issue reported in https://github.com/ruby/rubygems/issues/8930.

Closes https://github.com/ruby/rubygems/issues/8930

## What is your fix for the problem, implemented in this PR?

Keep the existing `./` prefixing behavior for bare relative executable names, but skip it when the resolved path already starts with `./` or `../`. This preserves the current support for executing commands found in the current directory, including hidden filenames like `.script`, while avoiding `././script` for explicit relative paths like `./script`.

I added regression specs that disable Bundler's exec-load optimization so the `Kernel.exec` path is exercised. They verify that `bundle exec ./script` leaves `$0` as `./script`, and that `bundle exec .script` still passes `./.script`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write tests for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the current code style and write meaningful commit messages without tags

## Tophatting

- `bin/rspec spec/commands/exec_spec.rb:344 spec/commands/exec_spec.rb:357 --format documentation`
- `bin/rspec spec/commands/exec_spec.rb`
- `git diff --check`
