### PR TITLE
Set `Bundler.settings[:ssl_ca_cert]` to download gems

### DIFF
--- a/bundler/lib/bundler/fetcher/gem_remote_fetcher.rb
+++ b/bundler/lib/bundler/fetcher/gem_remote_fetcher.rb
@@ -9,6 +9,8 @@ module Bundler
         super
 
         @pool_size = Bundler.settings.installation_parallelization
+        ssl_ca_cert = Bundler.settings[:ssl_ca_cert]
+        @cert_files << ssl_ca_cert if ssl_ca_cert
       end
 
       def request(*args)

--- a/spec/bundler/fetcher/gem_remote_fetcher_spec.rb
+++ b/spec/bundler/fetcher/gem_remote_fetcher_spec.rb
@@ -6,6 +6,36 @@ require_relative "../../support/artifice/helpers/artifice"
 require "bundler/vendored_persistent.rb"
 
 RSpec.describe Bundler::Fetcher::GemRemoteFetcher do
+  describe "#initialize" do
+    context "when ssl_ca_cert setting is not set" do
+      before do
+        allow(Bundler.settings).to receive(:[]).and_call_original
+        allow(Bundler.settings).to receive(:[]).with(:ssl_ca_cert).and_return(nil)
+      end
+
+      it "does not append the setting to @cert_files" do
+        cert_files = subject.instance_variable_get(:@cert_files)
+        gem_cert_files = Gem::Request.get_cert_files
+        expect(cert_files).to eq(gem_cert_files)
+      end
+    end
+
+    context "when ssl_ca_cert setting is set" do
+      let(:ca_cert_path) { "/path/to/ca_cert" }
+
+      before do
+        allow(Bundler.settings).to receive(:[]).and_call_original
+        allow(Bundler.settings).to receive(:[]).with(:ssl_ca_cert).and_return(ca_cert_path)
+      end
+
+      it "appends the setting to @cert_files" do
+        cert_files = subject.instance_variable_get(:@cert_files)
+        gem_cert_files = Gem::Request.get_cert_files
+        expect(cert_files).to eq(gem_cert_files + [ca_cert_path])
+      end
+    end
+  end
+
   describe "Parallel download" do
     it "download using multiple connections from the pool" do
       unless Bundler.rubygems.provides?(">= 4.0.0.dev")


### PR DESCRIPTION


## Issue

When `bundle install` connects with a certification (CA) to a private RubyGems HTTPS server emulated by WEBrick, the connection to the https://localhost:18443/versions succeeded, but the connection to download gems failed with the following error.

```
+ /home/jaruga/var/git/ruby/rubygems/bin/bundle config set --local ssl_ca_cert /home/jaruga/git/report-bundler-bundle-config-set-ssl_ca_cert/tmp/client/ssl/ca.crt
...
+ /home/jaruga/var/git/ruby/rubygems/bin/bundle install -V
Running `bundle install --verbose` with bundler 4.1.0.dev
Resolving dependencies because there's no lockfile
HTTP GET https://localhost:18443/versions
HTTP 206 Partial Content https://localhost:18443/versions
HTTP GET https://localhost:18443/versions
HTTP 200 OK https://localhost:18443/versions
Fetching gem metadata from https://localhost:18443/
Looking up gems ["hello"]
Resolving dependencies...
Using bundler 4.1.0.dev
1:  bundler (4.1.0.dev) from /home/jaruga/var/git/ruby/rubygems/bundler/bundler.gemspec
Fetching hello 0.1.0
Retrying download gem from https://localhost:18443/ due to error (2/4): Gem::RemoteFetcher::FetchError SSL_connect returned=1 errno=0 peeraddr=127.0.0.1:18443 state=error: certificate verify failed (unable to get local issuer certificate) (https://localhost:18443/gems/hello-0.1.0.gem)
Sleeping for 1.22 seconds before retry
Retrying download gem from https://localhost:18443/ due to error (3/4): Gem::RemoteFetcher::FetchError SSL_connect returned=1 errno=0 peeraddr=127.0.0.1:18443 state=error: certificate verify failed (unable to get local issuer certificate) (https://localhost:18443/gems/hello-0.1.0.gem)
Sleeping for 2.26 seconds before retry
Retrying download gem from https://localhost:18443/ due to error (4/4): Gem::RemoteFetcher::FetchError SSL_connect returned=1 errno=0 peeraddr=127.0.0.1:18443 state=error: certificate verify failed (unable to get local issuer certificate) (https://localhost:18443/gems/hello-0.1.0.gem)
Sleeping for 4.02 seconds before retry
Bundler::InstallError: Bundler::HTTPError: Could not download gem from https://localhost:18443/ due to underlying error <SSL_connect returned=1 errno=0 peeraddr=127.0.0.1:18443 state=error: certificate verify failed (unable to get local issuer certificate) (https://localhost:18443/gems/hello-0.1.0.gem)>
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/rubygems_integration.rb:406:in 'Bundler::RubygemsIntegration#download_gem'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/source/rubygems.rb:531:in 'block in Bundler::Source::Rubygems#download_gem'
  /home/jaruga/.local/ruby-4.1.0-debug-3ef48ef9c8-openssl-4.1.0-7194354488/lib/ruby/4.1.0+1/rubygems.rb:1068:in 'Gem.time'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/source/rubygems.rb:530:in 'Bundler::Source::Rubygems#download_gem'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/source/rubygems.rb:459:in 'Bundler::Source::Rubygems#fetch_gem'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/source/rubygems.rb:443:in 'Bundler::Source::Rubygems#fetch_gem_if_possible'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/source/rubygems.rb:575:in 'Bundler::Source::Rubygems#rubygems_gem_installer'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/source/rubygems.rb:184:in 'Bundler::Source::Rubygems#download'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/installer/gem_installer.rb:29:in 'Bundler::GemInstaller#download'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/installer/parallel_installer.rb:148:in 'Bundler::ParallelInstaller#do_download'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/installer/parallel_installer.rb:132:in 'block in Bundler::ParallelInstaller#worker_pool'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/worker.rb:70:in 'Bundler::Worker#apply_func'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/worker.rb:65:in 'block in Bundler::Worker#process_queue'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/worker.rb:56:in 'Kernel#loop'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/worker.rb:56:in 'Bundler::Worker#process_queue'
  /home/jaruga/var/git/ruby/rubygems/bundler/lib/bundler/worker.rb:98:in 'block (2 levels) in Bundler::Worker#create_threads'
...
```

## Reproducer

I prepared a minimal reproducer on the following repository. You can try for ruby/rubygems master branch.

https://github.com/junaruga/report-bundler-bundle-config-set-ssl_ca_cert

```
$ cd ~/git
$ git clone https://github.com/junaruga/report-bundler-bundle-config-set-ssl_ca_cert.git
$ cd ~/git/ruby/rubygems
$ ~/git/report-bundler-bundle-config-set-ssl_ca_cert/test.sh -d
```

## Cause & fix

`Bundler::Fetcher` creates the connection object by the `#connection` calling `#bundler_cert_store` storing `Bundler.settings[:ssl_ca_cert]` in the following part. It is used in some parts.

bundler/lib/bundler/fetcher.rb
```
    def bundler_cert_store
      ...
      ssl_ca_cert = Bundler.settings[:ssl_ca_cert] ||
                    (Gem.configuration.ssl_ca_cert if
                      Gem.configuration.respond_to?(:ssl_ca_cert))
      ...
    end
```

However in the case of downloading gems in Bundler, Bundler calls `Bundler::Source::Rubygems#download_gem` calling `Bundler::Fetcher#gem_remote_fetcher`
calling `Bundler::Fetcher::GemRemoteFetcher`
extending `Gem::RemoteFetcher` managing `@cert_files` for RubyGems.

Therefore, the `Bundler::Fetcher::GemRemoteFetcher` needs to update the `@cert_files` by adding the value of the `Bundler.settings[:ssl_ca_cert]`.

As in the process of downloading gems,
`Gem::Request.configure_connection_for_https` is called, and it gets `Gem.configuration.ssl_ca_cert`,
we don't need to add the value in the `Bundler::Fetcher::GemRemoteFetcher`.

The backtrace is below.

```
+ rdbg -c \
  -e 'b Gem::Request.configure_connection_for_https' \
  -e c \
  -- /home/jaruga/git/ruby/rubygems/bin/bundle install -V
...
(rdbg) bt    # backtrace command
=>#0>-Gem::Request.configure_connection_for_https(connection=#<Gem::Net::HTTP localhost:18443 open=fal..., cert_files=["/home/jaruga/.local/ruby-4.1.0-debug-3e...) at ~/.local/ruby-4.1.0-debug-3ef48ef9c8-openssl-4.1.0-7194354488/lib/ruby/4.1.0+1/rubygems/request.rb:71
...
  #20>Bundler::Source::Rubygems#download_gem(spec=Gem::Specification.new do |s| s.name = "h..., download_cache_path="/home/jaruga/var/git/report-bundler-bund..., previous_spec=nil) at ~/var/git/ruby/rubygems/bundler/lib/bundler/source/rubygems.rb:530
...
```

According to the following logic, `@cert_files` is always not `nil`, as `Dir.glob(pattern)` returns Array. We don't need to consider the `nil` case.

lib/rubygems/remote_fetcher.rb
```
  def initialize(proxy = nil, dns = nil, headers = {})
    ...
    @cert_files = Gem::Request.get_cert_files
    ...
  end
```

lib/rubygems/request.rb
```
  def self.get_cert_files
    pattern = File.expand_path("./ssl_certs/*/*.pem", __dir__)
    Dir.glob(pattern)
  end
```

Add unit tests for `Bundler::Fetcher::GemRemoteFetcher#initialize`.

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

The `bundle config set ssl_ca_cert` doesn't work in the process of downloading gems.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Added the `Bundler.settings[:ssl_ca_cert]` in the process of downloading gems.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
