### PR TITLE
Detect regressions hidden by the `.dev` version suffix on master

### DIFF
--- a/.github/workflows/bundler.yml
+++ b/.github/workflows/bundler.yml
@@ -69,6 +69,10 @@ jobs:
 
           - { os: { name: Ubuntu, value: ubuntu-24.04 }, ruby: { name: ruby-4.0 (psych), value: 4.0.5 }, use_psych: true }
 
+          # Regression coverage for release branches, where the version constants
+          # do not have a .dev suffix and behave differently.
+          - { os: { name: Ubuntu, value: ubuntu-24.04 }, ruby: { name: ruby-4.0 (release version), value: 4.0.5 }, strip_dev: true }
+
     env:
       RGV: .
       RUBYOPT: --disable-gems
@@ -82,6 +86,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby.value }}
           bundler: none
+      - name: Simulate a release version by stripping .dev
+        run: ruby -i -pe 'sub(/^(\s*VERSION = ")(\d+\.\d+\.\d+)\.dev/, "\\1\\2")' lib/rubygems.rb bundler/lib/bundler/version.rb
+        if: matrix.strip_dev
       - name: Restore gem caches
         uses: actions/cache/restore@v5
         id: restore-cache

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Simulate a release version by stripping .dev
         run: |
           ruby -i -pe 'sub(/^(\s*VERSION = ")(\d+\.\d+\.\d+)\.dev/, "\\1\\2")' lib/rubygems.rb bundler/lib/bundler/version.rb
-          bin/rake version:update_locked_bundler
+          bin/rake dev:deps version:update_locked_bundler
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Simulate release version"

--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -111,6 +111,36 @@ jobs:
         if: matrix.ruby.name != 'jruby'
     timeout-minutes: 15
 
+  release_version:
+    name: Check release version simulation
+    runs-on: ubuntu-24.04
+    env:
+      RUBYOPT: -Ilib
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Setup ruby
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+        with:
+          ruby-version: ruby
+          bundler: none
+      - name: Simulate a release version by stripping .dev
+        run: |
+          ruby -i -pe 'sub(/^(\s*VERSION = ")(\d+\.\d+\.\d+)\.dev/, "\\1\\2")' lib/rubygems.rb bundler/lib/bundler/version.rb
+          bin/rake version:update_locked_bundler
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Simulate release version"
+      - name: Check lockfiles do not depend on the local gem cache
+        run: |
+          version=$(ruby -Ibundler/lib -rbundler/version -e 'puts Bundler::VERSION')
+          mkdir -p cache
+          (cd bundler && gem build bundler.gemspec --output "../cache/bundler-${version}.gem")
+          echo "cache/" >> .git/info/exclude
+          bin/rake version:check dev:frozen_deps
+    timeout-minutes: 15
+
   all-pass:
     name: All ubuntu-lint jobs pass
 
@@ -120,6 +150,7 @@ jobs:
       - python_linters
       - ruby_linters
       - check_misc
+      - release_version
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Behavior gated on the `.dev` suffix (bundler's self-checksum in lockfiles, SelfManager version switching) is never exercised by CI on master, so breakage only surfaces on release branches, as happened with the lockfile drift fixed in #9501.


## What is your fix for the problem, implemented in this PR?

Add a release-version simulation: ubuntu-lint strips `.dev`, relocks, and verifies lockfile output does not depend on the local gem cache, and a bundler matrix cell runs the spec suite with the stripped version.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
