### PR TITLE
Fix ruby-core tarball detection in linked git worktrees

### DIFF
--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -357,7 +357,9 @@ module Spec
     end
 
     def ruby_core_tarball?
-      !git_root.join(".git").directory?
+      # A tarball checkout has no `.git` entry at all. Note that `.git` may be
+      # a file rather than a directory in linked git worktrees.
+      !git_root.join(".git").exist?
     end
 
     def rubocop_gemfile_basename


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

In a linked worktree `.git` is a gitdir pointer file, not a directory, so `ruby_core_tarball?` misdetected the checkout as a tarball and `shipped_files` mapped `exe/` to `libexec/`, failing the whole test suite.

## What is your fix for the problem, implemented in this PR?

Use `exist?` instead of `directory?`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
