### PR TITLE
Strip C1 control characters from displayed gem text

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -299,7 +299,7 @@ class Gem::Installer
 
     File.chmod(dir_mode, gem_dir) if dir_mode
 
-    say spec.post_install_message if options[:post_install_message] && !spec.post_install_message.nil?
+    say clean_text(spec.post_install_message) if options[:post_install_message] && !spec.post_install_message.nil?
 
     Gem::Specification.add_spec(spec) unless @install_dir
 

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -299,7 +299,7 @@ class Gem::Installer
 
     File.chmod(dir_mode, gem_dir) if dir_mode
 
-    say clean_text(spec.post_install_message) if options[:post_install_message] && !spec.post_install_message.nil?
+    say clean_text(spec.post_install_message.to_s) if options[:post_install_message] && !spec.post_install_message.nil?
 
     Gem::Specification.add_spec(spec) unless @install_dir
 

--- a/lib/rubygems/text.rb
+++ b/lib/rubygems/text.rb
@@ -10,8 +10,9 @@ module Gem::Text
   def clean_text(text)
     text = text.gsub(/[\000-\b\v-\f\016-\037\177]/, ".")
 
-    # C1 control characters (U+0080-U+009F) only occur in UTF-8 text and must
-    # be matched as codepoints so that multibyte characters are preserved.
+    # Match C1 control characters (U+0080-U+009F) as codepoints. This requires
+    # a valid UTF-8 string so the regexp does not split a multibyte sequence;
+    # strings in other encodings are left unchanged.
     if text.encoding == Encoding::UTF_8 && text.valid_encoding?
       text = text.gsub(/[\u0080-\u009f]/, ".")
     end

--- a/lib/rubygems/text.rb
+++ b/lib/rubygems/text.rb
@@ -8,7 +8,15 @@ module Gem::Text
   # Remove any non-printable characters and make the text suitable for
   # printing.
   def clean_text(text)
-    text.gsub(/[\000-\b\v-\f\016-\037\177]/, ".")
+    text = text.gsub(/[\000-\b\v-\f\016-\037\177]/, ".")
+
+    # C1 control characters (U+0080-U+009F) only occur in UTF-8 text and must
+    # be matched as codepoints so that multibyte characters are preserved.
+    if text.encoding == Encoding::UTF_8 && text.valid_encoding?
+      text = text.gsub(/[\u0080-\u009f]/, ".")
+    end
+
+    text
   end
 
   def truncate_text(text, description, max_length = 100_000)

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1481,6 +1481,23 @@ class TestGemInstaller < Gem::InstallerTestCase
     refute_match(/I am a shiny gem!/, @ui.output)
   end
 
+  def test_install_sanitizes_post_install_message
+    # Use for_spec so the in-memory message reaches the installer verbatim;
+    # building a gem would escape the control characters during serialization.
+    @spec = setup_base_spec
+    @spec.post_install_message = "shiny \e]2;pwn\a gem"
+
+    installer = Gem::Installer.for_spec @spec, post_install_message: true
+    installer.gem_home = @gemhome
+
+    use_ui @ui do
+      installer.install
+    end
+
+    assert_match(/shiny \.\]2;pwn\. gem/, @ui.output)
+    refute_match(/\e\]2;pwn/, @ui.output)
+  end
+
   def test_install_extension_dir
     gemhome2 = "#{@gemhome}2"
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1498,6 +1498,22 @@ class TestGemInstaller < Gem::InstallerTestCase
     refute_match(/\e\]2;pwn/, @ui.output)
   end
 
+  def test_install_handles_non_string_post_install_message
+    # post_install_message may be a non-String (the gemspec schema allows an
+    # array), so sanitizing must not assume it responds to gsub.
+    @spec = setup_base_spec
+    @spec.post_install_message = %w[one two]
+
+    installer = Gem::Installer.for_spec @spec, post_install_message: true
+    installer.gem_home = @gemhome
+
+    use_ui @ui do
+      installer.install
+    end
+
+    assert_match(/one/, @ui.output)
+  end
+
   def test_install_extension_dir
     gemhome2 = "#{@gemhome}2"
 

--- a/test/rubygems/test_gem_text.rb
+++ b/test/rubygems/test_gem_text.rb
@@ -107,8 +107,10 @@ Without the wrapping, the text might not look good in the RSS feed.
   end
 
   def test_clean_text_preserves_multibyte_characters
-    text = [0xe9, 0x85].pack("U*") # U+00E9 kept, NEL (U+0085) stripped
-    assert_equal [0xe9, 0x2e].pack("U*"), clean_text(text)
+    # U+0400 encodes to bytes D0 80, whose 0x80 continuation byte must not be
+    # mistaken for a C1 control byte. NEL (U+0085) is stripped.
+    text = [0x400, 0x85].pack("U*")
+    assert_equal [0x400, 0x2e].pack("U*"), clean_text(text)
   end
 
   def test_clean_text_passes_through_non_unicode_encodings

--- a/test/rubygems/test_gem_text.rb
+++ b/test/rubygems/test_gem_text.rb
@@ -100,4 +100,19 @@ Without the wrapping, the text might not look good in the RSS feed.
   def test_clean_text
     assert_equal ".]2;nyan.", clean_text("\e]2;nyan\a")
   end
+
+  def test_clean_text_strips_c1_control_characters
+    text = [0x41, 0x9b, 0x42].pack("U*") # "A", CSI (U+009B), "B"
+    assert_equal "A.B", clean_text(text)
+  end
+
+  def test_clean_text_preserves_multibyte_characters
+    text = [0xe9, 0x85].pack("U*") # U+00E9 kept, NEL (U+0085) stripped
+    assert_equal [0xe9, 0x2e].pack("U*"), clean_text(text)
+  end
+
+  def test_clean_text_passes_through_non_unicode_encodings
+    text = "x\x9by".dup.force_encoding("ISO-8859-1")
+    assert_equal text, clean_text(text)
+  end
 end


### PR DESCRIPTION
## What is your fix for the problem, implemented in this PR?

`Gem::Text#clean_text` now also strips C1 control characters (U+0080-U+009F).

They are matched as codepoints and only for valid UTF-8 text, so multibyte characters are preserved and other encodings are left unchanged. The post-install message is now routed through `clean_text` before it is printed.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
