### PR TITLE
Implement a make jobserver (continuation of #9210)

### DIFF
--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -110,10 +110,29 @@ module Bundler
     end
 
     def install_with_worker
-      installed_specs = {}
-      enqueue_specs(installed_specs)
+      with_jobserver do
+        installed_specs = {}
+        enqueue_specs(installed_specs)
 
-      process_specs(installed_specs) until finished_installing?
+        process_specs(installed_specs) until finished_installing?
+      end
+    end
+
+    def with_jobserver
+      r, w = IO.pipe
+      r.close_on_exec = false
+      w.close_on_exec = false
+      w.write("*" * @size)
+
+      old_makeflags = ENV["MAKEFLAGS"]
+      ENV["MAKEFLAGS"] = "#{old_makeflags} --jobserver-auth=#{r.fileno},#{w.fileno}"
+
+      yield
+    ensure
+      r.close
+      w.close
+
+      old_makeflags ? ENV["MAKEFLAGS"] = old_makeflags : ENV.delete("MAKEFLAGS")
     end
 
     def install_serially

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -125,14 +125,16 @@ module Bundler
       w.write("*" * @size)
 
       old_makeflags = ENV["MAKEFLAGS"]
-      ENV["MAKEFLAGS"] = "#{old_makeflags} --jobserver-auth=#{r.fileno},#{w.fileno}"
+      ENV["MAKEFLAGS"] = [old_makeflags, "--jobserver-auth=#{r.fileno},#{w.fileno}"].compact.join(" ")
 
       yield
     ensure
-      r.close
-      w.close
-
+      # Restore MAKEFLAGS before closing the pipe so a close failure can't
+      # leave the process with descriptors that point at a closed pipe.
       old_makeflags ? ENV["MAKEFLAGS"] = old_makeflags : ENV.delete("MAKEFLAGS")
+
+      r&.close
+      w&.close
     end
 
     def install_serially

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -124,10 +124,18 @@ module Bundler
     end
 
     def build_jobs
-      Bundler.settings[:jobs] || super
+      @jobserver_read_io&.read_nonblock(3, @jobserver_tokens)
+      available_jobs = @jobserver_tokens.empty? ? nil : @jobserver_tokens.size
+
+      available_jobs || Bundler.settings[:jobs] || super
+    rescue IO::WaitReadable
+      1
     end
 
     def build_extensions
+      @jobserver_tokens = +""
+      @jobserver_read_io, @jobserver_write_io = connect_to_jobserver
+
       extension_cache_path = options[:bundler_extension_cache_path]
       extension_dir = spec.extension_dir
       unless extension_cache_path && extension_dir
@@ -151,6 +159,11 @@ module Bundler
           FileUtils.cp_r extension_dir, extension_cache_path
         end
       end
+    ensure
+      unless @jobserver_tokens.empty?
+        @jobserver_write_io.write(@jobserver_tokens)
+        @jobserver_write_io.flush
+      end
     end
 
     def spec
@@ -166,6 +179,15 @@ module Bundler
     end
 
     private
+
+    def connect_to_jobserver
+      return unless ENV["MAKEFLAGS"]
+      read_fd, write_fd = ENV["MAKEFLAGS"].match(/--jobserver-auth=(\d+),(\d+)/)&.captures
+
+      return unless read_fd && write_fd
+
+      [IO.new(read_fd.to_i, autoclose: false), IO.new(write_fd.to_i, autoclose: false)]
+    end
 
     def prepare_extension_build(extension_dir)
       SharedHelpers.filesystem_access(extension_dir, :create) do

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -189,7 +189,7 @@ module Bundler
       return unless ENV["MAKEFLAGS"]
       # We append our own --jobserver-auth, so read the last one. Otherwise a
       # parent jobserver's descriptors (e.g. `bundle install` run under
-      # `make -j`) would be picked up instead of the pool we just created.
+      # `make -j`) would be picked up instead of the pool ParallelInstaller created.
       read_fd, write_fd = ENV["MAKEFLAGS"].scan(/--jobserver-auth=(\d+),(\d+)/).last
 
       return unless read_fd && write_fd

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -186,7 +186,10 @@ module Bundler
 
       return unless read_fd && write_fd
 
-      [IO.new(read_fd.to_i, autoclose: false), IO.new(write_fd.to_i, autoclose: false)]
+      # Pass explicit modes. On POSIX, IO.new detects the descriptor's access
+      # mode, but on Windows it can't, so the write end would default to read
+      # mode and raise "IOError: not opened for writing" when releasing slots.
+      [IO.new(read_fd.to_i, "r", autoclose: false), IO.new(write_fd.to_i, "w", autoclose: false)]
     end
 
     def prepare_extension_build(extension_dir)

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -4,6 +4,11 @@ require "rubygems/installer"
 
 module Bundler
   class RubyGemsGemInstaller < Gem::Installer
+    # Cap how many jobserver slots a single gem's `make` may grab so that one
+    # gem with many recipes doesn't starve the others sharing the pool. Beyond
+    # a handful of jobs the extra parallelism rarely pays off in practice.
+    MAX_JOBS_PER_GEM = 3
+
     def check_executable_overwrite(filename)
       # Bundler needs to install gems regardless of binstub overwriting
     end
@@ -124,11 +129,11 @@ module Bundler
     end
 
     def build_jobs
-      @jobserver_read_io&.read_nonblock(3, @jobserver_tokens)
-      available_jobs = @jobserver_tokens.empty? ? nil : @jobserver_tokens.size
+      @jobserver_read_io&.read_nonblock(MAX_JOBS_PER_GEM, @jobserver_tokens)
+      acquired_jobs = @jobserver_tokens.empty? ? nil : @jobserver_tokens.size
 
-      available_jobs || Bundler.settings[:jobs] || super
-    rescue IO::WaitReadable
+      acquired_jobs || Bundler.settings[:jobs] || super
+    rescue IO::WaitReadable, EOFError
       1
     end
 

--- a/bundler/lib/bundler/rubygems_gem_installer.rb
+++ b/bundler/lib/bundler/rubygems_gem_installer.rb
@@ -182,7 +182,10 @@ module Bundler
 
     def connect_to_jobserver
       return unless ENV["MAKEFLAGS"]
-      read_fd, write_fd = ENV["MAKEFLAGS"].match(/--jobserver-auth=(\d+),(\d+)/)&.captures
+      # We append our own --jobserver-auth, so read the last one. Otherwise a
+      # parent jobserver's descriptors (e.g. `bundle install` run under
+      # `make -j`) would be picked up instead of the pool we just created.
+      read_fd, write_fd = ENV["MAKEFLAGS"].scan(/--jobserver-auth=(\d+),(\d+)/).last
 
       return unless read_fd && write_fd
 

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -43,7 +43,7 @@ class Gem::Ext::Builder
       have_make_arguments = make_program.size > 1
       n_jobs ||= 0
 
-      if !have_make_arguments && n_jobs > 1 && !ENV["MAKEFLAGS"]&.match(/-j\d?(\s|\Z)/)
+      if !have_make_arguments && n_jobs > 1 && !ENV["MAKEFLAGS"]&.match(/-j\d*(\s|\Z)/)
         make_program << "-j#{n_jobs}"
       end
     end

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -41,8 +41,9 @@ class Gem::Ext::Builder
     # nmake doesn't support parallel build
     unless is_nmake
       have_make_arguments = make_program.size > 1
+      n_jobs ||= 0
 
-      if !have_make_arguments && !ENV["MAKEFLAGS"] && n_jobs
+      if !have_make_arguments && n_jobs > 1 && !ENV["MAKEFLAGS"]&.match(/-j\d?(\s|\Z)/)
         make_program << "-j#{n_jobs}"
       end
     end

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -76,4 +76,135 @@ RSpec.describe Bundler::ParallelInstaller do
       parallel_installer.call
     end
   end
+
+  describe "connect to make jobserver" do
+    before do
+      unless Gem::Installer.private_method_defined?(:build_jobs)
+        skip "This example is runnable when RubyGems::Installer implements `build_jobs`"
+      end
+
+      require "support/artifice/compact_index"
+
+      @previous_client = Gem::Request::ConnectionPools.client
+      Gem::Request::ConnectionPools.client = Gem::Net::HTTP
+      Gem::RemoteFetcher.fetcher.close_all
+
+      build_repo2 do
+        build_gem "one", &:add_c_extension
+        build_gem "two", &:add_c_extension
+      end
+
+      gemfile <<~G
+        source "https://gem.repo2"
+
+        gem "one"
+        gem "two"
+      G
+      lockfile <<~L
+        GEM
+          remote: https://gem.repo2/
+          specs:
+            one (1.0)
+            two (1.0)
+
+        DEPENDENCIES
+          one
+          two
+      L
+
+      @old_ui = Bundler.ui
+      Bundler.ui = Bundler::UI::Silent.new
+    end
+
+    after do
+      Bundler.ui = @old_ui
+      Gem::Request::ConnectionPools.client = @previous_client
+      Artifice.deactivate
+    end
+
+    let(:definition) do
+      allow(Bundler).to receive(:root) { bundled_app }
+
+      definition = Bundler::Definition.build(bundled_app.join("Gemfile"), bundled_app.join("Gemfile.lock"), false)
+      definition.tap(&:setup_domain!)
+    end
+    let(:installer) { Bundler::Installer.new(bundled_app, definition) }
+    let(:gem_one) { definition.specs.find {|spec| spec.name == "one" } }
+    let(:gem_two) { definition.specs.find {|spec| spec.name == "two" } }
+
+    it "takes all available slots" do
+      redefine_build_jobs do
+        Bundler::ParallelInstaller.call(installer, definition.specs, 5, false, true)
+      end
+
+      # Take 3 slots out of the 5 available.
+      expect(File.read(File.join(gem_one.extension_dir, "gem_make.out"))).to include("make -j3")
+      # Take the remaining 2 slots.
+      expect(File.read(File.join(gem_two.extension_dir, "gem_make.out"))).to include("make -j2")
+    end
+
+    it "fallback to non parallel when no slots are available" do
+      redefine_build_jobs do
+        Bundler::ParallelInstaller.call(installer, definition.specs, 3, false, true)
+      end
+
+      # Take 3 slots out of the 3 available.
+      expect(File.read(File.join(gem_one.extension_dir, "gem_make.out"))).to include("make -j3")
+      # Fallback to one slot (non parallel).
+      expect(File.read(File.join(gem_two.extension_dir, "gem_make.out"))).to_not include("make -j")
+    end
+
+    it "uses one jobs when installing serially" do
+      Bundler.settings.temporary(jobs: 1) do
+        Bundler::ParallelInstaller.call(installer, definition.specs, 1, false, true)
+      end
+
+      expect(File.read(File.join(gem_one.extension_dir, "gem_make.out"))).to_not include("make -j")
+      expect(File.read(File.join(gem_two.extension_dir, "gem_make.out"))).to_not include("make -j")
+    end
+
+    it "release the job slots" do
+      build_repo2 do
+        build_gem "one", &:add_c_extension
+        build_gem "two" do |spec|
+          spec.add_c_extension
+          spec.add_dependency(:one) # ParallelInstaller will wait for `one` to be fully installed.
+        end
+      end
+
+      Bundler::ParallelInstaller.call(installer, definition.specs, 3, false, true)
+
+      # Take 3 slots out of the 3 available.
+      expect(File.read(File.join(gem_one.extension_dir, "gem_make.out"))).to include("make -j3")
+      # Take 3 slots that were released.
+      expect(File.read(File.join(gem_two.extension_dir, "gem_make.out"))).to include("make -j3")
+    end
+
+    def redefine_build_jobs
+      old_method = Bundler::RubyGemsGemInstaller.instance_method(:build_jobs)
+      Bundler::RubyGemsGemInstaller.remove_method(:build_jobs)
+
+      gem_one_waiting = true
+      gem_two_waiting = true
+
+      Bundler::RubyGemsGemInstaller.define_method(:build_jobs) do
+        if spec.name == "one"
+          value = old_method.bind(self).call
+          gem_one_waiting = false
+          sleep(0.1) while gem_two_waiting
+        elsif spec.name == "two"
+          sleep(0.1) while gem_one_waiting
+          value = old_method.bind(self).call
+          gem_two_waiting = false
+        end
+
+        value
+      end
+
+      yield
+    ensure
+      Bundler::RubyGemsGemInstaller.remove_method(:build_jobs)
+      Bundler::RubyGemsGemInstaller.define_method(:build_jobs, old_method)
+    end
+  end
 end

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -184,18 +184,21 @@ RSpec.describe Bundler::ParallelInstaller do
       old_method = Bundler::RubyGemsGemInstaller.instance_method(:build_jobs)
       Bundler::RubyGemsGemInstaller.remove_method(:build_jobs)
 
-      gem_one_waiting = true
-      gem_two_waiting = true
+      # Rendezvous so that "one" grabs its slots first and keeps holding them
+      # until "two" has grabbed the rest. Blocking on a queue avoids the
+      # busy-wait and makes the ordering deterministic.
+      one_acquired = Thread::Queue.new
+      two_acquired = Thread::Queue.new
 
       Bundler::RubyGemsGemInstaller.define_method(:build_jobs) do
         if spec.name == "one"
           value = old_method.bind(self).call
-          gem_one_waiting = false
-          sleep(0.1) while gem_two_waiting
+          one_acquired << true
+          two_acquired.pop
         elsif spec.name == "two"
-          sleep(0.1) while gem_one_waiting
+          one_acquired.pop
           value = old_method.bind(self).call
-          gem_two_waiting = false
+          two_acquired << true
         end
 
         value

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -1389,7 +1389,7 @@ RSpec.describe "bundle install with gem sources" do
       expect(gem_make_out).not_to include("make -j8")
     end
 
-    it "pass down the BUNDLE_JOBS to RubyGems when running the compilation of an extension" do
+    it "uses 3 slots from the available pool when running the compilation of an extension" do
       ENV.delete("MAKEFLAGS")
 
       install_gemfile(<<~G, env: { "BUNDLE_JOBS" => "8" })
@@ -1399,10 +1399,10 @@ RSpec.describe "bundle install with gem sources" do
 
       gem_make_out = File.read(File.join(@gemspec.extension_dir, "gem_make.out"))
 
-      expect(gem_make_out).to include("make -j8")
+      expect(gem_make_out).to include("make -j3")
     end
 
-    it "uses nprocessors by default" do
+    it "consumes 3 slots from the pool when BUNDLE_JOBS isn't set" do
       ENV.delete("MAKEFLAGS")
 
       install_gemfile(<<~G)
@@ -1412,7 +1412,7 @@ RSpec.describe "bundle install with gem sources" do
 
       gem_make_out = File.read(File.join(@gemspec.extension_dir, "gem_make.out"))
 
-      expect(gem_make_out).to include("make -j#{Etc.nprocessors + 1}")
+      expect(gem_make_out).to include("make -j3")
     end
   end
 


### PR DESCRIPTION
Resumes #9210. @Edouard-chin I'd like to get this solved, so I'm picking your work back up here. This rebases your jobserver implementation onto the current master, resolving the conflicts from the spec directory move and the priority queue change.

Fixes #9170.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
