### PR TITLE
Make JRuby OutOfMemoryError friendly error spec deterministic

### DIFF
--- a/spec/bundler/friendly_errors_spec.rb
+++ b/spec/bundler/friendly_errors_spec.rb
@@ -133,11 +133,9 @@ RSpec.describe Bundler, "friendly errors" do
 
     context "Java::JavaLang::OutOfMemoryError", :jruby_only do
       it "Bundler.ui receive error" do
-        install_gemfile <<-G, raise_on_error: false, env: { "JRUBY_OPTS" => "-J-Xmx32M" }, artifice: nil
-          source "https://gem.repo1"
-        G
-
-        expect(err).to include("JVM has run out of memory")
+        error = Java::JavaLang::OutOfMemoryError.new
+        expect(Bundler.ui).to receive(:error).with(/JVM has run out of memory/)
+        Bundler::FriendlyErrors.log_error(error)
       end
     end
 


### PR DESCRIPTION
The JRuby-only OutOfMemoryError example in the friendly errors spec ran a real bundle install under a 32M JVM heap and asserted that Bundler caught the OOM and printed its friendly message. At that heap size the outcome is a knife-edge. Sometimes a Ruby-level Java::JavaLang::OutOfMemoryError is raised and Bundler's handler runs, and sometimes the JVM dies during boot so the JRuby launcher prints its own safety-cap message before Bundler's rescue runs. As a result the example flaked on the Ubuntu JRuby CI job while macOS and Windows JRuby passed.

This drives Bundler::FriendlyErrors.log_error directly with a Java::JavaLang::OutOfMemoryError instance and asserts on the message sent to Bundler.ui, mirroring the sibling log_error examples in the same file. It still verifies the OutOfMemoryError to friendly-message mapping while removing all dependence on JVM memory pressure.
