### PR TITLE
Point Bundler gemspec metadata at the moved docs

### DIFF
--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/ruby/rubygems/issues?q=is%3Aopen+is%3Aissue+label%3ABundler",
-    "changelog_uri" => "https://github.com/ruby/rubygems/blob/master/bundler/CHANGELOG.md",
+    "changelog_uri" => "https://github.com/ruby/rubygems/blob/master/CHANGELOG-bundler.md",
     "homepage_uri" => "https://bundler.io/",
-    "source_code_uri" => "https://github.com/ruby/rubygems/tree/master/bundler",
+    "source_code_uri" => "https://github.com/ruby/rubygems",
   }
 
   s.required_ruby_version     = ">= 3.2.0"


### PR DESCRIPTION
Bundler's docs moved to the top level on master as CHANGELOG-bundler.md and the source tree is no longer under bundler/. Backport the metadata-only part of that change so the published 4.0 gem points changelog_uri and source_code_uri at the current master locations.

This excludes the s.files and spec helper changes from the original commit since 4.0 keeps the older flat layout. The URIs target the master branch on GitHub, so they resolve to the new doc layout regardless of the 4.0 tree.

Closes https://github.com/ruby/rubygems/issues/9645

https://github.com/ruby/rubygems/commit/db533d1651
