### PR TITLE
Remove incidental use of ~> in code comments

### DIFF
--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -5,8 +5,8 @@ require_relative "vendored_tsort"
 ##
 # A RequestSet groups a request to activate a set of dependencies.
 #
-#   nokogiri = Gem::Dependency.new 'nokogiri', '~> 1.6'
-#   pg = Gem::Dependency.new 'pg', '~> 0.14'
+#   nokogiri = Gem::Dependency.new 'nokogiri', '>= 1.6'
+#   pg = Gem::Dependency.new 'pg', '>= 0.14'
 #
 #   set = Gem::RequestSet.new nokogiri, pg
 #
@@ -86,8 +86,8 @@ class Gem::RequestSet
   # Creates a RequestSet for a list of Gem::Dependency objects, +deps+.  You
   # can then #resolve and #install the resolved list of dependencies.
   #
-  #   nokogiri = Gem::Dependency.new 'nokogiri', '~> 1.6'
-  #   pg = Gem::Dependency.new 'pg', '~> 0.14'
+  #   nokogiri = Gem::Dependency.new 'nokogiri', '>= 1.6'
+  #   pg = Gem::Dependency.new 'pg', '>= 0.14'
   #
   #   set = Gem::RequestSet.new nokogiri, pg
 

--- a/lib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/rubygems/request_set/gem_dependency_api.rb
@@ -13,7 +13,7 @@
 #   source 'https://rubygems.org'
 #
 #   gem 'rails', '3.2.14a
-#   gem 'devise', '~> 2.1', '>= 2.1.3'
+#   gem 'devise', '>= 2.1.3', '< 3'
 #   gem 'cancan'
 #   gem 'airbrake'
 #   gem 'pg'

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -532,7 +532,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   # Usage:
   #
-  #   spec.add_development_dependency 'example', '~> 1.1', '>= 1.1.4'
+  #   spec.add_development_dependency 'example', '>= 1.1.4', '< 2'
   #
   # Development dependencies aren't installed by default and aren't
   # activated when a gem is required.
@@ -546,7 +546,7 @@ class Gem::Specification < Gem::BasicSpecification
   #
   # Usage:
   #
-  #   spec.add_dependency 'example', '~> 1.1', '>= 1.1.4'
+  #   spec.add_dependency 'example', '>= 1.1.4', '< 2'
 
   def add_dependency(gem, *requirements)
     if requirements.uniq.size != requirements.size


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

At the recent developer meeting, we discussed switching from using pessimistic versioning by default to using optimistic versioning by default.

## What is your fix for the problem, implemented in this PR?

Remove a few cases left in code comments where ~> was used.

For cases where only one version is used, switch to >=.

For cases where two versions are used (~> and >=), switch to >= and <, as that is a bit more natural (starting and ending of range).

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
