### PR TITLE
Stop silently dropping eligible PRs from patch release preparation

### DIFF
--- a/tool/release.rb
+++ b/tool/release.rb
@@ -178,19 +178,33 @@ class Release
   def prepare!
     initial_branch = `git rev-parse --abbrev-ref HEAD`.strip
 
+    # Refresh the upstream refs first so the release is cut from the latest
+    # origin state. A stale local `master` or stable branch would otherwise
+    # silently drop PRs merged after the last local fetch.
+    system("git", "fetch", "--prune", "origin", exception: true)
+
     check_git_state!
 
     unless @prerelease
-      create_if_not_exist_and_switch_to(@stable_branch, from: "master")
+      create_if_not_exist_and_switch_to(@stable_branch, from: "origin/master")
       system("git", "push", "origin", @stable_branch, exception: true) if @level == :minor_or_major && !ENV["DRYRUN"]
     end
 
-    from_branch = if @level == :minor_or_major && @prerelease
+    base_branch = if @level == :minor_or_major && @prerelease
       "master"
     else
       @stable_branch
     end
-    create_if_not_exist_and_switch_to(@release_branch, from: from_branch)
+
+    # The ref the release branch is cut from. Patch releases and prereleases
+    # branch straight off the upstream ref so a stale local copy can't leave
+    # commits behind; a new stable branch was just created locally above.
+    release_base = if @level == :minor_or_major
+      @prerelease ? "origin/master" : @stable_branch
+    else
+      "origin/#{@stable_branch}"
+    end
+    create_if_not_exist_and_switch_to(@release_branch, from: release_base)
 
     begin
       @bundler.set_relevant_pull_requests_from(unreleased_pull_requests)
@@ -204,14 +218,14 @@ class Release
 
       gh_client.create_pull_request(
         "ruby/rubygems",
-        from_branch,
+        base_branch,
         @release_branch,
         "Prepare RubyGems #{@rubygems.version} and Bundler #{@bundler.version}",
         release_pull_request_body
       ) unless ENV["DRYRUN"]
 
       unless @prerelease
-        create_if_not_exist_and_switch_to("cherry_pick_changelogs", from: "master")
+        create_if_not_exist_and_switch_to("cherry_pick_changelogs", from: "origin/master")
 
         begin
           system("git", "cherry-pick", bundler_changelog, rubygems_changelog, exception: true)
@@ -397,7 +411,7 @@ class Release
   # `unreleased_pr_ids` cannot see them and their changelog entries would
   # otherwise be dropped from the release.
   def stable_branch_backport_commits
-    `git log --format=%H #{@last_release_tag}..#{@stable_branch}`.split("\n").reject(&:empty?)
+    `git log --format=%H #{@last_release_tag}..origin/#{@stable_branch}`.split("\n").reject(&:empty?)
   end
 
   # Source SHAs already cherry-picked onto the stable branch, derived from the
@@ -408,7 +422,7 @@ class Release
   # through those commits left on master.
   def released_commit_shas
     @released_commit_shas ||= begin
-      log = `git log --format=%B #{@previous_release_tag}..#{@stable_branch}`
+      log = `git log --format=%B #{@previous_release_tag}..origin/#{@stable_branch}`
       shas = Set.new
       log.scan(/cherry picked from commit ([0-9a-f]+)/).flatten.each do |sha|
         shas << sha
@@ -435,7 +449,7 @@ class Release
   end
 
   def unreleased_pr_ids
-    head = @level == :minor_or_major ? "HEAD" : "master"
+    head = @level == :minor_or_major ? "HEAD" : "origin/master"
     commits = `git log --format=%H #{@previous_release_tag}..#{head}`.split("\n")
     commits.reject! {|sha| released_commit_shas.include?(sha) } if @level == :patch
     commits.concat(stable_branch_backport_commits) if @level == :patch

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -154,6 +154,10 @@ class Release
       "v#{@stable_branch}.0"
     end
 
+    # The most recent release on this line. For patch releases it bounds the
+    # search for backport PRs merged straight onto the stable branch since then.
+    @last_release_tag = @level == :patch ? "v#{@stable_branch}.#{segments[2] - 1}" : @previous_release_tag
+
     rubygems_version = segments.join(".").gsub(/([a-z])\.(\d)/i, '\1\2')
     @rubygems = Rubygems.new(rubygems_version, @stable_branch)
 
@@ -271,6 +275,11 @@ class Release
     prs = relevant_unreleased_pull_requests
     raise "No unreleased PRs were found. Make sure to tag them with appropriate labels so that they are selected for backport." unless prs.any?
 
+    # Dedicated backport PRs target the stable branch directly, so they are
+    # already on the release branch and only need a changelog entry, not
+    # another cherry-pick.
+    prs = prs.reject {|pr| already_on_stable_branch?(pr) }
+
     puts "The following unreleased prs were found:\n#{prs.map {|pr| "* #{pr.url}" }.join("\n")}"
 
     prs.each do |pr|
@@ -375,6 +384,22 @@ class Release
     @unreleased_pull_requests ||= scan_unreleased_pull_requests(unreleased_pr_ids)
   end
 
+  # True when the PR's merged commit is already reachable from the release
+  # branch, e.g. a backport PR merged straight onto the stable branch rather
+  # than cherry-picked from master.
+  def already_on_stable_branch?(pr)
+    system("git", "merge-base", "--is-ancestor", pr.merge_commit_sha, "HEAD", out: IO::NULL, err: IO::NULL)
+  end
+
+  # Commits merged directly onto the stable branch since the last release, such
+  # as dedicated backport PRs that target the stable branch instead of being
+  # cherry-picked from master. They never land on master, so the master scan in
+  # `unreleased_pr_ids` cannot see them and their changelog entries would
+  # otherwise be dropped from the release.
+  def stable_branch_backport_commits
+    `git log --format=%H #{@last_release_tag}..#{@stable_branch}`.split("\n").reject(&:empty?)
+  end
+
   # Source SHAs already cherry-picked onto the stable branch, derived from the
   # `(cherry picked from commit X)` footer that `git cherry-pick -x` records.
   # When the footer references a merge commit (PRs merged with "Create a merge
@@ -413,6 +438,7 @@ class Release
     head = @level == :minor_or_major ? "HEAD" : "master"
     commits = `git log --format=%H #{@previous_release_tag}..#{head}`.split("\n")
     commits.reject! {|sha| released_commit_shas.include?(sha) } if @level == :patch
+    commits.concat(stable_branch_backport_commits) if @level == :patch
 
     # GitHub search API has a rate limit of 30 requests per minute for authenticated users
     rate_limit = 28


### PR DESCRIPTION
The patch release scan only looked at master, so a fix merged straight onto the stable branch through a dedicated backport PR was never discovered and its changelog entry was lost. It now also scans the stable branch since the last release and skips cherry-picking those PRs because they are already on the release branch.

prepare! also branched off the local master and stable refs, so a clone that had not pulled the latest master left freshly merged PRs out of the release. It now fetches origin up front and works from the remote-tracking refs.
