### PR TITLE
Don't require pressing Return when selecting a gem

### DIFF
--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -95,8 +95,96 @@ module Bundler
       end
       Bundler.ui.info "0 : - exit -", true
 
-      num = Bundler.ui.ask("> ").to_i
-      num > 0 ? specs[num - 1] : nil
+      num = ask_for_number(specs.count)
+      num && num > 0 ? specs[num - 1] : nil
+    end
+
+    # Reads a menu selection in the range 0..max, returning the chosen number
+    # or nil if no selection was made (Ctrl-D/EOF). When stdin/stdout are a TTY,
+    # a choice is accepted on a single keypress as soon as it is unambiguous,
+    # i.e. no larger valid number has the typed digits as a prefix (so "1" is
+    # accepted instantly when there are < 10 options, but waits for a second
+    # digit when "10"/"11"/... are also valid). Enter resolves the prefix to
+    # the number typed so far (e.g. selecting "1" while "10" exists), backspace
+    # edits, and Ctrl-C aborts (exit 130). Falls back to a line-based prompt otherwise.
+    def self.ask_for_number(max)
+      return Bundler.ui.ask("> ").to_i unless single_keypress_supported?
+
+      buf = String.new
+      # The prompt, echo and newlines are written straight to $stdout (rather
+      # than through Bundler.ui) because this path only runs on an interactive
+      # TTY, where we need precise, unbuffered control over the cursor.
+      $stdout.print "> "
+      $stdout.flush
+
+      loop do
+        ch = $stdin.getch
+        # "No selection" -- the same outcome as choosing 0/exit -- via either a
+        # real EOF (nil, e.g. the terminal detached) or Ctrl-D, which getch's
+        # raw mode delivers as a byte (4 = EOT) rather than as EOF.
+        if ch.nil? || ch == 4.chr
+          $stdout.print "\n"
+          return
+        end
+        # Ctrl-C arrives as a raw byte because getch disables the terminal's
+        # signal keys. Re-raising Interrupt here would be re-rescued and printed
+        # by with_friendly_errors; instead exit with the conventional SIGINT
+        # status (130) so Bundler still terminates with proper signal semantics
+        # (see rubygems/bundler#6092) but without dumping a backtrace.
+        if ch == 3.chr
+          $stdout.print "\n"
+          exit(128 + Signal.list["INT"])
+        end
+
+        case ch
+        when "\r", "\n"
+          if valid_number?(buf, max)
+            $stdout.print "\n"
+            return buf.to_i
+          end
+        when "\u007f", "\b" # backspace / delete
+          unless buf.empty?
+            buf.chop!
+            $stdout.print "\b \b"
+            $stdout.flush
+          end
+        when /\A[0-9]\z/
+          candidate = buf + ch
+          # Ignore a digit that cannot lead to any valid selection.
+          next unless prefix_of_valid?(candidate, max)
+          buf = candidate
+          $stdout.print ch
+          $stdout.flush
+          if valid_number?(buf, max) && !has_longer_valid?(buf, max)
+            $stdout.print "\n"
+            return buf.to_i
+          end
+        end
+      end
+    end
+
+    def self.single_keypress_supported?
+      return false unless $stdin.tty? && $stdout.tty?
+      require "io/console"
+      $stdin.respond_to?(:getch)
+    rescue LoadError
+      false
+    end
+
+    # buf is exactly a valid token (no leading zeros) within 0..max.
+    def self.valid_number?(buf, max)
+      !buf.empty? && buf == buf.to_i.to_s && buf.to_i <= max
+    end
+
+    # Some valid token in 0..max starts with the typed digits (incl. equal).
+    def self.prefix_of_valid?(buf, max)
+      (0..max).any? {|i| i.to_s.start_with?(buf) }
+    end
+
+    # A *longer* valid token in 0..max starts with the typed digits, so the
+    # selection is still ambiguous (e.g. "1" while "10" is also valid).
+    def self.has_longer_valid?(buf, max)
+      (0..max).any? {|i| i.to_s != buf && i.to_s.start_with?(buf) }
     end
 
     def self.gem_not_found_message(missing_gem_name, alternatives)

--- a/spec/bundler/cli_common_spec.rb
+++ b/spec/bundler/cli_common_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/cli"
+require "stringio"
 
 RSpec.describe Bundler::CLI::Common do
   describe "gem_not_found_message" do
@@ -17,6 +18,85 @@ RSpec.describe Bundler::CLI::Common do
       expect(message).to match("Did you mean 'nokogiri'?")
       message = subject.gem_not_found_message("methosd", %w[method methods bogus])
       expect(message).to match(/Did you mean 'method(|s)' or 'method(|s)'?/)
+    end
+  end
+
+  describe "ask_for_number" do
+    BACKSPACE = 127.chr # DEL
+    CTRL_C = 3.chr      # ETX
+    CTRL_D = 4.chr      # EOT
+
+    # Run ask_for_number against a scripted sequence of keypresses, with the
+    # single-keypress path forced on and $stdin/$stdout swapped for fakes.
+    def select(keys, max)
+      allow(described_class).to receive(:single_keypress_supported?).and_return(true)
+      input = double("stdin")
+      allow(input).to receive(:getch).and_return(*keys)
+
+      old_stdin = $stdin
+      old_stdout = $stdout
+      $stdin = input
+      $stdout = StringIO.new
+      described_class.ask_for_number(max)
+    ensure
+      $stdin = old_stdin
+      $stdout = old_stdout
+    end
+
+    context "when no option number is a prefix of another (fewer than ten options)" do
+      it "accepts a choice on a single keypress, without Enter" do
+        expect(select(["1"], 3)).to eq(1)
+        expect(select(["3"], 3)).to eq(3)
+      end
+
+      it "treats 0 as the exit choice" do
+        expect(select(["0"], 3)).to eq(0)
+      end
+
+      it "ignores a digit that cannot match any option" do
+        expect(select(["8", "2"], 3)).to eq(2)
+      end
+    end
+
+    context "when an option number is a prefix of another (ten or more options)" do
+      it "waits for a second digit before resolving an ambiguous prefix" do
+        expect(select(["1", "0"], 11)).to eq(10)
+        expect(select(["1", "1"], 11)).to eq(11)
+      end
+
+      it "still accepts an unambiguous digit immediately" do
+        expect(select(["7"], 11)).to eq(7)
+        expect(select(["0"], 11)).to eq(0)
+      end
+
+      it "resolves the shorter number when Enter is pressed" do
+        expect(select(["1", "\r"], 11)).to eq(1)
+        expect(select(["1", "\n"], 11)).to eq(1)
+      end
+    end
+
+    it "supports backspace to edit the buffer" do
+      expect(select(["1", BACKSPACE, "3"], 11)).to eq(3)
+    end
+
+    it "aborts with the conventional SIGINT status (130) on Ctrl-C" do
+      expect { select([CTRL_C], 3) }.to raise_error(SystemExit) do |error|
+        expect(error.status).to eq(130)
+      end
+    end
+
+    it "returns nil at EOF instead of looping" do
+      expect(select([nil], 3)).to be_nil
+    end
+
+    it "cancels (returns nil) on Ctrl-D" do
+      expect(select([CTRL_D], 3)).to be_nil
+    end
+
+    it "falls back to a line prompt when single keypress input is unsupported" do
+      allow(described_class).to receive(:single_keypress_supported?).and_return(false)
+      allow(Bundler.ui).to receive(:ask).with("> ").and_return("2")
+      expect(described_class.ask_for_number(3)).to eq(2)
     end
   end
 end


### PR DESCRIPTION
I opened [this discussion](https://github.com/ruby/rubygems/discussions/9609) a few weeks ago but it didn't get a response yet - so following up with a concrete implementation to make the proposal easier to evaluate. Happy to adjust the approach based on feedback.

## What was the end-user or developer problem that led to this PR?

When using commands `info`, `show`, `open` with an ambiguous search-term (e.g. `bundle show rspec`), a menu with numbered candidates is shown. Selecting one always required confirming with <kbd>Return</kbd>, which adds friction to what is usually a single-digit choice.

## What is your fix for the problem, implemented in this PR?

The menu now accepts a selection on a single keypress, so no extra <kbd>Return</kbd> is needed in the common case:
- ≤ 9 options → any digit selects immediately, no <kbd>Return</kbd>.
- ≥ 10 options → only digits that are a prefix of a larger number wait (e.g. 1 when 10/11 exist); everything else (2–9, 0) still fires instantly. <kbd>Return</kbd> resolves the prefix to what's typed so far (e.g.
selecting 1 while 10 exists). Backspace edits the entry, digits that can't lead to any valid option are ignored.

Terminal control keys behave conventionally:

- <kbd>Ctrl-C</kbd> aborts with the standard SIGINT exit status (130), without printing a backtrace. (It can't simply re-raise Interrupt, because with_friendly_errors re-raises SignalException to the interpreter (see rubygems/bundler#6092) - which would dump a backtrace; so it exits explicitly with 128 + SIGINT.)
- <kbd>Ctrl-D</kbd> / EOF cancels (no selection), exiting 0. This matches the previous line-based prompt, where EOF made nil.to_i return 0.

The single-keypress path is only used when both stdin and stdout are a TTY and io/console is available. Otherwise (piped input, non-interactive shells, CI) it falls back to the existing line-based prompt, so scripted usage and existing specs are unaffected.

The discussion raised whether this should be opt-in via configuration. I've kept it on by default, since the non-TTY fallback means scripts and CI are unaffected and the change to interactive use is minimal. I'm happy to gate it behind a config setting if maintainers prefer.


## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
