### PR TITLE
Don't require source plugins to be installed to parse a lockfile: 4.0.x

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -167,6 +167,7 @@ bundler/lib/bundler/plugin/installer/git.rb
 bundler/lib/bundler/plugin/installer/path.rb
 bundler/lib/bundler/plugin/installer/rubygems.rb
 bundler/lib/bundler/plugin/source_list.rb
+bundler/lib/bundler/plugin/unloaded_source.rb
 bundler/lib/bundler/process_lock.rb
 bundler/lib/bundler/remote_specification.rb
 bundler/lib/bundler/resolver.rb

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -200,9 +200,14 @@ module Bundler
     # @return [API::Source] the instance of the class that handles the source
     #                       type passed in locked_opts
     def from_lock(locked_opts)
+      opts = locked_opts.merge("uri" => locked_opts["remote"])
+      # use an inert placeholder when the plugin handling this source is not
+      # installed, so that the lockfile can still be parsed
+      return UnloadedSource.new(opts) unless source?(locked_opts["type"])
+
       src = source(locked_opts["type"])
 
-      src.new(locked_opts.merge("uri" => locked_opts["remote"]))
+      src.new(opts)
     end
 
     # To be called via the API to register a hooks and corresponding block that

--- a/bundler/lib/bundler/plugin.rb
+++ b/bundler/lib/bundler/plugin.rb
@@ -4,11 +4,12 @@ require_relative "plugin/api"
 
 module Bundler
   module Plugin
-    autoload :DSL,        File.expand_path("plugin/dsl", __dir__)
-    autoload :Events,     File.expand_path("plugin/events", __dir__)
-    autoload :Index,      File.expand_path("plugin/index", __dir__)
-    autoload :Installer,  File.expand_path("plugin/installer", __dir__)
-    autoload :SourceList, File.expand_path("plugin/source_list", __dir__)
+    autoload :DSL,            File.expand_path("plugin/dsl", __dir__)
+    autoload :Events,         File.expand_path("plugin/events", __dir__)
+    autoload :Index,          File.expand_path("plugin/index", __dir__)
+    autoload :Installer,      File.expand_path("plugin/installer", __dir__)
+    autoload :SourceList,     File.expand_path("plugin/source_list", __dir__)
+    autoload :UnloadedSource, File.expand_path("plugin/unloaded_source", __dir__)
 
     class MalformattedPlugin < PluginError; end
     class UndefinedCommandError < PluginError; end

--- a/bundler/lib/bundler/plugin/unloaded_source.rb
+++ b/bundler/lib/bundler/plugin/unloaded_source.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Bundler
+  module Plugin
+    # Stands in for a source handled by a plugin that is not loaded yet, so
+    # that the lockfile can still be parsed during the plugin install pass,
+    # and by external tools reading a lockfile without the plugin installed.
+    class UnloadedSource
+      include API::Source
+
+      # Unlike real plugin sources, where the handling class encodes the
+      # source type, all unloaded sources share this class, so the type must
+      # be compared explicitly.
+      def ==(other)
+        super && options["type"] == other.options["type"]
+      end
+
+      alias_method :eql?, :==
+
+      def hash
+        [super, options["type"]].hash
+      end
+    end
+  end
+end

--- a/bundler/spec/bundler/lockfile_parser_spec.rb
+++ b/bundler/spec/bundler/lockfile_parser_spec.rb
@@ -252,6 +252,25 @@ RSpec.describe Bundler::LockfileParser do
       end
     end
 
+    context "when a plugin source's plugin is not installed" do
+      let(:lockfile_contents) { <<~L + super().sub("DEPENDENCIES\n", "DEPENDENCIES\n  private_gem!\n") }
+        PLUGIN SOURCE
+          remote: https://example.com/private
+          type: not_installed_plugin_type
+          specs:
+            private_gem (1.2.3)
+
+      L
+
+      it "parses dependencies and specs using a placeholder source" do
+        expect(subject.valid?).to be(true)
+        expect(subject.dependencies.keys).to include("private_gem", "peiji-san", "rake")
+        private_spec = subject.specs.find {|s| s.name == "private_gem" }
+        expect(private_spec.version).to eq(v("1.2.3"))
+        expect(private_spec.source).to be_a(Bundler::Plugin::UnloadedSource)
+      end
+    end
+
     context "when CHECKSUMS has duplicate checksums in the lockfile that don't match" do
       let(:bad_checksum) { "sha256=c0ffee11c0ffee11c0ffee11c0ffee11c0ffee11c0ffee11c0ffee11c0ffee11" }
       let(:lockfile_contents) { super().split(/(?<=CHECKSUMS\n)/m).insert(1, "  rake (10.3.2) #{bad_checksum}\n").join }

--- a/bundler/spec/bundler/plugin/unloaded_source_spec.rb
+++ b/bundler/spec/bundler/plugin/unloaded_source_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Bundler::Plugin::UnloadedSource do
+  let(:uri) { "uri://to/test" }
+
+  def source(type)
+    described_class.new("uri" => uri, "type" => type)
+  end
+
+  describe "equality" do
+    it "treats sources with the same uri and type as equal" do
+      a = source("type_a")
+      b = source("type_a")
+
+      expect(a).to eq(b)
+      expect(a).to eql(b)
+      expect(a.hash).to eq(b.hash)
+    end
+
+    it "treats sources with the same uri but different types as not equal" do
+      a = source("type_a")
+      b = source("type_b")
+
+      expect(a).not_to eq(b)
+      expect(a).not_to eql(b)
+      expect(a.hash).not_to eq(b.hash)
+    end
+
+    it "is not equal to a real plugin source with the same uri and type" do
+      klass = Class.new
+      klass.send :include, Bundler::Plugin::API::Source
+
+      expect(source("type_a")).not_to eq(klass.new("uri" => uri, "type" => "type_a"))
+    end
+  end
+end

--- a/bundler/spec/bundler/plugin_spec.rb
+++ b/bundler/spec/bundler/plugin_spec.rb
@@ -238,6 +238,15 @@ RSpec.describe Bundler::Plugin do
         with(hash_including("type" => "l_source", "uri" => "xyz", "other" => "random")) { s_instance }
       expect(subject.from_lock(opts)).to be(s_instance)
     end
+
+    it "returns an UnloadedSource when the plugin handling the source is not installed" do
+      opts = { "type" => "missing_source", "remote" => "https://example.com/private" }
+      allow(index).to receive(:source_plugin).with("missing_source") { nil }
+
+      source = subject.from_lock(opts)
+      expect(source).to be_a(Plugin::UnloadedSource)
+      expect(source.uri).to eq("https://example.com/private")
+    end
   end
 
   describe "#root" do


### PR DESCRIPTION
Backport of https://github.com/ruby/rubygems/pull/9620 to the 4.0 branch, fixing https://github.com/ruby/rubygems/issues/9614.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
