### PR TITLE
Don't require source plugins to be installed to parse a lockfile

### DIFF
--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -233,6 +233,9 @@ module Bundler
       # when reading the lockfile while doing the plugin-install-from-gemfile phase,
       # we need to ignore any plugin sources
       return UnloadedSource.new(opts) if @gemfile_parse
+      # use an inert placeholder when the plugin handling this source is not
+      # installed, so that the lockfile can still be parsed
+      return UnloadedSource.new(opts) unless source?(locked_opts["type"])
 
       src = source(locked_opts["type"])
 

--- a/bundler/lib/bundler/plugin/unloaded_source.rb
+++ b/bundler/lib/bundler/plugin/unloaded_source.rb
@@ -3,9 +3,23 @@
 module Bundler
   module Plugin
     # Stands in for a source handled by a plugin that is not loaded yet, so
-    # that the lockfile can still be parsed during the plugin install pass.
+    # that the lockfile can still be parsed during the plugin install pass,
+    # and by external tools reading a lockfile without the plugin installed.
     class UnloadedSource
       include API::Source
+
+      # Unlike real plugin sources, where the handling class encodes the
+      # source type, all unloaded sources share this class, so the type must
+      # be compared explicitly.
+      def ==(other)
+        super && options["type"] == other.options["type"]
+      end
+
+      alias_method :eql?, :==
+
+      def hash
+        [super, options["type"]].hash
+      end
     end
   end
 end

--- a/spec/bundler/lockfile_parser_spec.rb
+++ b/spec/bundler/lockfile_parser_spec.rb
@@ -252,6 +252,25 @@ RSpec.describe Bundler::LockfileParser do
       end
     end
 
+    context "when a plugin source's plugin is not installed" do
+      let(:lockfile_contents) { <<~L + super().sub("DEPENDENCIES\n", "DEPENDENCIES\n  private_gem!\n") }
+        PLUGIN SOURCE
+          remote: https://example.com/private
+          type: not_installed_plugin_type
+          specs:
+            private_gem (1.2.3)
+
+      L
+
+      it "parses dependencies and specs using a placeholder source" do
+        expect(subject.valid?).to be(true)
+        expect(subject.dependencies.keys).to include("private_gem", "peiji-san", "rake")
+        private_spec = subject.specs.find {|s| s.name == "private_gem" }
+        expect(private_spec.version).to eq(v("1.2.3"))
+        expect(private_spec.source).to be_a(Bundler::Plugin::UnloadedSource)
+      end
+    end
+
     context "when lockfile_path is given" do
       it "uses the provided path in error messages instead of looking up Bundler.default_lockfile" do
         expect(Bundler::SharedHelpers).not_to receive(:relative_lockfile_path)

--- a/spec/bundler/plugin/unloaded_source_spec.rb
+++ b/spec/bundler/plugin/unloaded_source_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::Plugin::UnloadedSource do
+  let(:uri) { "uri://to/test" }
+
+  def source(type)
+    described_class.new("uri" => uri, "type" => type)
+  end
+
+  describe "equality" do
+    it "treats sources with the same uri and type as equal" do
+      a = source("type_a")
+      b = source("type_a")
+
+      expect(a).to eq(b)
+      expect(a).to eql(b)
+      expect(a.hash).to eq(b.hash)
+    end
+
+    it "treats sources with the same uri but different types as not equal" do
+      a = source("type_a")
+      b = source("type_b")
+
+      expect(a).not_to eq(b)
+      expect(a).not_to eql(b)
+      expect(a.hash).not_to eq(b.hash)
+    end
+
+    it "is not equal to a real plugin source with the same uri and type" do
+      klass = Class.new
+      klass.send :include, Bundler::Plugin::API::Source
+
+      expect(source("type_a")).not_to eq(klass.new("uri" => uri, "type" => "type_a"))
+    end
+  end
+end

--- a/spec/bundler/plugin_spec.rb
+++ b/spec/bundler/plugin_spec.rb
@@ -237,6 +237,15 @@ RSpec.describe Bundler::Plugin do
         with(hash_including("type" => "l_source", "uri" => "xyz", "other" => "random")) { s_instance }
       expect(subject.from_lock(opts)).to be(s_instance)
     end
+
+    it "returns an UnloadedSource when the plugin handling the source is not installed" do
+      opts = { "type" => "missing_source", "remote" => "https://example.com/private" }
+      allow(index).to receive(:source_plugin).with("missing_source") { nil }
+
+      source = subject.from_lock(opts)
+      expect(source).to be_a(Plugin::UnloadedSource)
+      expect(source.uri).to eq("https://example.com/private")
+    end
   end
 
   describe "#root" do


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Third-party tools like `bundler-audit` read lockfiles through `Bundler::LockfileParser.new(contents)` without evaluating the Gemfile.

When a lockfile contains a `PLUGIN SOURCE` block whose plugin is not installed locally, `Plugin.from_lock` raised `Bundler::Plugin::UnknownSourceError` and aborted the whole parse, so even `DEPENDENCIES` could not be read. The same raise also prevented `bundle install` from recovering when a plugin source was removed from the Gemfile but still present in the lockfile.

Fixes #9614

## What is your fix for the problem, implemented in this PR?

`Plugin.from_lock` now falls back to the inert `UnloadedSource` placeholder when the plugin handling the source type is not installed, so the lockfile can still be parsed and the specs under that source remain readable.

Regular `bundle install` is unaffected because plugins are installed during the plugin-install-from-gemfile phase before the main lockfile parse, and a Gemfile that still declares the source keeps raising from the DSL as before.

Since all unloaded sources share a single class, `UnloadedSource#==` and `#hash` now also compare the source type so that two plugin sources with the same remote but different types are not conflated.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
