### PR TITLE
Preserve per-source cooldown when converging sources from the lockfile

### DIFF
--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -11,7 +11,7 @@ module Bundler
       API_REQUEST_SIZE = 100
       REQUIRE_MUTEX = Mutex.new
 
-      attr_accessor :remotes
+      attr_accessor :remotes, :remote_cooldowns
 
       def initialize(options = {})
         @options = options

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -169,6 +169,10 @@ module Bundler
         # locked sources never include credentials so always prefer remotes from the gemfile
         replacement_source.remotes = gemfile_source.remotes
 
+        # cooldowns are only ever declared in the Gemfile, so carry them over
+        # along with the remotes they apply to
+        replacement_source.remote_cooldowns = gemfile_source.remote_cooldowns
+
         yield replacement_source if block_given?
 
         replacement_source

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -143,6 +143,64 @@ RSpec.describe "bundle install with the cooldown setting" do
       expect(the_bundle).to include_gems("ripe_gem 1.0.0")
     end
 
+    it "applies per-source Gemfile cooldown on bundle update when a lockfile exists" do
+      # Converging the Gemfile sources with the lockfile sources used to drop
+      # the per-source cooldown, so it only ever worked on a first resolve
+      # without a lockfile.
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "update ripe_gem", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0")
+    end
+
+    it "applies per-source Gemfile cooldown to gems added after the lockfile was written" do
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+        gem "child"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "install", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0", "child 1.0.0")
+    end
+
     it "is overridden by CLI --cooldown when Gemfile sets a different per-source value" do
       gemfile <<-G
         source "https://gem.repo3", cooldown: 0


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

While rolling out cooldown on our apps I noticed that a per-source cooldown declared in the Gemfile (`source "https://rubygems.org", cooldown: 7`) stops having any effect once a `Gemfile.lock` exists. `bundle update`, and `bundle install` after adding a new gem to the Gemfile, both resolve to versions inside the cooldown window as if no cooldown was configured. The same value set through `bundle config set cooldown 7` or `--cooldown 7` is honored in those scenarios.

Repro:

```
$ printf 'source "https://rubygems.org"\ngem "rack", "3.2.0"\n' > Gemfile
$ bundle lock
$ printf 'source "https://rubygems.org", cooldown: 10000\ngem "rack"\n' > Gemfile
$ bundle lock --update rack
# silently updates to the newest rack, despite a window that excludes
# every version ever published. With `bundle config set cooldown 10000`
# instead, resolution correctly reports all versions excluded.
```

The cause is in `SourceList#replace_rubygems_source`. When the Gemfile sources are converged with the lockfile sources, the locked source object replaces the Gemfile one and only `remotes` is copied across. The `@remote_cooldowns` hash stays behind on the discarded Gemfile source, so `cooldown_for` returns nil for every remote and the fetchers are built without a cooldown.

## What is your fix for the problem, implemented in this PR?

Carry the cooldowns over together with the remotes they apply to when a rubygems source is replaced by its locked equivalent.

Added two specs that fail on master: `bundle update` with a lockfile present, and resolving a gem added to the Gemfile after the lockfile was written.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
