### PR TITLE
Probe socket errors via SO_ERROR in TCPSocketProbe

### DIFF
--- a/bundler/lib/bundler/mirror.rb
+++ b/bundler/lib/bundler/mirror.rb
@@ -160,18 +160,18 @@ module Bundler
 
       def wait_for_writtable_socket(socket, address, timeout)
         if IO.select(nil, [socket], nil, timeout)
-          probe_writtable_socket(socket, address)
+          probe_writtable_socket(socket)
         else # TCP Handshake timed out, or there is something dropping packets
           false
         end
       end
 
-      def probe_writtable_socket(socket, address)
-        socket.connect_nonblock(address)
-      rescue Errno::EISCONN
-        true
-      rescue StandardError # Connection failed
-        false
+      def probe_writtable_socket(socket)
+        # Check the pending error on the socket rather than calling
+        # +connect_nonblock+ a second time. On BSD-based systems such as macOS a
+        # second connect returns +EISCONN+ even when the asynchronous connect
+        # failed, which would make a down mirror look reachable.
+        socket.getsockopt(Socket::SOL_SOCKET, Socket::SO_ERROR).int == 0
       end
     end
   end


### PR DESCRIPTION
Bundler::Settings::TCPSocketProbe confirmed a non-blocking connect by calling connect_nonblock a second time, which is not portable. On BSD-based systems such as macOS the second connect returns EISCONN even after the asynchronous connect failed with ECONNREFUSED, so a mirror that is down was reported as reachable. This made the "probes falsey when the server is down" example in spec/bundler/mirror_spec.rb fail on macOS.

Check the pending socket error with getsockopt(SOL_SOCKET, SO_ERROR) once IO.select reports the socket writable. That is the portable way to detect the result of a non-blocking connect.

This mirrors the same fix made in ruby/ruby.
https://github.com/ruby/ruby/pull/17392
