### PR TITLE
RubyGems: Remove unused ctx.tmp_dh_callback in start_ssl_server

### DIFF
--- a/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
+++ b/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
@@ -14,20 +14,6 @@ require "rubygems/package"
 class TestGemRemoteFetcherLocalSSLServer < Gem::TestCase
   include Gem::DefaultUserInteraction
 
-  # Generated via:
-  #   x = OpenSSL::PKey::DH.new(2048) # wait a while...
-  #   x.to_s => pem
-  TEST_KEY_DH2048 = OpenSSL::PKey::DH.new <<-_END_OF_PEM_
------BEGIN DH PARAMETERS-----
-MIIBCAKCAQEA3Ze2EHSfYkZLUn557torAmjBgPsqzbodaRaGZtgK1gEU+9nNJaFV
-G1JKhmGUiEDyIW7idsBpe4sX/Wqjnp48Lr8IeI/SlEzLdoGpf05iRYXC8Cm9o8aM
-cfmVgoSEAo9YLBpzoji2jHkO7Q5IPt4zxbTdlmmGFLc/GO9q7LGHhC+rcMcNTGsM
-49AnILNn49pq4Y72jSwdmvq4psHZwwFBbPwLdw6bLUDDCN90jfqvYt18muwUxDiN
-NP0fuvVAIB158VnQ0liHSwcl6+9vE1mL0Jo/qEXQxl0+UdKDjaGfTsn6HIrwTnmJ
-PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
------END DH PARAMETERS-----
-    _END_OF_PEM_
-
   def setup
     super
     @ssl_server_thread = nil
@@ -155,7 +141,6 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     ctx.cert = cert("ssl_cert.pem")
     ctx.key = key("ssl_key.pem")
     ctx.ca_file = File.join(__dir__, "ca_cert.pem")
-    ctx.tmp_dh_callback = proc { TEST_KEY_DH2048 }
     ctx.verify_mode = config[:verify_mode] if config[:verify_mode]
     @ssl_server = OpenSSL::SSL::SSLServer.new(server, ctx)
     @ssl_server_thread = Thread.new do


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

I think the following code in `start_ssl_server`, test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb is possibly not used any more.

```
ctx.tmp_dh_callback = proc { TEST_KEY_DH2048 }
```

In my investigation, the code was added at the commit 5e16a5428f973667cabfa07e94ff939e7a83ebd9 [link](https://github.com/ruby/rubygems/commit/5e16a5428f973667cabfa07e94ff939e7a83ebd9#diff-a147b017b4627aa78fdd88ff89433d309916c65d34cacace9a9b0f2d212de4acR923) when the `start_ssl_server` method was used with WEBrick or OpenSSL versions older than version 1.1.

I confirmed that the test with Ruby compiled with OpenSSL 1.1.1w passed as follows.

```
$ which ruby
~/.local/ruby-4.1.0-debug-d190c264ec-openssl-1.1.1w-debug/bin/ruby

$ ruby -e 'require "openssl"; p OpenSSL::OPENSSL_VERSION'
"OpenSSL 1.1.1w  11 Sep 2023"

$ bin/test-unit test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
Loaded suite Gem::TestCase
Started
.......
Finished in 3.645390202 seconds.
----------------------------------------------------------------------------------------
7 tests, 19 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------
1.92 tests/s, 5.21 assertions/s
Coverage report generated for rubygems to /home/jaruga/var/git/ruby/rubygems2/coverage.
Line Coverage: 32.06% (1328 / 4142)
```

Because as far as I know, RHEL 8 server in [RubyCI](https://rubyci.org/
) has the oldest version of OpenSSL 1.1.1k.

```
$ openssl version
OpenSSL 1.1.1k  FIPS 25 Mar 2021
```

So, as I confirmed the test passed with OpenSSL 1.1.1w, I guess the changed test passes in all the servers of RubyCI.

Ruby OpenSSL latest stable version 4.0.x's minimal supported OpenSSL vesion is 1.1.1. So, I think it's good enough to test with OpenSSL 1.1.1.

https://github.com/ruby/openssl

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Deleted the unused `ctx.tmp_dh_callback` logic.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
