### PR TITLE
Suggest access issues, not only yanking, for missing locked gems

### DIFF
--- a/bundler/lib/bundler/definition.rb
+++ b/bundler/lib/bundler/definition.rb
@@ -711,9 +711,10 @@ module Bundler
             "available locally before rerunning Bundler."
           else
             "Your bundle is locked to #{locked_gem} from #{locked_gem.source}, but that version can " \
-            "no longer be found in that source. That means the author of #{locked_gem} has removed it. " \
-            "You'll need to update your bundle to a version other than #{locked_gem} that hasn't been " \
-            "removed in order to install."
+            "no longer be found in that source. That means either the author of #{locked_gem} has removed it, " \
+            "or you no longer have access to that source. You'll need to update your bundle to a version other " \
+            "than #{locked_gem} that hasn't been removed, or check your credentials and access rights for " \
+            "#{locked_gem.source}, in order to install."
           end
 
           raise GemNotFound, message

--- a/spec/install/yanked_spec.rb
+++ b/spec/install/yanked_spec.rb
@@ -26,6 +26,8 @@ RSpec.context "when installing a bundle that includes yanked gems" do
     G
 
     expect(err).to include("Your bundle is locked to foo (10.0.0)")
+    expect(err).to include("either the author of foo (10.0.0) has removed it, or you no longer have access to that source")
+    expect(err).to include("check your credentials and access rights")
   end
 
   context "when a platform specific yanked version is included in the lockfile, and a generic variant is available remotely" do


### PR DESCRIPTION
A gem locked to a private registry such as GitHub Packages returns 403 or 404 when the caller has no access to that source. Bundler cannot tell that response apart from a genuine 404, so the resolver treated the gem as missing and told the user the author had removed it. That wording sent people hunting for a yank that never happened instead of checking their credentials.

This relaxes the message for the non implicit global source case so it names both possibilities. It still notes that the author may have removed the gem, and it now also says the user may no longer have access to the source and points at the locked source to verify credentials and access rights. The implicit global source branch is left unchanged.

Closes https://github.com/ruby/rubygems/issues/9628
