### PR TITLE
Changelogs for RubyGems 4.0.14 and Bundler 4.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.0.14 / 2026-06-10
+
+### Enhancements:
+
+* Add executables and bindir validation to the gem installer. Pull request [#9595](https://github.com/ruby/rubygems/pull/9595) by hsbt
+* Strip C1 control characters from displayed gem text. Pull request [#9597](https://github.com/ruby/rubygems/pull/9597) by hsbt
+* Installs bundler 4.0.14 as a default gem.
+
 ## 4.0.13 / 2026-06-03
 
 ### Enhancements:

--- a/bundler/CHANGELOG.md
+++ b/bundler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.0.14 / 2026-06-10
+
+### Bug fixes:
+
+* Preserve per-source cooldown when converging sources from the lockfile. Pull request [#9601](https://github.com/ruby/rubygems/pull/9601) by bryanwoods
+* Don't exclude the locked version from cooldown during bundle update. Pull request [#9599](https://github.com/ruby/rubygems/pull/9599) by hsbt
+
 ## 4.0.13 / 2026-06-03
 
 ### Enhancements:


### PR DESCRIPTION
Cherry-picking change logs from future RubyGems 4.0.14 and Bundler 4.0.14 into master.