### PR TITLE
Added Cooldown regression tests

### DIFF
--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -668,6 +668,23 @@ RSpec.describe "bundle install with the cooldown setting" do
 
       expect(the_bundle).to include_gems("ripe_gem 2.0.0")
     end
+
+    it "keys per-source cooldown by the declared URI even behind a mirror" do
+      # A mirror rewrites the fetch URI, but cooldown is recorded under the URI
+      # written in the Gemfile. The cooldown must still apply through the
+      # redirect to the mirror that actually serves the gems.
+      bundle "config set mirror.https://gem.repo2 https://gem.repo3"
+
+      gemfile <<-G
+        source "https://gem.repo2", cooldown: 7
+        gem "ripe_gem"
+      G
+
+      bundle "install", artifice: "compact_index_cooldown",
+                        env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo3.to_s }
+
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0")
+    end
   end
 
   context "with a source that does not provide publish dates" do

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -638,6 +638,36 @@ RSpec.describe "bundle install with the cooldown setting" do
       expect(lockfile).to include("ripe_gem (1.0.0)")
       expect(lockfile).not_to include("ripe_gem (2.0.0)")
     end
+
+    it "ignores cooldown and installs the locked version when frozen" do
+      # Frozen installs read the lockfile instead of resolving, so cooldown has
+      # no say. A version already locked inside the window must still install.
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (2.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "config set frozen true"
+      bundle "install", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("ripe_gem 2.0.0")
+    end
   end
 
   context "with a source that does not provide publish dates" do

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -583,6 +583,33 @@ RSpec.describe "bundle install with the cooldown setting" do
       # its in-window 2.0.0 stays excluded.
       expect(the_bundle).to include_gems("ripe_gem 1.0.0", "solo_gem 1.0.0")
     end
+
+    it "applies per-source Gemfile cooldown to a gem added via bundle add" do
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "add child", artifice: "compact_index_cooldown"
+
+      expect(the_bundle).to include_gems("child 1.0.0")
+    end
   end
 
   context "with a source that does not provide publish dates" do

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -610,6 +610,34 @@ RSpec.describe "bundle install with the cooldown setting" do
 
       expect(the_bundle).to include_gems("child 1.0.0")
     end
+
+    it "applies per-source Gemfile cooldown on bundle lock --update" do
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "lock --update ripe_gem", artifice: "compact_index_cooldown"
+
+      expect(lockfile).to include("ripe_gem (1.0.0)")
+      expect(lockfile).not_to include("ripe_gem (2.0.0)")
+    end
   end
 
   context "with a source that does not provide publish dates" do

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -488,4 +488,28 @@ RSpec.describe "bundle install with the cooldown setting" do
       expect(the_bundle).to include_gems("upgradable 3.0.0")
     end
   end
+
+  context "with a source that does not provide publish dates" do
+    before do
+      build_repo3 do
+        build_gem "ripe_gem", "1.0.0"
+        build_gem "ripe_gem", "2.0.0"
+      end
+    end
+
+    it "cannot apply cooldown and installs the latest version" do
+      # The legacy dependency API does not expose per-version publish dates, so
+      # the cooldown filter has nothing to compare against and is silently
+      # inactive. This pins that limitation; flip the expectation if publish
+      # dates ever become available over this endpoint.
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+      G
+
+      bundle "install", artifice: "endpoint"
+
+      expect(the_bundle).to include_gems("ripe_gem 2.0.0")
+    end
+  end
 end

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -487,6 +487,102 @@ RSpec.describe "bundle install with the cooldown setting" do
 
       expect(the_bundle).to include_gems("upgradable 3.0.0")
     end
+
+    it "keeps a top-level source cooldown through a partial update with multiple sources" do
+      build_repo4 do
+        build_gem "solo_gem", "1.0.0" do |s|
+          s.date = Time.now.utc - (30 * 86_400)
+        end
+        build_gem "solo_gem", "2.0.0" do |s|
+          s.date = Time.now.utc - (1 * 86_400)
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+        source "https://gem.repo4" do
+          gem "solo_gem"
+        end
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (1.0.0)
+
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            solo_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+          solo_gem!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "update ripe_gem", artifice: "compact_index_cooldown"
+
+      # A partial update converges the still-locked sources, the path that used
+      # to drop cooldown. repo3's cooldown must survive that even with a second
+      # source in the Gemfile, so its in-window 2.0.0 stays excluded.
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0", "solo_gem 1.0.0")
+    end
+
+    it "carries cooldown declared on a gem-block source" do
+      build_repo4 do
+        build_gem "solo_gem", "1.0.0" do |s|
+          s.date = Time.now.utc - (30 * 86_400)
+        end
+        build_gem "solo_gem", "2.0.0" do |s|
+          s.date = Time.now.utc - (1 * 86_400)
+        end
+      end
+
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem"
+        source "https://gem.repo4", cooldown: 7 do
+          gem "solo_gem"
+        end
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (1.0.0)
+
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            solo_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+          solo_gem!
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "update solo_gem", artifice: "compact_index_cooldown"
+
+      # The cooldown lives on the gem-block source, which is also converged from
+      # the lockfile. A partial update of solo_gem must keep that cooldown, so
+      # its in-window 2.0.0 stays excluded.
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0", "solo_gem 1.0.0")
+    end
   end
 
   context "with a source that does not provide publish dates" do

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -489,12 +489,13 @@ RSpec.describe "bundle install with the cooldown setting" do
     end
 
     it "keeps a top-level source cooldown through a partial update with multiple sources" do
+      now = Time.now.utc
       build_repo4 do
         build_gem "solo_gem", "1.0.0" do |s|
-          s.date = Time.now.utc - (30 * 86_400)
+          s.date = now - (30 * 86_400)
         end
         build_gem "solo_gem", "2.0.0" do |s|
-          s.date = Time.now.utc - (1 * 86_400)
+          s.date = now - (1 * 86_400)
         end
       end
 
@@ -537,12 +538,13 @@ RSpec.describe "bundle install with the cooldown setting" do
     end
 
     it "carries cooldown declared on a gem-block source" do
+      now = Time.now.utc
       build_repo4 do
         build_gem "solo_gem", "1.0.0" do |s|
-          s.date = Time.now.utc - (30 * 86_400)
+          s.date = now - (30 * 86_400)
         end
         build_gem "solo_gem", "2.0.0" do |s|
-          s.date = Time.now.utc - (1 * 86_400)
+          s.date = now - (1 * 86_400)
         end
       end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Follow-up regression coverage for the per-source cooldown fix in #9601.

- Pin that cooldown is silently inactive over the dependency API, which exposes no per-version publish dates for the filter to compare against.
- Keep per-source cooldown attached to its own source across a partial update, for both a top-level source and a gem-block source.
- Inherit the source's cooldown for a gem added via `bundle add` against an existing lockfile.
- Hold a gem inside the cooldown window on `bundle lock --update`, asserted against the written lockfile (the exact path from the original report).
- Pin that a frozen install reads the lockfile and ignores cooldown entirely.
- Confirm cooldown is keyed by the URI declared in the Gemfile and still applies through a mirror redirect.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
