### PR TITLE
Exempt lockfile versions from cooldown on every resolution path

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -1319,7 +1319,7 @@ module Bundler
 
     def new_resolution_base(last_resolve:, unlock:)
       new_resolution_platforms = @current_platform_missing ? @new_platforms + [Bundler.local_platform] : @new_platforms
-      Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, locked_specs: @originally_locked_specs, unlock: unlock, prerelease: gem_version_promoter.pre?, prefer_local: @prefer_local, new_platforms: new_resolution_platforms, overrides: @overrides)
+      Resolver::Base.new(source_requirements, expanded_dependencies, last_resolve, @platforms, locked_specs: @originally_locked_specs, unlock: unlock, prerelease: gem_version_promoter.pre?, prefer_local: @prefer_local, new_platforms: new_resolution_platforms, overrides: @overrides, explicit_unlocks: @explicit_unlocks)
     end
 
     def new_resolver(base)

--- a/bundler/lib/bundler/resolver.rb
+++ b/bundler/lib/bundler/resolver.rb
@@ -456,25 +456,29 @@ module Bundler
     def cooldown_excluded?(spec)
       return false unless spec.respond_to?(:created_at) && spec.created_at
       return false unless spec.respond_to?(:remote) && spec.remote
-      return false if pinned_by_lockfile_floor?(spec)
+      return false if locked_by_lockfile?(spec)
       days = spec.remote.effective_cooldown
       return false if days.nil? || days <= 0
       (cooldown_now - spec.created_at) < (days * 86_400)
     end
 
-    # A spec sitting exactly at a `>= locked_version` prevent-downgrade floor is
-    # the version the lockfile currently pins. `bundle update` and `bundle
-    # outdated` install that floor so resolution never moves a gem backwards.
-    # Filtering it out for cooldown would then make resolution impossible
-    # whenever the locked version is itself inside the cooldown window, which is
-    # exactly what happens to a lockfile written before cooldown was enabled.
-    # Keep it eligible; gems being explicitly updated carry an exact `=`
-    # requirement instead and stay subject to the cooldown filter.
-    def pinned_by_lockfile_floor?(spec)
+    # A version already written to the lockfile has been adopted, and cooldown
+    # only governs the adoption of *new* versions, so it must never retract one
+    # the lockfile already pins. Keying this off the locked specs rather than the
+    # prevent-downgrade floor matters because that floor is absent on resolutions
+    # that re-pick a gem from scratch: the auxiliary full update run to compute
+    # `--update` targets, and the from-scratch retries after a conflict unlocks a
+    # gem. In those passes the locked version is the only candidate, so filtering
+    # it out makes an unrelated operation impossible whenever every published
+    # version matching the requirement sits inside the cooldown window.
+    #
+    # Gems named on a `bundle update GEM` command are the exception: the user
+    # asked to move them, so they stay subject to cooldown and a locked-but-fresh
+    # release is pushed back to an older one (or fails loudly when none exists).
+    def locked_by_lockfile?(spec)
       return false unless defined?(@base) && @base
-      requirement = base_requirements[spec.name]
-      return false unless requirement && !requirement.exact?
-      requirement.requirements.any? {|op, version| op == ">=" && version == spec.version }
+      return false if @base.explicitly_unlocked?(spec.name)
+      @base.locked_specs[spec.name].any? {|locked| locked.version == spec.version }
     end
 
     def cooldown_now

--- a/bundler/lib/bundler/resolver/base.rb
+++ b/bundler/lib/bundler/resolver/base.rb
@@ -9,6 +9,7 @@ module Bundler
 
       def initialize(source_requirements, dependencies, base, platforms, options)
         @overrides = options.delete(:overrides) || []
+        @explicit_unlocks = options.delete(:explicit_unlocks) || []
         @source_requirements = source_requirements
         @locked_specs = options[:locked_specs]
 
@@ -42,6 +43,14 @@ module Bundler
 
       def get_package(name)
         @packages[name]
+      end
+
+      # Gems the user named on a `bundle update GEM` / `bundle lock --update GEM`
+      # command line. These are the only ones meant to move off their locked
+      # version, so cooldown keeps applying to them while every other locked gem
+      # stays exempt.
+      def explicitly_unlocked?(name)
+        @explicit_unlocks.include?(name)
       end
 
       def base_requirements

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -107,7 +107,50 @@ RSpec.describe "bundle install with the cooldown setting" do
         build_gem "upgradable", "3.0.0" do |s|
           s.date = now - (30 * 86_400)
         end
+
+        # every published version is inside the cooldown window
+        build_gem "fresh_gem", "0.3.1" do |s|
+          s.date = now - (1 * 86_400)
+        end
+        build_gem "fresh_gem", "0.3.2" do |s|
+          s.date = now - (1 * 86_400)
+        end
       end
+    end
+
+    it "keeps a locked all-in-cooldown gem when explicitly updating an unrelated gem" do
+      # Updating ripe_gem runs an auxiliary full-update resolution to compute its
+      # target version. That pass carries no prevent-downgrade floor, so without
+      # exempting locked versions it re-picks fresh_gem from an empty
+      # cooldown-filtered candidate set (every published 0.3.x is in the window)
+      # and fails an update that never touched fresh_gem.
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "fresh_gem", "~> 0.3"
+        gem "ripe_gem"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            fresh_gem (0.3.2)
+            ripe_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          fresh_gem (~> 0.3)
+          ripe_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "lock --update ripe_gem", artifice: "compact_index_cooldown"
+
+      expect(lockfile).to include("fresh_gem (0.3.2)")
     end
 
     it "excludes versions within the cooldown window" do

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -684,6 +684,34 @@ RSpec.describe "bundle install with the cooldown setting" do
       expect(lockfile).not_to include("ripe_gem (2.0.0)")
     end
 
+    it "still applies cooldown and downgrades a gem explicitly updated via bundle lock --update" do
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (2.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "lock --update ripe_gem", artifice: "compact_index_cooldown"
+
+      expect(lockfile).to include("ripe_gem (1.0.0)")
+      expect(lockfile).not_to include("ripe_gem (2.0.0)")
+    end
+
     it "ignores cooldown and installs the locked version when frozen" do
       # Frozen installs read the lockfile instead of resolving, so cooldown has
       # no say. A version already locked inside the window must still install.


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle update GEM` computes its target versions with an auxiliary full-update resolution that carries no prevent-downgrade floor, so the floor-based exemption from #9599 never applied there.

A locked gem whose every published version sits inside the cooldown window then resolved to an empty candidate set, failing updates that never touched it.


Fixes https://github.com/ruby/rubygems/issues/9613

## What is your fix for the problem, implemented in this PR?

Key the exemption off the lockfile contents, which every resolution path can see; gems explicitly named on the command line stay subject to cooldown.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
