### PR TITLE
Skip the make jobserver on Windows

### DIFF
--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -119,22 +119,31 @@ module Bundler
     end
 
     def with_jobserver
-      r, w = IO.pipe
-      r.close_on_exec = false
-      w.close_on_exec = false
-      w.write("*" * @size)
+      # The POSIX make jobserver hands tokens to child `make` processes through
+      # an inherited pipe identified by its file descriptor numbers, which
+      # Windows cannot inherit. nmake also rejects a GNU make `--jobserver-auth`
+      # left in MAKEFLAGS and aborts every native extension build with
+      # `fatal error U1065: invalid option '-'`. Skip the jobserver on Windows.
+      return yield if Gem.win_platform?
 
-      old_makeflags = ENV["MAKEFLAGS"]
-      ENV["MAKEFLAGS"] = [old_makeflags, "--jobserver-auth=#{r.fileno},#{w.fileno}"].compact.join(" ")
+      begin
+        r, w = IO.pipe
+        r.close_on_exec = false
+        w.close_on_exec = false
+        w.write("*" * @size)
 
-      yield
-    ensure
-      # Restore MAKEFLAGS before closing the pipe so a close failure can't
-      # leave the process with descriptors that point at a closed pipe.
-      old_makeflags ? ENV["MAKEFLAGS"] = old_makeflags : ENV.delete("MAKEFLAGS")
+        old_makeflags = ENV["MAKEFLAGS"]
+        ENV["MAKEFLAGS"] = [old_makeflags, "--jobserver-auth=#{r.fileno},#{w.fileno}"].compact.join(" ")
 
-      r&.close
-      w&.close
+        yield
+      ensure
+        # Restore MAKEFLAGS before closing the pipe so a close failure can't
+        # leave the process with descriptors that point at a closed pipe.
+        old_makeflags ? ENV["MAKEFLAGS"] = old_makeflags : ENV.delete("MAKEFLAGS")
+
+        r&.close
+        w&.close
+      end
     end
 
     def install_serially

--- a/bundler/lib/bundler/installer/parallel_installer.rb
+++ b/bundler/lib/bundler/installer/parallel_installer.rb
@@ -119,12 +119,13 @@ module Bundler
     end
 
     def with_jobserver
-      # The POSIX make jobserver hands tokens to child `make` processes through
-      # an inherited pipe identified by its file descriptor numbers, which
-      # Windows cannot inherit. nmake also rejects a GNU make `--jobserver-auth`
-      # left in MAKEFLAGS and aborts every native extension build with
-      # `fatal error U1065: invalid option '-'`. Skip the jobserver on Windows.
-      return yield if Gem.win_platform?
+      # The jobserver hands tokens to child `make` processes through MAKEFLAGS
+      # using the GNU make `--jobserver-auth` protocol. nmake, the default make
+      # on mswin, instead reads MAKEFLAGS as bare option letters and aborts
+      # every native extension build with `fatal error U1065: invalid option
+      # '-'`. Skip the jobserver when nmake is in use. Other Windows toolchains
+      # such as mingw use GNU make and keep working through the inherited pipe.
+      return yield if nmake?
 
       begin
         r, w = IO.pipe
@@ -144,6 +145,14 @@ module Bundler
         r&.close
         w&.close
       end
+    end
+
+    # Mirror how RubyGems' extension builder picks the make program so the
+    # jobserver is only set up when a GNU-compatible make will consume it.
+    def nmake?
+      make = ENV["MAKE"] || ENV["make"]
+      make ||= "nmake" if RUBY_PLATFORM.include?("mswin")
+      /\bnmake/i.match?(make.to_s)
     end
 
     def install_serially

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -219,4 +219,24 @@ RSpec.describe Bundler::ParallelInstaller do
       Bundler::RubyGemsGemInstaller.define_method(:build_jobs, old_method)
     end
   end
+
+  describe "make jobserver on Windows" do
+    # nmake reads MAKEFLAGS from the environment and treats its contents as
+    # bare option letters, so a GNU make `--jobserver-auth` aborts the build
+    # with `fatal error U1065: invalid option '-'`. The fd-based jobserver also
+    # cannot work on Windows, so it must be skipped there entirely.
+    it "leaves MAKEFLAGS untouched" do
+      allow(Gem).to receive(:win_platform?).and_return(true)
+
+      parallel_installer = Bundler::ParallelInstaller.new(nil, [], 5, false, false)
+
+      makeflags_before = ENV["MAKEFLAGS"]
+      makeflags_during = :not_yielded
+      parallel_installer.send(:with_jobserver) do
+        makeflags_during = ENV["MAKEFLAGS"]
+      end
+
+      expect(makeflags_during).to eq(makeflags_before)
+    end
+  end
 end

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -220,18 +220,25 @@ RSpec.describe Bundler::ParallelInstaller do
     end
   end
 
-  describe "make jobserver on Windows", :windows_only do
+  describe "make jobserver with nmake" do
     # nmake reads MAKEFLAGS from the environment and treats its contents as
     # bare option letters, so a GNU make `--jobserver-auth` aborts the build
-    # with `fatal error U1065: invalid option '-'`. The fd-based jobserver also
-    # cannot work on Windows, so it must be skipped there entirely.
+    # with `fatal error U1065: invalid option '-'`. The jobserver must be
+    # skipped when nmake is the make program.
     it "leaves MAKEFLAGS untouched" do
       parallel_installer = Bundler::ParallelInstaller.new(nil, [], 5, false, false)
 
       makeflags_before = ENV["MAKEFLAGS"]
       makeflags_during = :not_yielded
-      parallel_installer.send(:with_jobserver) do
-        makeflags_during = ENV["MAKEFLAGS"]
+
+      old_make = ENV["MAKE"]
+      ENV["MAKE"] = "nmake"
+      begin
+        parallel_installer.send(:with_jobserver) do
+          makeflags_during = ENV["MAKEFLAGS"]
+        end
+      ensure
+        ENV["MAKE"] = old_make
       end
 
       expect(makeflags_during).to eq(makeflags_before)

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -220,14 +220,12 @@ RSpec.describe Bundler::ParallelInstaller do
     end
   end
 
-  describe "make jobserver on Windows" do
+  describe "make jobserver on Windows", :windows_only do
     # nmake reads MAKEFLAGS from the environment and treats its contents as
     # bare option letters, so a GNU make `--jobserver-auth` aborts the build
     # with `fatal error U1065: invalid option '-'`. The fd-based jobserver also
     # cannot work on Windows, so it must be skipped there entirely.
     it "leaves MAKEFLAGS untouched" do
-      allow(Gem).to receive(:win_platform?).and_return(true)
-
       parallel_installer = Bundler::ParallelInstaller.new(nil, [], 5, false, false)
 
       makeflags_before = ENV["MAKEFLAGS"]

--- a/spec/support/filters.rb
+++ b/spec/support/filters.rb
@@ -33,7 +33,6 @@ RSpec.configure do |config|
   config.filter_run_excluding truffleruby_only: RUBY_ENGINE != "truffleruby"
   config.filter_run_excluding man: Gem.win_platform?
   config.filter_run_excluding mri_only: RUBY_ENGINE != "ruby"
-  config.filter_run_excluding windows_only: !Gem.win_platform?
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 

--- a/spec/support/filters.rb
+++ b/spec/support/filters.rb
@@ -33,6 +33,7 @@ RSpec.configure do |config|
   config.filter_run_excluding truffleruby_only: RUBY_ENGINE != "truffleruby"
   config.filter_run_excluding man: Gem.win_platform?
   config.filter_run_excluding mri_only: RUBY_ENGINE != "ruby"
+  config.filter_run_excluding windows_only: !Gem.win_platform?
 
   config.filter_run_when_matching :focus unless ENV["CI"]
 


### PR DESCRIPTION
Since the make jobserver was introduced, bundle install fails on mswin for every gem with native extensions. The parallel installer adds a GNU make `--jobserver-auth` to MAKEFLAGS, which nmake inherits and reads as bare option letters. nmake then aborts each build with `fatal error U1065: invalid option '-'`. This broke ruby/rbs CI while installing bigdecimal, prism, digest, ffi and others.

https://github.com/ruby/rbs/actions/runs/27736519019/job/82054372031

mingw and other Windows toolchains use GNU make and consume the jobserver tokens through the inherited pipe without trouble, so the skip is limited to nmake. The make program is detected the same way the extension builder picks it, honoring the MAKE environment variable and the mswin default.

The added spec forces nmake through the MAKE environment variable and checks that MAKEFLAGS is left untouched.
