### PR TITLE
RubyGems: Use of --source should not fallback to other sources

### DIFF
--- a/lib/rubygems/dependency_installer.rb
+++ b/lib/rubygems/dependency_installer.rb
@@ -91,6 +91,11 @@ class Gem::DependencyInstaller
     @build_extension = options[:build_extension]
     @install_plugin = options[:install_plugin]
 
+    # Sources explicitly requested via `--source`. When present, the gems named
+    # on the command line must be found in one of these sources instead of
+    # silently falling back to the default sources.
+    @explicit_sources = options[:sources]
+
     # Indicates that we should not try to update any deps unless
     # we absolutely must.
     @minimal_deps = options[:minimal_deps]
@@ -214,6 +219,7 @@ class Gem::DependencyInstaller
     installer_set = Gem::Resolver::InstallerSet.new @domain
     installer_set.ignore_installed = (@minimal_deps == false) || @only_install_dir
     installer_set.force = @force
+    installer_set.explicit_sources = @explicit_sources
 
     if consider_local?
       if dep_or_name =~ /\.gem$/ && File.file?(dep_or_name)

--- a/lib/rubygems/local_remote_options.rb
+++ b/lib/rubygems/local_remote_options.rb
@@ -102,7 +102,10 @@ module Gem::LocalRemoteOptions
     accept_uri_http
 
     add_option(:"Local/Remote", "-s", "--source URL", Gem::URI::HTTP,
-               "Append URL to list of remote gem sources") do |source, options|
+               "Append URL to list of remote gem sources.",
+               "Gems named on the command line are installed",
+               "only from these sources; their dependencies",
+               "may still come from the default sources") do |source, options|
       source << "/" unless source.end_with?("/")
 
       if options.delete :sources_cleared
@@ -110,6 +113,12 @@ module Gem::LocalRemoteOptions
       else
         Gem.sources << source unless Gem.sources.include?(source)
       end
+
+      # Remember the sources that were explicitly requested on the command line
+      # so that resolution of the gems named on the command line can be
+      # restricted to them (their dependencies may still come from other
+      # sources). See Gem::Resolver::InstallerSet#add_always_install.
+      (options[:sources] ||= []) << source unless options[:sources]&.include?(source)
     end
   end
 

--- a/lib/rubygems/resolver/installer_set.rb
+++ b/lib/rubygems/resolver/installer_set.rb
@@ -33,6 +33,13 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   attr_accessor :force # :nodoc:
 
   ##
+  # Sources explicitly requested via `--source`. When set, gems added to the
+  # always_install list (i.e. the gems named on the command line) must be found
+  # in one of these sources rather than falling back to the default sources.
+
+  attr_accessor :explicit_sources # :nodoc:
+
+  ##
   # Creates a new InstallerSet that will look for gems in +domain+.
 
   def initialize(domain)
@@ -43,6 +50,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
     @f = Gem::SpecFetcher.fetcher
 
     @always_install      = []
+    @explicit_sources    = nil
     @ignore_dependencies = false
     @ignore_installed    = false
     @local               = {}
@@ -59,7 +67,7 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   def add_always_install(dependency)
     request = Gem::Resolver::DependencyRequest.new dependency, nil
 
-    found = find_all request
+    found = find_all_for_always_install request
 
     found.delete_if do |s|
       s.version.prerelease? && !s.local?
@@ -242,6 +250,26 @@ class Gem::Resolver::InstallerSet < Gem::Resolver::Set
   end
 
   private
+
+  ##
+  # Like #find_all, but when sources were explicitly requested via `--source`,
+  # the gem named on the command line must be found in one of those sources
+  # rather than silently falling back to the default sources. Dependencies are
+  # unaffected, since they are not resolved through #add_always_install and may
+  # still come from any configured source.
+
+  def find_all_for_always_install(request)
+    return find_all(request) if @explicit_sources.nil? || @explicit_sources.empty?
+
+    original_remote_set = @remote_set
+    @remote_set = Gem::Resolver::BestSet.new Gem::SourceList.from(@explicit_sources)
+    @remote_set.prerelease = original_remote_set.prerelease
+    begin
+      find_all(request)
+    ensure
+      @remote_set = original_remote_set
+    end
+  end
 
   def metadata_satisfied?(spec)
     spec.required_ruby_version.satisfied_by?(Gem.ruby_version) &&

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -63,6 +63,50 @@ class TestGemDependencyInstaller < Gem::TestCase
     assert_equal [@a1], inst.installed_gems
   end
 
+  def test_install_with_explicit_source_falls_back_for_dependencies
+    spec_fetcher do |fetcher|
+      fetcher.download "b", 1
+    end
+
+    spec_fetcher "http://other.example/" do |fetcher|
+      fetcher.download "a", 1 do |s|
+        s.add_dependency "b", ">= 0"
+      end
+    end
+
+    Gem.sources << "http://other.example/"
+
+    inst = Gem::DependencyInstaller.new sources: ["http://other.example/"]
+    inst.install "a"
+
+    # 'a' is installed from the explicitly requested source, while its
+    # dependency 'b' (only available on the default source) still resolves via
+    # the regular fallback.
+    assert_equal %w[a-1 b-1], inst.installed_gems.map(&:full_name).sort
+  end
+
+  def test_install_with_explicit_source_does_not_fall_back_for_named_gem
+    spec_fetcher do |fetcher|
+      fetcher.download "a", 1
+    end
+
+    spec_fetcher "http://other.example/" do |fetcher|
+      fetcher.download "b", 1
+    end
+
+    Gem.sources << "http://other.example/"
+
+    inst = Gem::DependencyInstaller.new sources: ["http://other.example/"]
+
+    # 'a' only exists on the default source, so installing it from the explicit
+    # source must fail rather than silently using the default source.
+    assert_raise Gem::UnsatisfiableDependencyError do
+      inst.install "a"
+    end
+
+    assert_equal [], inst.installed_gems
+  end
+
   def test_install_prerelease
     util_setup_gems
 

--- a/test/rubygems/test_gem_local_remote_options.rb
+++ b/test/rubygems/test_gem_local_remote_options.rb
@@ -92,6 +92,17 @@ class TestGemLocalRemoteOptions < Gem::TestCase
     assert_equal original_sources, Gem.sources
   end
 
+  def test_source_option_tracks_explicit_sources
+    @cmd.add_source_option
+
+    s1 = Gem::URI.parse "http://more-gems.example.com/"
+    s2 = Gem::URI.parse "http://other-gems.example.com/some_subdir"
+
+    @cmd.handle_options %W[--source #{s1} --source #{s2}]
+
+    assert_equal [s1.to_s, "#{s2}/"], @cmd.options[:sources]
+  end
+
   def test_short_source_option
     @cmd.add_source_option
 

--- a/test/rubygems/test_gem_resolver_installer_set.rb
+++ b/test/rubygems/test_gem_resolver_installer_set.rb
@@ -24,6 +24,48 @@ class TestGemResolverInstallerSet < Gem::TestCase
     assert_equal dep("b"), e.dependency.dependency
   end
 
+  def test_add_always_install_with_explicit_source_ignores_other_sources
+    spec_fetcher do |fetcher|
+      fetcher.download "a", 3
+    end
+
+    spec_fetcher "http://other.example/" do |fetcher|
+      fetcher.download "a", 1
+    end
+
+    Gem.sources << "http://other.example/"
+
+    set = Gem::Resolver::InstallerSet.new :both
+    set.explicit_sources = ["http://other.example/"]
+
+    set.add_always_install dep("a")
+
+    # Even though the default source has a newer a-3, the gem named on the
+    # command line must come from the explicitly requested source (a-1).
+    assert_equal %w[a-1], set.always_install.map(&:full_name)
+  end
+
+  def test_add_always_install_with_explicit_source_does_not_fall_back
+    spec_fetcher do |fetcher|
+      fetcher.download "a", 1
+    end
+
+    spec_fetcher "http://other.example/" do |fetcher|
+      fetcher.download "b", 1
+    end
+
+    Gem.sources << "http://other.example/"
+
+    set = Gem::Resolver::InstallerSet.new :both
+    set.explicit_sources = ["http://other.example/"]
+
+    # 'a' only exists on the default source, so requesting it from the explicit
+    # source must fail instead of silently falling back.
+    assert_raise Gem::UnsatisfiableDependencyError do
+      set.add_always_install dep("a")
+    end
+  end
+
   def test_add_always_install_errors
     @stub_fetcher = Gem::FakeFetcher.new
     Gem::RemoteFetcher.fetcher = @stub_fetcher


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`--source` is only *appended* to the source list, so if the requested source is
unreachable or doesn't carry the gem, `gem install` silently falls back to the
default sources and installs from there with a success exit code:

```
$ gem install paint --source https://example.com/
WARNING:  Unable to pull data from 'https://example.com/': Bad response Not Found 404
Successfully installed paint-2.3.0     # ← from rubygems.org, not the requested source
```

This is a source-substitution / dependency-confusion risk: if a private gem shares
a name with a public one, an attacker squatting that name can have their code
installed whenever the private source is down (flagged as "technically a security
issue" in the original report).

Refs #2313

## What is your fix for the problem, implemented in this PR?

Gems named on the command line are now resolved only from the explicitly requested
`--source`(s), failing if not found there. Their dependencies still resolve from
all configured sources, so private gems that depend on public ones keep working.

`--source` records its URLs in `options[:sources]`, which are passed to the resolver
as `explicit_sources`; `InstallerSet#add_always_install` then resolves the named
gems against a set built only from those sources, leaving dependency resolution
untouched.

The thread also suggested phasing this in via a deprecation warning first — happy to
do that instead if preferred.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write tests for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the current code style and write meaningful commit messages without tags

