### PR TITLE
Follow-ups to including ruby platform variants in the lock file

### DIFF
--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -225,14 +225,27 @@ module Bundler
       overrides = @definition.overrides
       @definition.specs.each do |spec|
         unless spec.matches_current_ruby_with_overrides?(overrides)
-          raise InstallError, "#{spec.full_name} requires ruby version #{spec.required_ruby_version}, " \
-            "which is incompatible with the current version, #{Gem.ruby_version}"
+          raise InstallError, incompatibility_message(spec, "requires ruby version #{spec.required_ruby_version}, " \
+            "which is incompatible with the current version, #{Gem.ruby_version}")
         end
         unless spec.matches_current_rubygems_with_overrides?(overrides)
-          raise InstallError, "#{spec.full_name} requires rubygems version #{spec.required_rubygems_version}, " \
-            "which is incompatible with the current version, #{Gem.rubygems_version}"
+          raise InstallError, incompatibility_message(spec, "requires rubygems version #{spec.required_rubygems_version}, " \
+            "which is incompatible with the current version, #{Gem.rubygems_version}")
         end
       end
+    end
+
+    # Build the error raised when a locked spec can't run on the current Ruby or
+    # RubyGems. When the offending spec is a platform-specific variant locked in
+    # frozen mode, point users at the fix: re-resolving outside frozen mode adds
+    # the Ruby (non platform-specific) fallback variant to the lockfile.
+    def incompatibility_message(spec, reason)
+      message = "#{spec.full_name} #{reason}"
+      return message unless Bundler.frozen_bundle? && spec.platform != Gem::Platform::RUBY
+
+      message + "\n\nThe lockfile only includes the #{spec.platform} variant of #{spec.name}. " \
+        "If a compatible Ruby variant is available, run `bundle install` outside of frozen/deployment mode " \
+        "to add it to the lockfile as a fallback, then commit the updated #{SharedHelpers.relative_lockfile_path}."
     end
 
     def lock

--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -192,7 +192,7 @@ module Bundler
     end
 
     def find_compatible_platform_spec(specs, locked_platforms: nil)
-      candidate_platforms(locked_platforms).each do |plat|
+      candidate_platforms(locked_platforms: locked_platforms).each do |plat|
         candidates = MatchPlatform.select_best_platform_match(specs, plat)
         spec = choose_compatible(candidates, fallback_to_non_installable: false)
         return spec if spec
@@ -204,7 +204,7 @@ module Bundler
     # requires compilation, but works when precompiled gems are incompatible.
     # When a set of locked platforms is given (frozen mode), restrict the
     # candidates to those, so we never materialize a platform that wasn't locked.
-    def candidate_platforms(locked_platforms = nil)
+    def candidate_platforms(locked_platforms: nil)
       target = source.is_a?(Source::Path) ? platform : Bundler.local_platform
       platforms = [target, platform, Gem::Platform::RUBY].uniq
       return platforms unless locked_platforms

--- a/lib/bundler/lazy_specification.rb
+++ b/lib/bundler/lazy_specification.rb
@@ -10,7 +10,7 @@ module Bundler
 
     attr_reader :name, :version, :platform, :materialization
     attr_accessor :source, :remote, :force_ruby_platform, :dependencies, :required_ruby_version, :required_rubygems_version
-    attr_accessor :overrides, :locked_platforms
+    attr_accessor :overrides
 
     #
     # For backwards compatibility with existing lockfiles, if the most specific
@@ -50,7 +50,6 @@ module Bundler
       @force_ruby_platform = default_force_ruby_platform
       @most_specific_locked_platform = nil
       @materialization = nil
-      @locked_platforms = nil
     end
 
     def missing?
@@ -131,13 +130,13 @@ module Bundler
       materialize(self, &:first)
     end
 
-    def materialized_for_installation
-      @materialization = materialize_for_installation
+    def materialized_for_installation(locked_platforms = nil)
+      @materialization = materialize_for_installation(locked_platforms)
 
       self unless incomplete?
     end
 
-    def materialize_for_installation
+    def materialize_for_installation(locked_platforms)
       source.local!
 
       if use_exact_resolved_specifications?
@@ -147,7 +146,7 @@ module Bundler
         # Exact spec is incompatible; in frozen mode, try to find a compatible platform variant
         # In non-frozen mode, return nil to trigger re-resolution and lockfile update
         if Bundler.frozen_bundle?
-          materialize([name, version]) {|specs| resolve_best_platform(specs, locked_platforms_only: true) }
+          materialize([name, version]) {|specs| resolve_best_platform(specs, locked_platforms: locked_platforms) }
         end
       else
         materialize([name, version]) {|specs| resolve_best_platform(specs) }
@@ -188,12 +187,12 @@ module Bundler
     # Try platforms in order of preference until finding a compatible spec.
     # Used for legacy lockfiles and as a fallback when the exact locked spec
     # is incompatible. Falls back to frozen bundle behavior if none match.
-    def resolve_best_platform(specs, locked_platforms_only: false)
-      find_compatible_platform_spec(specs, locked_platforms_only: locked_platforms_only) || frozen_bundle_fallback(specs)
+    def resolve_best_platform(specs, locked_platforms: nil)
+      find_compatible_platform_spec(specs, locked_platforms: locked_platforms) || frozen_bundle_fallback(specs)
     end
 
-    def find_compatible_platform_spec(specs, locked_platforms_only: false)
-      candidate_platforms(locked_platforms_only: locked_platforms_only).each do |plat|
+    def find_compatible_platform_spec(specs, locked_platforms: nil)
+      candidate_platforms(locked_platforms).each do |plat|
         candidates = MatchPlatform.select_best_platform_match(specs, plat)
         spec = choose_compatible(candidates, fallback_to_non_installable: false)
         return spec if spec
@@ -203,10 +202,12 @@ module Bundler
 
     # Platforms to try in order of preference. Ruby platform is last since it
     # requires compilation, but works when precompiled gems are incompatible.
-    def candidate_platforms(locked_platforms_only: false)
+    # When a set of locked platforms is given (frozen mode), restrict the
+    # candidates to those, so we never materialize a platform that wasn't locked.
+    def candidate_platforms(locked_platforms = nil)
       target = source.is_a?(Source::Path) ? platform : Bundler.local_platform
       platforms = [target, platform, Gem::Platform::RUBY].uniq
-      return platforms unless locked_platforms_only && locked_platforms
+      return platforms unless locked_platforms
 
       platforms & locked_platforms
     end

--- a/lib/bundler/match_platform.rb
+++ b/lib/bundler/match_platform.rb
@@ -15,9 +15,9 @@ module Bundler
       Gem::Platform.sort_and_filter_best_platform_match(matching, platform)
     end
 
-    def self.select_best_local_platform_match(specs, force_ruby: false)
+    def self.select_best_local_platform_match(specs, force_ruby: false, locked_platforms: nil)
       local = Bundler.local_platform
-      matching = select_all_platform_match(specs, local, force_ruby: force_ruby).filter_map(&:materialized_for_installation)
+      matching = select_all_platform_match(specs, local, force_ruby: force_ruby).filter_map {|spec| spec.materialized_for_installation(locked_platforms) }
 
       Gem::Platform.sort_best_platform_match(matching, local)
     end

--- a/lib/bundler/materialization.rb
+++ b/lib/bundler/materialization.rb
@@ -12,7 +12,7 @@ module Bundler
       @dep = dep
       @platform = platform
       @candidates = candidates
-      set_locked_platforms
+      @locked_platforms = candidates&.map(&:platform)
     end
 
     def complete?
@@ -25,7 +25,7 @@ module Bundler
       elsif platform
         MatchPlatform.select_best_platform_match(@candidates, platform, force_ruby: dep.force_ruby_platform)
       else
-        MatchPlatform.select_best_local_platform_match(@candidates, force_ruby: dep.force_ruby_platform || dep.default_force_ruby_platform)
+        MatchPlatform.select_best_local_platform_match(@candidates, force_ruby: dep.force_ruby_platform || dep.default_force_ruby_platform, locked_platforms: @locked_platforms)
       end
     end
 
@@ -56,14 +56,5 @@ module Bundler
     private
 
     attr_reader :dep, :platform
-
-    def set_locked_platforms
-      return unless @candidates
-
-      platforms = @candidates.map(&:platform)
-      @candidates.each do |candidate|
-        candidate.locked_platforms = platforms if candidate.respond_to?(:locked_platforms=)
-      end
-    end
   end
 end

--- a/spec/install/gemfile/specific_platform_spec.rb
+++ b/spec/install/gemfile/specific_platform_spec.rb
@@ -352,6 +352,8 @@ RSpec.describe "bundle install with specific platforms" do
         bundle "install --verbose", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
         expect(exitstatus).not_to eq(0)
         expect(err).to include("nokogiri-1.18.10-x86_64-linux requires ruby version < #{Gem.ruby_version}")
+        expect(err).to include("The lockfile only includes the x86_64-linux variant of nokogiri")
+        expect(err).to include("run `bundle install` outside of frozen/deployment mode")
       end
     end
   end

--- a/spec/install/gemfile/specific_platform_spec.rb
+++ b/spec/install/gemfile/specific_platform_spec.rb
@@ -356,6 +356,43 @@ RSpec.describe "bundle install with specific platforms" do
         expect(err).to include("run `bundle install` outside of frozen/deployment mode")
       end
     end
+
+    it "does not suggest a ruby fallback variant when the locked incompatible variant is already the ruby variant" do
+      build_repo4 do
+        build_gem "nokogiri", "1.18.10" do |s|
+          s.required_ruby_version = "< #{Gem.ruby_version}"
+        end
+      end
+
+      gemfile <<~G
+        source "https://gem.repo4"
+
+        gem "nokogiri"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo4/
+          specs:
+            nokogiri (1.18.10)
+
+        PLATFORMS
+          x86_64-linux
+
+        DEPENDENCIES
+          nokogiri
+
+        BUNDLED WITH
+          #{Bundler::VERSION}
+      L
+
+      simulate_platform "x86_64-linux" do
+        bundle "install --verbose", env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+        expect(exitstatus).not_to eq(0)
+        expect(err).to include("nokogiri-1.18.10 requires ruby version < #{Gem.ruby_version}")
+        expect(err).not_to include("The lockfile only includes")
+      end
+    end
   end
 
   it "doesn't discard previously installed platform specific gem and fall back to ruby on subsequent bundles" do


### PR DESCRIPTION
These are small follow-ups to #9556 that came out of review. The feature semantics stay the same. Only the implementation and the error path change.

Materialization no longer mutates the shared LazySpecification candidates from its constructor. It now computes the locked platform set and threads it through materialization to where the candidate platforms are restricted, which removes the respond_to?(:locked_platforms=) guard and the now-unused accessor.

When frozen mode has only an incompatible platform-specific variant locked, install used to fail with no hint about the fix. The error now points users at re-resolving outside frozen mode, which adds the ruby variant to the lockfile as a fallback.
