### PR TITLE
Resolve Git LFS files in git sources from the real remote

### DIFF
--- a/bundler/lib/bundler/source/git/git_proxy.rb
+++ b/bundler/lib/bundler/source/git/git_proxy.rb
@@ -144,6 +144,12 @@ module Bundler
                 FileUtils.rm_rf(p)
               end
               git "clone", "--no-checkout", "--quiet", path.to_s, destination.to_s
+              # The copy is cloned from the local bare cache, which holds no Git LFS
+              # objects, so point origin back at the real remote and let git-lfs derive
+              # its endpoint from there when checking out. Use the credential-filtered
+              # URI to avoid persisting secrets in the copy's .git/config; auth is left
+              # to git's credential helper.
+              git "remote", "set-url", "origin", credential_filtered_uri, dir: destination
               File.chmod((File.stat(destination).mode | 0o777) & ~File.umask, destination)
             rescue Errno::EEXIST => e
               file_path = e.message[%r{.*?((?:[a-zA-Z]:)?/.*)}, 1]

--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -98,6 +98,34 @@ RSpec.describe Bundler::Source::Git::GitProxy do
     end
   end
 
+  describe "#copy_to" do
+    let(:revision) { "abc123" }
+    let(:destination) { tmp("git-proxy-copy") }
+
+    before do
+      # The bare cache (`path`) is the clone source, so stub it away and only
+      # exercise the post-clone wiring of the working copy at `destination`.
+      allow(File).to receive(:stat).and_call_original
+      allow(File).to receive(:stat).with(destination).and_return(double("File::Stat", mode: 0o755))
+      allow(File).to receive(:chmod)
+      allow(git_proxy).to receive(:capture).and_return(["", "", clone_result])
+    end
+
+    it "points the working copy's origin back at the real remote" do
+      expect(git_proxy).to receive(:capture).with(["remote", "set-url", "origin", uri], destination).and_return(["", "", clone_result])
+      git_proxy.copy_to(destination)
+    end
+
+    it "does not persist credentials in the working copy's origin" do
+      Bundler.settings.temporary(uri => "u:p") do
+        credentialed_uri = "https://u:p@github.com/ruby/rubygems.git"
+        expect(git_proxy).not_to receive(:capture).with(["remote", "set-url", "origin", credentialed_uri], destination)
+        expect(git_proxy).to receive(:capture).with(["remote", "set-url", "origin", uri], destination).and_return(["", "", clone_result])
+        git_proxy.copy_to(destination)
+      end
+    end
+  end
+
   describe "#version" do
     context "with a normal version number" do
       before do

--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -124,6 +124,17 @@ RSpec.describe Bundler::Source::Git::GitProxy do
         git_proxy.copy_to(destination)
       end
     end
+
+    context "when the remote URI embeds credentials" do
+      let(:uri) { "https://user:secret@github.com/ruby/rubygems.git" }
+
+      it "strips the password before writing origin" do
+        filtered_uri = "https://user@github.com/ruby/rubygems.git"
+        expect(git_proxy).not_to receive(:capture).with(["remote", "set-url", "origin", uri], destination)
+        expect(git_proxy).to receive(:capture).with(["remote", "set-url", "origin", filtered_uri], destination).and_return(["", "", clone_result])
+        git_proxy.copy_to(destination)
+      end
+    end
   end
 
   describe "#version" do

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe "bundle install with git sources" do
       expect(out).to eq("WIN")
     end
 
+    it "points the installed copy's origin at the real remote, not the local cache" do
+      install_base_gemfile
+
+      installed = Pathname.glob(default_bundle_path("bundler/gems/foo-1.0-*")).first
+      origin = git("config --get remote.origin.url", installed).strip
+      expect(origin).to eq(lib_path("foo-1.0").to_s)
+    end
+
     it "does not (yet?) enforce CHECKSUMS" do
       build_git "foo"
       revision = revision_for(lib_path("foo-1.0"))


### PR DESCRIPTION
A git source gem that stores files with Git LFS fails to install with "smudge filter lfs failed". Bundler clones the working copy from its local bare cache, so the copy's origin points at that cache. The cache holds no LFS objects, so git-lfs looks there during checkout and cannot resolve the pointers.

This resets the working copy's origin back at the real remote right after the clone. git-lfs then derives its endpoint from the real remote and downloads the LFS objects during checkout. The post-clone fetch already passes the cache path explicitly so it stays unaffected, and the reset that triggers the smudge now sees the correct origin. The origin value comes from the credential-filtered URI so no secrets land in the copy's .git/config, leaving authentication to git's credential helper.

Closes #9612
