### PR TITLE
Restrict the ruby-core sync shim to the legacy Bundler layout branches

### DIFF
--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -56,7 +56,7 @@ jobs:
           path: ruby/rubygems
           persist-credentials: false
         if: matrix.branch != 'ruby_3_4'
-      - name: Sync tools
+      - name: Adjust sync tool for the legacy Bundler layout
         run: |
           sed -i 's|\["bundler/spec", "spec/bundler"\]|["spec", "spec/bundler"]|' tool/sync_default_gems.rb
           sed -i 's|\["bundler/bin/#{binstub}", "spec/bin/#{binstub}"\]|["bin/#{binstub}", "spec/bin/#{binstub}"]|' tool/sync_default_gems.rb
@@ -70,6 +70,10 @@ jobs:
           sed -i 's|upstream}/bundler/lib/|upstream}/lib/|g' tool/sync_default_gems.rb
           sed -i 's|upstream}/bundler/exe/|upstream}/exe/|g' tool/sync_default_gems.rb
           sed -i 's|upstream}/bundler/bundler.gemspec|upstream}/bundler.gemspec|g' tool/sync_default_gems.rb
+        working-directory: ruby/ruby
+        if: matrix.branch != 'master'
+      - name: Sync tools
+        run: |
           ruby tool/sync_default_gems.rb rubygems
           mv spec/bundler/support/bundle spec/bin/bundle 2>/dev/null || true
         working-directory: ruby/ruby

--- a/.github/workflows/ruby-core.yml
+++ b/.github/workflows/ruby-core.yml
@@ -56,22 +56,26 @@ jobs:
           path: ruby/rubygems
           persist-credentials: false
         if: matrix.branch != 'ruby_3_4'
-      - name: Adjust sync tool for the legacy Bundler layout
+      - name: Adjust sync tool for the legacy Bundler layout (ruby_3_4)
+        run: |
+          sed -i 's|/bundler/spec"|/spec"|g' tool/sync_default_gems.rb
+          sed -i 's|/bundler/bin/|/bin/|g' tool/sync_default_gems.rb
+          sed -i 's|upstream}/bundler/lib/|upstream}/lib/|g' tool/sync_default_gems.rb
+          sed -i 's|upstream}/bundler/exe/|upstream}/exe/|g' tool/sync_default_gems.rb
+          sed -i 's|upstream}/bundler/bundler.gemspec|upstream}/bundler.gemspec|g' tool/sync_default_gems.rb
+        working-directory: ruby/ruby
+        if: matrix.branch == 'ruby_3_4'
+      - name: Adjust sync tool for the legacy Bundler layout (ruby_4_0)
         run: |
           sed -i 's|\["bundler/spec", "spec/bundler"\]|["spec", "spec/bundler"]|' tool/sync_default_gems.rb
           sed -i 's|\["bundler/bin/#{binstub}", "spec/bin/#{binstub}"\]|["bin/#{binstub}", "spec/bin/#{binstub}"]|' tool/sync_default_gems.rb
-          sed -i 's|/bundler/spec"|/spec"|g' tool/sync_default_gems.rb
-          sed -i 's|/bundler/bin/|/bin/|g' tool/sync_default_gems.rb
           sed -i 's|\["bundler/lib/bundler.rb", "lib/bundler.rb"\]|["lib/bundler.rb", "lib/bundler.rb"]|' tool/sync_default_gems.rb
           sed -i 's|\["bundler/lib/bundler", "lib/bundler"\]|["lib/bundler", "lib/bundler"]|' tool/sync_default_gems.rb
           sed -i 's|\["bundler/exe/bundle", "libexec/bundle"\]|["exe/bundle", "libexec/bundle"]|' tool/sync_default_gems.rb
           sed -i 's|\["bundler/exe/bundler", "libexec/bundler"\]|["exe/bundler", "libexec/bundler"]|' tool/sync_default_gems.rb
           sed -i 's|\["bundler/bundler.gemspec", "lib/bundler/bundler.gemspec"\]|["bundler.gemspec", "lib/bundler/bundler.gemspec"]|' tool/sync_default_gems.rb
-          sed -i 's|upstream}/bundler/lib/|upstream}/lib/|g' tool/sync_default_gems.rb
-          sed -i 's|upstream}/bundler/exe/|upstream}/exe/|g' tool/sync_default_gems.rb
-          sed -i 's|upstream}/bundler/bundler.gemspec|upstream}/bundler.gemspec|g' tool/sync_default_gems.rb
         working-directory: ruby/ruby
-        if: matrix.branch != 'master'
+        if: matrix.branch == 'ruby_4_0'
       - name: Sync tools
         run: |
           ruby tool/sync_default_gems.rb rubygems


### PR DESCRIPTION
ruby/ruby master now follows the flattened Bundler layout, so the sed shim that rewrote tool/sync_default_gems.rb before syncing no longer changes anything there. Running it for the master matrix branch is dead weight.

Guard the shim by branch instead. ruby_3_4 still syncs Bundler with cp_r-style source paths and ruby_4_0 still uses the bundler/-prefixed mappings, so each gets its own step matched to its branch. master needs neither and now runs the sync unmodified.

https://github.com/ruby/ruby/pull/17461
