### PR TITLE
Detect stale release branches on origin

### DIFF
--- a/tool/release.rb
+++ b/tool/release.rb
@@ -253,6 +253,11 @@ class Release
       errors << "Release branches already exist: #{existing.join(", ")}. Please delete them before running this task."
     end
 
+    existing_remote = branches.select {|b| system("git", "rev-parse", "--verify", "refs/remotes/origin/#{b}", out: IO::NULL, err: IO::NULL) }
+    unless existing_remote.empty?
+      errors << "Release branches already exist on origin: #{existing_remote.map {|b| "origin/#{b}" }.join(", ")}. `git checkout` would silently base work on them instead of the intended branch. Delete them from origin, or run `git fetch --prune origin` if they are already gone."
+    end
+
     raise errors.join("\n") unless errors.empty?
   end
 


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

The existing check only looks at local branches, but when a previous release run left `release/*` or `cherry_pick_changelogs` on origin, plain `git checkout` DWIMs into a tracking branch based on the stale remote branch, ignoring the intended base and mixing leftover commits into the release PR.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
