### PR TITLE
bundler: Fix Bundler::Fetcher for PQC support, adding integration connection tests

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -318,7 +318,7 @@ module Bundler
         if ssl_client_cert
           pem = File.read(ssl_client_cert)
           con.cert = OpenSSL::X509::Certificate.new(pem)
-          con.key  = OpenSSL::PKey::RSA.new(pem)
+          con.key  = OpenSSL::PKey.read(pem)
         end
 
         con.read_timeout = Fetcher.api_timeout

--- a/spec/bundler/fetcher/gem_remote_fetcher_local_ssl_server_spec.rb
+++ b/spec/bundler/fetcher/gem_remote_fetcher_local_ssl_server_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "bundler/fetcher"
+require Spec::Path.rubygems_test_dir.join("local_ssl_server_utilities")
+
+RSpec.describe "Bundler::Fetcher local SSL server", if: Gem::HAVE_OPENSSL do
+  include Gem::LocalSSLServerUtilities
+
+  before do
+    initialize_ssl_server
+  end
+
+  after do
+    stop_ssl_server
+  end
+
+  describe "#connection" do
+    context "non-PQC" do
+      it "connects" do
+        ssl_server = start_ssl_server
+        allow(Bundler.settings).to receive(:[]).and_call_original
+        allow(Bundler.settings).to receive(:[]).with(:ssl_ca_cert).and_return(File.join(certs_dir, "ca_cert.pem"))
+        response = fetch_path("https://localhost:#{ssl_server.addr[1]}/yaml")
+        expect(response.code).to eq("200")
+      end
+
+      it "connects with client cert auth" do
+        ssl_server = start_ssl_server(
+          verify_mode: OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
+        )
+        allow(Bundler.settings).to receive(:[]).and_call_original
+        allow(Bundler.settings).to receive(:[]).with(:ssl_ca_cert).and_return(File.join(certs_dir, "ca_cert.pem"))
+        allow(Bundler.settings).to receive(:[]).with(:ssl_client_cert).and_return(File.join(certs_dir, "client.pem"))
+        response = fetch_path("https://localhost:#{ssl_server.addr[1]}/yaml")
+        expect(response.code).to eq("200")
+      end
+    end
+
+    context "PQC" do
+      before do
+        skip_unless_support_pqc
+      end
+
+      it "connects" do
+        ssl_server = start_ssl_server(mode: :pqc)
+        allow(Bundler.settings).to receive(:[]).and_call_original
+        allow(Bundler.settings).to receive(:[]).with(:ssl_ca_cert).and_return(File.join(certs_dir, "mldsa65_ca_cert.pem"))
+        response = fetch_path("https://localhost:#{ssl_server.addr[1]}/yaml")
+        expect(response.code).to eq("200")
+      end
+
+      it "connects with client cert auth" do
+        ssl_server = start_ssl_server(
+          mode: :pqc,
+          verify_mode: OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
+        )
+        allow(Bundler.settings).to receive(:[]).and_call_original
+        allow(Bundler.settings).to receive(:[]).with(:ssl_ca_cert).and_return(File.join(certs_dir, "mldsa65_ca_cert.pem"))
+        allow(Bundler.settings).to receive(:[]).with(:ssl_client_cert).and_return(File.join(certs_dir, "mldsa65_client.pem"))
+        response = fetch_path("https://localhost:#{ssl_server.addr[1]}/yaml")
+        expect(response.code).to eq("200")
+      end
+    end
+  end
+
+  def fetch_path(uri)
+    uri = Gem::URI(uri)
+    remote = double("remote", uri: uri, original_uri: nil)
+    fetcher = Bundler::Fetcher.new(remote)
+
+    connection = fetcher.send(:connection)
+    connection.request(uri)
+  end
+
+  def skip_unless_support_pqc
+    without_pqc_support do |message|
+      skip message
+    end
+  end
+end

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -93,14 +93,14 @@ RSpec.describe Bundler::Fetcher do
       end
     end
 
-    context "when bunder ssl ssl configuration is set" do
+    context "when bunder ssl configuration is set" do
       before do
         cert = File.join(Spec::Path.tmpdir, "cert")
         File.open(cert, "w") {|f| f.write "PEM" }
         allow(Bundler.settings).to receive(:[]).and_return(nil)
         allow(Bundler.settings).to receive(:[]).with(:ssl_client_cert).and_return(cert)
         expect(OpenSSL::X509::Certificate).to receive(:new).with("PEM").and_return("cert")
-        expect(OpenSSL::PKey::RSA).to receive(:new).with("PEM").and_return("key")
+        expect(OpenSSL::PKey).to receive(:read).with("PEM").and_return("key")
       end
       after do
         FileUtils.rm File.join(Spec::Path.tmpdir, "cert")
@@ -120,7 +120,7 @@ RSpec.describe Bundler::Fetcher do
         )
         expect(File).to receive(:read).and_return("")
         expect(OpenSSL::X509::Certificate).to receive(:new).and_return("cert")
-        expect(OpenSSL::PKey::RSA).to receive(:new).and_return("key")
+        expect(OpenSSL::PKey).to receive(:read).and_return("key")
         store = double("ca store")
         expect(store).to receive(:add_file)
         expect(OpenSSL::X509::Store).to receive(:new).and_return(store)

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Bundler::ParallelInstaller do
   describe "priority queue" do
     before do
       require "support/artifice/compact_index"
+      Artifice.activate_with(CompactIndexAPI)
 
       @previous_client = Gem::Request::ConnectionPools.client
       Gem::Request::ConnectionPools.client = Gem::Net::HTTP
@@ -98,6 +99,7 @@ RSpec.describe Bundler::ParallelInstaller do
       end
 
       require "support/artifice/compact_index"
+      Artifice.activate_with(CompactIndexAPI)
 
       @previous_client = Gem::Request::ConnectionPools.client
       Gem::Request::ConnectionPools.client = Gem::Net::HTTP

--- a/spec/support/artifice/helpers/artifice.rb
+++ b/spec/support/artifice/helpers/artifice.rb
@@ -12,13 +12,18 @@ module Artifice
   def self.activate_with(endpoint)
     require_relative "rack_request"
 
+    # Preserve the original on first activation only. Without ||=, a second
+    # activate_with call saves the already-replaced Artifice::Net::HTTP, so
+    # deactivate would fail to restore the real Gem::Net::HTTP.
+    @original_net_http ||= ::Gem::Net::HTTP
     Net::HTTP.endpoint = endpoint
     replace_net_http(Artifice::Net::HTTP)
   end
 
   # Deactivate the Artifice replacement.
   def self.deactivate
-    replace_net_http(::Gem::Net::HTTP)
+    replace_net_http(@original_net_http) if @original_net_http
+    @original_net_http = nil
   end
 
   def self.replace_net_http(value)

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -79,6 +79,10 @@ module Spec
       @spec_dir ||= source_root.join(ruby_core? ? "spec/bundler" : "spec")
     end
 
+    def rubygems_test_dir
+      @rubygems_test_dir ||= source_root.join("test/rubygems")
+    end
+
     def man_dir
       @man_dir ||= lib_dir.join("bundler/man")
     end

--- a/spec/support/shards.rb
+++ b/spec/support/shards.rb
@@ -194,6 +194,7 @@ module Spec
         "spec/bundler/override_spec.rb",
         "spec/install/gemfile/override_spec.rb",
         "spec/install/path_spec.rb",
+        "spec/bundler/fetcher/gem_remote_fetcher_local_ssl_server_spec.rb",
       ],
     }.freeze
   end

--- a/test/rubygems/local_ssl_server_utilities.rb
+++ b/test/rubygems/local_ssl_server_utilities.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+# This file can be loaded by RubyGems test-unit files and Bundler rspec files.
+# Don't add test-unit or rspec dependent logic in this file.
+
+require "socket"
+require "openssl"
+
+module Gem::LocalSSLServerUtilities
+  CERTS_DIR = __dir__
+
+  def certs_dir
+    CERTS_DIR
+  end
+
+  def initialize_ssl_server
+    @ssl_server_thread = nil
+    @ssl_server = nil
+  end
+
+  def stop_ssl_server
+    if @ssl_server_thread
+      @ssl_server_thread.kill.join
+      @ssl_server_thread = nil
+    end
+    if @ssl_server
+      @ssl_server.close
+      @ssl_server = nil
+    end
+  end
+
+  # mode:
+  #   :non_pqc - Run single server with PQC-unsupported RSA (default)
+  #   :pqc     - Run single server with PQC-supported key exchange,
+  #              X25519MLKEM768, and PQC-supported certificate, ML-DSA-65
+  def start_ssl_server(config = {})
+    mode = config.fetch(:mode, :non_pqc)
+    server = TCPServer.new(0)
+    ctx = OpenSSL::SSL::SSLContext.new
+
+    case mode
+    when :non_pqc
+      ctx.cert = cert("ssl_cert.pem")
+      ctx.key = key("ssl_key.pem")
+      ctx.ca_file = File.join(certs_dir, "ca_cert.pem")
+    when :pqc
+      ctx.cert = cert("mldsa65_ssl_cert.pem")
+      ctx.key = key("mldsa65_ssl_key.pem")
+      ctx.ca_file = File.join(certs_dir, "mldsa65_ca_cert.pem")
+      ctx.groups = "X25519MLKEM768"
+    end
+
+    ctx.verify_mode = config[:verify_mode] if config[:verify_mode]
+    @ssl_server = OpenSSL::SSL::SSLServer.new(server, ctx)
+    @ssl_server_thread = Thread.new do
+      loop do
+        ssl_client = @ssl_server.accept
+        Thread.new(ssl_client) do |client|
+          handle_request(client)
+        ensure
+          client.close
+        end
+      rescue OpenSSL::SSL::SSLError
+        # Ignore SSL errors because we're testing them implicitly
+      end
+    end
+    @ssl_server
+  end
+
+  def handle_request(client)
+    request = client.gets
+    if request&.start_with?("GET /yaml")
+      client.print "HTTP/1.1 200 OK\r\nContent-Type: text/yaml\r\n\r\n--- true\n"
+    elsif request&.start_with?("GET /insecure_redirect")
+      location = request.match(/to=([^ ]+)/)[1]
+      client.print "HTTP/1.1 301 Moved Permanently\r\nLocation: #{location}\r\n\r\n"
+    else
+      client.print "HTTP/1.1 404 Not Found\r\n\r\n"
+    end
+  end
+
+  def cert(filename)
+    OpenSSL::X509::Certificate.new(File.read(File.join(certs_dir, filename)))
+  end
+
+  def key(filename)
+    OpenSSL::PKey.read(File.read(File.join(certs_dir, filename)))
+  end
+
+  def without_pqc_support(&block)
+    # PQC algorithms ML-KEM and ML-DSA require OpenSSL >= 3.5.
+    # https://openssl-library.org/post/2025-04-08-openssl-35-final-release/
+    unless OpenSSL::OPENSSL_VERSION_NUMBER >= 0x30500000
+      yield "PQC algorithms require OpenSSL >= 3.5"
+      return
+    end
+    # ctx.groups (OpenSSL::SSL::SSLContext#groups) used in start_ssl_server
+    # mode :pqc requires Ruby OpenSSL >= 4.0.
+    unless Gem::Version.new(OpenSSL::VERSION) >= Gem::Version.new("4.0")
+      yield "PQC test requires Ruby OpenSSL >= 4.0"
+      return
+    end
+    # Even with a new enough OpenSSL, the runtime may keep PQC groups and
+    # signature algorithms out of its default negotiation lists (for example
+    # RHEL's system-wide crypto policies). The PQC server forces both, while
+    # the gem fetcher connects with the default client configuration, so a
+    # real loopback handshake is the only reliable way to tell whether this
+    # environment can negotiate PQC at all.
+    unless Gem::LocalSSLServerUtilities.support_pqc_handshake?
+      yield "PQC handshake is not available in this OpenSSL configuration"
+    end
+  end
+
+  # Probe an actual PQC handshake between a forced-PQC server and a
+  # default-configured client, mirroring what the integration tests exercise.
+  # Memoized so the probe runs at most once per process.
+  def self.support_pqc_handshake?
+    return @support_pqc_handshake unless @support_pqc_handshake.nil?
+
+    @support_pqc_handshake = probe_pqc_handshake
+  end
+
+  def self.probe_pqc_handshake
+    server = TCPServer.new("127.0.0.1", 0)
+    ctx = OpenSSL::SSL::SSLContext.new
+    ctx.cert = OpenSSL::X509::Certificate.new(File.read(File.join(CERTS_DIR, "mldsa65_ssl_cert.pem")))
+    ctx.key = OpenSSL::PKey.read(File.read(File.join(CERTS_DIR, "mldsa65_ssl_key.pem")))
+    ctx.groups = "X25519MLKEM768"
+    ssl_server = OpenSSL::SSL::SSLServer.new(server, ctx)
+
+    port = server.addr[1]
+    server_thread = Thread.new do
+      client = ssl_server.accept
+      client.close
+    rescue OpenSSL::OpenSSLError
+      nil
+    end
+
+    client_ctx = OpenSSL::SSL::SSLContext.new
+    client_ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    socket = TCPSocket.new("127.0.0.1", port)
+    ssl = OpenSSL::SSL::SSLSocket.new(socket, client_ctx)
+    ssl.connect
+    ssl.close
+    true
+  rescue OpenSSL::OpenSSLError, SystemCallError
+    false
+  ensure
+    server_thread&.join(5)
+    server_thread&.kill if server_thread&.alive?
+    ssl_server&.close
+    server&.close
+  end
+end

--- a/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
+++ b/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "helper"
-require "socket"
-require "openssl"
+require_relative "local_ssl_server_utilities"
 
 unless Gem::HAVE_OPENSSL
   warn "Skipping Gem::RemoteFetcher tests.  openssl not found."
@@ -13,28 +12,21 @@ require "rubygems/package"
 
 class TestGemRemoteFetcherLocalSSLServer < Gem::TestCase
   include Gem::DefaultUserInteraction
+  include Gem::LocalSSLServerUtilities
 
   def setup
     super
-    @ssl_server_thread = nil
-    @ssl_server = nil
+    initialize_ssl_server
   end
 
   def teardown
-    if @ssl_server_thread
-      @ssl_server_thread.kill.join
-      @ssl_server_thread = nil
-    end
-    if @ssl_server
-      @ssl_server.close
-      @ssl_server = nil
-    end
+    stop_ssl_server
     super
   end
 
   def test_ssl_connection
     ssl_server = start_ssl_server
-    temp_ca_cert = File.join(__dir__, "ca_cert.pem")
+    temp_ca_cert = File.join(certs_dir, "ca_cert.pem")
     with_configured_fetcher(":ssl_ca_cert: #{temp_ca_cert}") do |fetcher|
       fetcher.fetch_path("https://localhost:#{ssl_server.addr[1]}/yaml")
     end
@@ -44,7 +36,7 @@ class TestGemRemoteFetcherLocalSSLServer < Gem::TestCase
     omit_unless_support_pqc
 
     ssl_server = start_ssl_server(mode: :pqc)
-    temp_ca_cert = File.join(__dir__, "mldsa65_ca_cert.pem")
+    temp_ca_cert = File.join(certs_dir, "mldsa65_ca_cert.pem")
     with_configured_fetcher(":ssl_ca_cert: #{temp_ca_cert}") do |fetcher|
       fetcher.fetch_path("https://localhost:#{ssl_server.addr[1]}/yaml")
     end
@@ -55,8 +47,8 @@ class TestGemRemoteFetcherLocalSSLServer < Gem::TestCase
       { verify_mode: OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT }
     )
 
-    temp_ca_cert = File.join(__dir__, "ca_cert.pem")
-    temp_client_cert = File.join(__dir__, "client.pem")
+    temp_ca_cert = File.join(certs_dir, "ca_cert.pem")
+    temp_client_cert = File.join(certs_dir, "client.pem")
 
     with_configured_fetcher(
       ":ssl_ca_cert: #{temp_ca_cert}\n" \
@@ -74,8 +66,8 @@ class TestGemRemoteFetcherLocalSSLServer < Gem::TestCase
       verify_mode: OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT
     )
 
-    temp_ca_cert = File.join(__dir__, "mldsa65_ca_cert.pem")
-    temp_client_cert = File.join(__dir__, "mldsa65_client.pem")
+    temp_ca_cert = File.join(certs_dir, "mldsa65_ca_cert.pem")
+    temp_client_cert = File.join(certs_dir, "mldsa65_client.pem")
 
     with_configured_fetcher(
       ":ssl_ca_cert: #{temp_ca_cert}\n" \
@@ -90,8 +82,8 @@ class TestGemRemoteFetcherLocalSSLServer < Gem::TestCase
       { verify_mode: OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT }
     )
 
-    temp_ca_cert = File.join(__dir__, "ca_cert.pem")
-    temp_client_cert = File.join(__dir__, "invalid_client.pem")
+    temp_ca_cert = File.join(certs_dir, "ca_cert.pem")
+    temp_client_cert = File.join(certs_dir, "invalid_client.pem")
 
     with_configured_fetcher(
       ":ssl_ca_cert: #{temp_ca_cert}\n" \
@@ -122,7 +114,7 @@ class TestGemRemoteFetcherLocalSSLServer < Gem::TestCase
   def test_do_not_follow_insecure_redirect
     @server_uri = "http://example.com"
     ssl_server = start_ssl_server
-    temp_ca_cert = File.join(__dir__, "ca_cert.pem")
+    temp_ca_cert = File.join(certs_dir, "ca_cert.pem")
     expected_error_message =
       "redirecting to non-https resource: #{@server_uri} (https://localhost:#{ssl_server.addr[1]}/insecure_redirect?to=#{@server_uri})"
 
@@ -164,121 +156,9 @@ class TestGemRemoteFetcherLocalSSLServer < Gem::TestCase
     Gem.configuration = nil
   end
 
-  # mode:
-  #   :non_pqc - Run single server with PQC-unsupported RSA (default)
-  #   :pqc     - Run single server with PQC-supported key exchange,
-  #              X25519MLKEM768, and PQC-supported certificate, ML-DSA-65
-  def start_ssl_server(config = {})
-    mode = config.fetch(:mode, :non_pqc)
-    server = TCPServer.new(0)
-    ctx = OpenSSL::SSL::SSLContext.new
-
-    case mode
-    when :non_pqc
-      ctx.cert = cert("ssl_cert.pem")
-      ctx.key = key("ssl_key.pem")
-      ctx.ca_file = File.join(__dir__, "ca_cert.pem")
-    when :pqc
-      ctx.cert = cert("mldsa65_ssl_cert.pem")
-      ctx.key = key("mldsa65_ssl_key.pem")
-      ctx.ca_file = File.join(__dir__, "mldsa65_ca_cert.pem")
-      ctx.groups = "X25519MLKEM768"
-    end
-
-    ctx.verify_mode = config[:verify_mode] if config[:verify_mode]
-    @ssl_server = OpenSSL::SSL::SSLServer.new(server, ctx)
-    @ssl_server_thread = Thread.new do
-      loop do
-        ssl_client = @ssl_server.accept
-        Thread.new(ssl_client) do |client|
-          handle_request(client)
-        ensure
-          client.close
-        end
-      rescue OpenSSL::SSL::SSLError
-        # Ignore SSL errors because we're testing them implicitly
-      end
-    end
-    @ssl_server
-  end
-
-  def handle_request(client)
-    request = client.gets
-    if request.start_with?("GET /yaml")
-      client.print "HTTP/1.1 200 OK\r\nContent-Type: text/yaml\r\n\r\n--- true\n"
-    elsif request.start_with?("GET /insecure_redirect")
-      location = request.match(/to=([^ ]+)/)[1]
-      client.print "HTTP/1.1 301 Moved Permanently\r\nLocation: #{location}\r\n\r\n"
-    else
-      client.print "HTTP/1.1 404 Not Found\r\n\r\n"
-    end
-  end
-
-  def cert(filename)
-    OpenSSL::X509::Certificate.new(File.read(File.join(__dir__, filename)))
-  end
-
-  def key(filename)
-    OpenSSL::PKey.read(File.read(File.join(__dir__, filename)))
-  end
-
   def omit_unless_support_pqc
-    # PQC algorithms ML-KEM and ML-DSA require OpenSSL >= 3.5.
-    # https://openssl-library.org/post/2025-04-08-openssl-35-final-release/
-    omit "PQC algorithms require OpenSSL >= 3.5" unless
-      OpenSSL::OPENSSL_VERSION_NUMBER >= 0x30500000
-    # ctx.groups (OpenSSL::SSL::SSLContext#groups) used in start_ssl_server
-    # mode :pqc requires Ruby OpenSSL >= 4.0.
-    omit "PQC test requires Ruby OpenSSL >= 4.0" unless
-      Gem::Version.new(OpenSSL::VERSION) >= Gem::Version.new("4.0")
-    # Even with a new enough OpenSSL, the runtime may keep PQC groups and
-    # signature algorithms out of its default negotiation lists (for example
-    # RHEL's system-wide crypto policies). The PQC server forces both, while
-    # the gem fetcher connects with the default client configuration, so a
-    # real loopback handshake is the only reliable way to tell whether this
-    # environment can negotiate PQC at all.
-    omit "PQC handshake is not available in this OpenSSL configuration" unless
-      self.class.support_pqc_handshake?
-  end
-
-  # Probe an actual PQC handshake between a forced-PQC server and a
-  # default-configured client, mirroring what the integration tests exercise.
-  # Memoized so the probe runs at most once per process.
-  def self.support_pqc_handshake?
-    return @support_pqc_handshake unless @support_pqc_handshake.nil?
-
-    @support_pqc_handshake = probe_pqc_handshake
-  end
-
-  def self.probe_pqc_handshake
-    server = TCPServer.new("127.0.0.1", 0)
-    ctx = OpenSSL::SSL::SSLContext.new
-    ctx.cert = OpenSSL::X509::Certificate.new(File.read(File.join(__dir__, "mldsa65_ssl_cert.pem")))
-    ctx.key = OpenSSL::PKey.read(File.read(File.join(__dir__, "mldsa65_ssl_key.pem")))
-    ctx.groups = "X25519MLKEM768"
-    ssl_server = OpenSSL::SSL::SSLServer.new(server, ctx)
-
-    port = server.addr[1]
-    server_thread = Thread.new do
-      client = ssl_server.accept
-      client.close
-    rescue OpenSSL::OpenSSLError
-      nil
+    without_pqc_support do |message|
+      omit message
     end
-
-    client_ctx = OpenSSL::SSL::SSLContext.new
-    client_ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    socket = TCPSocket.new("127.0.0.1", port)
-    ssl = OpenSSL::SSL::SSLSocket.new(socket, client_ctx)
-    ssl.connect
-    ssl.close
-    true
-  rescue OpenSSL::OpenSSLError, SystemCallError
-    false
-  ensure
-    server_thread&.join(5)
-    server_thread&.kill if server_thread&.alive?
-    ssl_server&.close
-    server&.close
   end
 end if Gem::HAVE_OPENSSL


### PR DESCRIPTION
## Summary

This PR is related to https://github.com/ruby/rubygems/issues/9543. The first commit is the same with https://github.com/ruby/rubygems/pull/9615. I want to see the #9615 is reviewed and merged. After that, I will rebase this PR on the latest master branch. The second commit is this PR's commit.

Created spec/bundler/fetcher/gem_remote_fetcher_local_ssl_server_spec.rb adding non-PQC and PQC server/client connection integration tests.

As "Bundler::Fetcher local SSL server #connection PQC connects with client cert auth" failed with the following error due to hardcoded `OpenSSL::PKey::RSA.new` in `Bundler::Fetcher#connection`, fixed it to support ML-DSA ssl_client_cert.

```
$ bin/rspec spec/bundler/fetcher/gem_remote_fetcher_local_ssl_server_spec.rb
...
Failures:

  1) Bundler::Fetcher local SSL server #connection PQC connects with client cert auth
     Failure/Error: fetcher = Bundler::Fetcher.new(remote)

     OpenSSL::PKey::PKeyError:
       incorrect pkey type: UNDEF
     # /home/jaruga/.local/ruby-4.1.0-debug-3ef48ef9c8-openssl-4.1.0-7194354488/lib/ruby/4.1.0+1/openssl/pkey.rb:394:in 'OpenSSL::PKey::RSA#initialize'
     # /home/jaruga/.local/ruby-4.1.0-debug-3ef48ef9c8-openssl-4.1.0-7194354488/lib/ruby/4.1.0+1/openssl/pkey.rb:394:in 'Class#new'
     # /home/jaruga/.local/ruby-4.1.0-debug-3ef48ef9c8-openssl-4.1.0-7194354488/lib/ruby/4.1.0+1/openssl/pkey.rb:394:in 'OpenSSL::PKey::RSA.new'
     # ./bundler/lib/bundler/fetcher.rb:321:in 'Bundler::Fetcher#connection'
     # ./bundler/lib/bundler/fetcher.rb:140:in 'Bundler::Fetcher#initialize'
     # ./spec/bundler/fetcher/gem_remote_fetcher_local_ssl_server_spec.rb:69:in 'RSpec::ExampleGroups::BundlerFetcherLocalSSLServer#fetch_path'
     # ./spec/bundler/fetcher/gem_remote_fetcher_local_ssl_server_spec.rb:60:in 'block (4 levels) in <top (required)>'
...
```

Created test/rubygems/local_ssl_server_utilities.rb to manage utility methods
called by RubyGems test-unit and Bundler rspec tests.

Co-Authored-By: Claude <noreply@anthropic.com>

## Files

### spec/bundler/fetcher/gem_remote_fetcher_local_ssl_server_spec.rb

I aligned the file structure with `test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb`. I also referred to `spec/bundler/fetcher/gem_remote_fetcher_spec.rb`.

### test/rubygems/local_ssl_server_utilities.rb

For the file's naming, I referred to `test/rubygems/multifactor_auth_utilities.rb`, there are following files as support files, I think `test/rubygems/*_utilities.rb` file is suitable in this case in my opinion.

```
test/rubygems/helper.rb
test/rubygems/utilities.rb
test/rubygems/multifactor_auth_utilities.rb
test/rubygems/mock_gem_ui.rb
```

<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

`Bundler::Fetcher#connection` doesn't work with ML-DSA ssl_client_cert due to hardcoded `OpenSSL::PKey::RSA.new`.

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

Fixed the `Bundler::Fetcher#connection` to support ML-DSA ssl_client_cert.
Added integration HTTPS server/client connection tests.

## Make sure the following tasks are checked

- [X] Describe the problem / feature
- [X] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [X] Write code to solve the problem
- [X] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
