### PR TITLE
Reduce peak memory usage of full index loading and bundle install

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -244,11 +244,6 @@ module Bundler
       @resolver = nil
       @resolution_base = nil
       sources.release_resolution_memory!
-
-      # Most of the released objects are old generation, so they won't be
-      # reclaimed by minor GCs and would otherwise keep the heap from
-      # shrinking until a major GC happens to run.
-      GC.start
     end
 
     # For given dependency list returns a SpecSet with Gemspec of all the required

--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -236,6 +236,21 @@ module Bundler
       sources.prefer_local!
     end
 
+    # Releases memory only needed during resolution, such as remote spec
+    # indexes and resolver state. Only safe to call once resolution is
+    # complete and the result has been materialized, since any further
+    # resolution will need to refetch remote specs.
+    def release_resolution_memory!
+      @resolver = nil
+      @resolution_base = nil
+      sources.release_resolution_memory!
+
+      # Most of the released objects are old generation, so they won't be
+      # reclaimed by minor GCs and would otherwise keep the heap from
+      # shrinking until a major GC happens to run.
+      GC.start
+    end
+
     # For given dependency list returns a SpecSet with Gemspec of all the required
     # dependencies.
     #  1. The method first resolves the dependencies specified in Gemfile

--- a/bundler/lib/bundler/fetcher.rb
+++ b/bundler/lib/bundler/fetcher.rb
@@ -243,6 +243,10 @@ module Bundler
       fetchers.first.api_fetcher?
     end
 
+    def release_resolution_memory!
+      @fetchers&.each(&:release_resolution_memory!)
+    end
+
     def gem_remote_fetcher
       @gem_remote_fetcher ||= begin
         require_relative "fetcher/gem_remote_fetcher"

--- a/bundler/lib/bundler/fetcher/base.rb
+++ b/bundler/lib/bundler/fetcher/base.rb
@@ -38,6 +38,9 @@ module Bundler
         false
       end
 
+      def release_resolution_memory!
+      end
+
       private
 
       def log_specs(&block)

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -63,6 +63,13 @@ module Bundler
         true
       end
 
+      # The client holds the parsed checksums of all info files in the
+      # index. Dropping it is always safe because it is rebuilt from the
+      # local cache on demand.
+      def release_resolution_memory!
+        @compact_index_client = nil
+      end
+
       private
 
       def compact_index_client

--- a/bundler/lib/bundler/fetcher/compact_index.rb
+++ b/bundler/lib/bundler/fetcher/compact_index.rb
@@ -80,6 +80,12 @@ module Bundler
       end
 
       def fetch_gem_infos(names)
+        # Create the client and update the versions file on this thread.
+        # Otherwise the workers race to lazily create the client and update
+        # the versions file concurrently, e.g. when the client was released
+        # after resolution and is being rebuilt for `bundle cache`.
+        compact_index_client.available?
+
         in_parallel(names) {|name| compact_index_client.info(name) }
       rescue TooManyRequestsError # rubygems.org is rate limiting us, slow down.
         @bundle_worker&.stop

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -198,7 +198,9 @@ module Bundler
       specs = @definition.specs
       # Installing default gems may need the remote index again to cache
       # their .gem files, so keep resolution memory around in that case.
-      @definition.release_resolution_memory! if specs.none?(&:default_gem?)
+      # The bundler spec itself is excluded because it comes from the
+      # metadata source and never goes through that path.
+      @definition.release_resolution_memory! if specs.none? {|s| s.default_gem? && s.source.is_a?(Source::Rubygems) }
       spec_installations = ParallelInstaller.call(self, specs, jobs, standalone, force, local: local)
       spec_installations.each do |installation|
         post_install_messages[installation.name] = installation.post_install_message if installation.has_post_install_message?

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -196,7 +196,9 @@ module Bundler
       local = options[:local] || options[:"prefer-local"]
       jobs = Bundler.settings.installation_parallelization
       specs = @definition.specs
-      @definition.release_resolution_memory!
+      # Installing default gems may need the remote index again to cache
+      # their .gem files, so keep resolution memory around in that case.
+      @definition.release_resolution_memory! if specs.none?(&:default_gem?)
       spec_installations = ParallelInstaller.call(self, specs, jobs, standalone, force, local: local)
       spec_installations.each do |installation|
         post_install_messages[installation.name] = installation.post_install_message if installation.has_post_install_message?

--- a/bundler/lib/bundler/installer.rb
+++ b/bundler/lib/bundler/installer.rb
@@ -195,7 +195,9 @@ module Bundler
       force = options[:force]
       local = options[:local] || options[:"prefer-local"]
       jobs = Bundler.settings.installation_parallelization
-      spec_installations = ParallelInstaller.call(self, @definition.specs, jobs, standalone, force, local: local)
+      specs = @definition.specs
+      @definition.release_resolution_memory!
+      spec_installations = ParallelInstaller.call(self, specs, jobs, standalone, force, local: local)
       spec_installations.each do |installation|
         post_install_messages[installation.name] = installation.post_install_message if installation.has_post_install_message?
       end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -25,6 +25,7 @@ module Bundler
         @checksum_store = Checksum::Store.new
         @gem_installers = {}
         @gem_installers_mutex = Mutex.new
+        @remote_specs_mutex = Mutex.new
 
         cooldown = options["cooldown"]
         Array(options["remotes"]).reverse_each {|r| add_remote(r, cooldown: cooldown) }
@@ -339,7 +340,7 @@ module Bundler
 
       def release_resolution_memory!
         @specs = nil
-        @remote_specs = nil
+        @remote_specs_mutex.synchronize { @remote_specs = nil }
         @fetchers&.each(&:release_resolution_memory!)
       end
 
@@ -420,13 +421,15 @@ module Bundler
       end
 
       def remote_specs
-        @remote_specs ||= Index.build do |idx|
-          index_fetchers = fetchers - api_fetchers
+        @remote_specs ||= @remote_specs_mutex.synchronize do
+          @remote_specs ||= Index.build do |idx|
+            index_fetchers = fetchers - api_fetchers
 
-          if index_fetchers.empty?
-            fetch_names(api_fetchers, dependency_names, idx)
-          else
-            fetch_names(fetchers, nil, idx)
+            if index_fetchers.empty?
+              fetch_names(api_fetchers, dependency_names, idx)
+            else
+              fetch_names(fetchers, nil, idx)
+            end
           end
         end
       end

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -243,7 +243,7 @@ module Bundler
       def cached_built_in_gem(spec, local: false)
         cached_path = cached_gem(spec)
         if cached_path.nil? && !local
-          remote_spec = remote_specs.search(spec).first
+          remote_spec = remote_spec_for(spec)
           if remote_spec
             cached_path = fetch_gem(remote_spec)
             spec.remote = remote_spec.remote
@@ -429,6 +429,17 @@ module Bundler
             fetch_names(fetchers, nil, idx)
           end
         end
+      end
+
+      # Looks up a single spec in the remote sources, fetching only its own
+      # name when the full remote index is not already materialized.
+      def remote_spec_for(spec)
+        return remote_specs.search(spec).first if @remote_specs || api_fetchers.empty?
+
+        index = Index.build do |idx|
+          fetch_names(api_fetchers, [spec.name], idx)
+        end
+        index.search(spec).first
       end
 
       def fetch_names(fetchers, dependency_names, index)

--- a/bundler/lib/bundler/source/rubygems.rb
+++ b/bundler/lib/bundler/source/rubygems.rb
@@ -337,6 +337,12 @@ module Bundler
         @cached_specs = nil
       end
 
+      def release_resolution_memory!
+        @specs = nil
+        @remote_specs = nil
+        @fetchers&.each(&:release_resolution_memory!)
+      end
+
       protected
 
       def remote_names

--- a/bundler/lib/bundler/source_list.rb
+++ b/bundler/lib/bundler/source_list.rb
@@ -140,6 +140,10 @@ module Bundler
       rubygems_sources.each(&:clear_cache)
     end
 
+    def release_resolution_memory!
+      rubygems_sources.each(&:release_resolution_memory!)
+    end
+
     private
 
     def map_sources(replacement_sources)

--- a/lib/rubygems/safe_marshal/reader.rb
+++ b/lib/rubygems/safe_marshal/reader.rb
@@ -28,6 +28,8 @@ module Gem
 
       def initialize(io)
         @io = io
+        @object_links = {}
+        @symbol_links = {}
       end
 
       def read!
@@ -191,7 +193,7 @@ module Gem
 
       def read_symbol_link
         offset = read_integer
-        Elements::SymbolLink.new(offset)
+        @symbol_links[offset] ||= Elements::SymbolLink.new(offset)
       end
 
       def read_user_marshal
@@ -200,43 +202,9 @@ module Gem
         Elements::UserMarshal.new(name, data)
       end
 
-      # profiling bundle install --full-index shows that
-      # offset 6 is by far the most common object link,
-      # so we special case it to avoid allocating a new
-      # object a third of the time.
-      # the following are all the object links that
-      # appear more than 10000 times in my profiling
-
-      OBJECT_LINKS = {
-        6 => Elements::ObjectLink.new(6).freeze,
-        30 => Elements::ObjectLink.new(30).freeze,
-        81 => Elements::ObjectLink.new(81).freeze,
-        34 => Elements::ObjectLink.new(34).freeze,
-        38 => Elements::ObjectLink.new(38).freeze,
-        50 => Elements::ObjectLink.new(50).freeze,
-        91 => Elements::ObjectLink.new(91).freeze,
-        42 => Elements::ObjectLink.new(42).freeze,
-        46 => Elements::ObjectLink.new(46).freeze,
-        150 => Elements::ObjectLink.new(150).freeze,
-        100 => Elements::ObjectLink.new(100).freeze,
-        104 => Elements::ObjectLink.new(104).freeze,
-        108 => Elements::ObjectLink.new(108).freeze,
-        242 => Elements::ObjectLink.new(242).freeze,
-        246 => Elements::ObjectLink.new(246).freeze,
-        139 => Elements::ObjectLink.new(139).freeze,
-        143 => Elements::ObjectLink.new(143).freeze,
-        114 => Elements::ObjectLink.new(114).freeze,
-        308 => Elements::ObjectLink.new(308).freeze,
-        200 => Elements::ObjectLink.new(200).freeze,
-        54 => Elements::ObjectLink.new(54).freeze,
-        62 => Elements::ObjectLink.new(62).freeze,
-        1_286_245 => Elements::ObjectLink.new(1_286_245).freeze,
-      }.freeze
-      private_constant :OBJECT_LINKS
-
       def read_object_link
         offset = read_integer
-        OBJECT_LINKS[offset] || Elements::ObjectLink.new(offset)
+        @object_links[offset] ||= Elements::ObjectLink.new(offset)
       end
 
       EMPTY_HASH = Elements::Hash.new([].freeze).freeze


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

On 32-bit AIX, `gem source --add` and `gem update --system` crash with `[FATAL] failed to allocate memory` (https://github.com/ruby/rubygems/issues/9368).

Two independent causes: `Gem::SafeMarshal` allocates an ObjectLink element for every link occurrence when loading the full index (specs.4.8 contains 4.7M links pointing at only 156k unique offsets), and `bundle install` keeps every resolution artifact alive through installation, an EndpointSpecification for every version of every gem in the dependency closure plus the parsed checksums of all ~190k gems in the compact index.

## What is your fix for the problem, implemented in this PR?

The SafeMarshal reader now interns link elements by offset, which also subsumes the hard-coded `OBJECT_LINKS` table and reduces peak RSS of loading specs.4.8 from 573MB to 448MB.

On the Bundler side, the new `Definition#release_resolution_memory!` drops resolver state, remote spec indexes and compact index client caches once the resolution result has been materialized, all lazily memoized and therefore safe to drop, reducing peak RSS of a cold `bundle install` of a 103-gem app from 427MB to 360MB.

This does not fully fix the AIX problem because SafeMarshal's remaining peak still exceeds the 256MB default data segment of 32-bit AIX processes. Converting it to single-pass loading is the planned follow-up.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
