### PR TITLE
Forward-port Windows fixes from ruby/ruby

### DIFF
--- a/lib/rubygems/util/atomic_file_writer.rb
+++ b/lib/rubygems/util/atomic_file_writer.rb
@@ -26,6 +26,16 @@ module Gem
       basename = File.basename(file_name)
       tmp_path = File.join(dirname, ".#{basename.byteslice(0, 254 - tmp_suffix.bytesize)}#{tmp_suffix}")
 
+      # The temporary name is longer than the final one, so on Windows a
+      # writable destination can still map to a path beyond the 260-character
+      # MAX_PATH limit. Only in that case, trim the random suffix just enough to
+      # fit, keeping at least 8 hex characters to avoid collisions.
+      if tmp_path.length >= 260 && Gem.win_platform?
+        keep = [tmp_suffix.bytesize - (tmp_path.length - 259), ".tmp.".bytesize + 8].max
+        tmp_suffix = tmp_suffix.byteslice(0, keep)
+        tmp_path = File.join(dirname, ".#{basename.byteslice(0, 254 - tmp_suffix.bytesize)}#{tmp_suffix}")
+      end
+
       flags = File::RDWR | File::CREAT | File::EXCL | File::BINARY
       flags |= File::SHARE_DELETE if defined?(File::SHARE_DELETE)
 

--- a/lib/rubygems/util/atomic_file_writer.rb
+++ b/lib/rubygems/util/atomic_file_writer.rb
@@ -24,16 +24,22 @@ module Gem
       tmp_suffix = ".tmp.#{SecureRandom.hex}"
       dirname = File.dirname(file_name)
       basename = File.basename(file_name)
-      tmp_path = File.join(dirname, ".#{basename.byteslice(0, 254 - tmp_suffix.bytesize)}#{tmp_suffix}")
+      base_slice = basename.byteslice(0, 254 - tmp_suffix.bytesize)
+      tmp_path = File.join(dirname, ".#{base_slice}#{tmp_suffix}")
 
       # The temporary name is longer than the final one, so on Windows a
       # writable destination can still map to a path beyond the 260-character
-      # MAX_PATH limit. Only in that case, trim the random suffix just enough to
-      # fit, keeping at least 8 hex characters to avoid collisions.
+      # MAX_PATH limit. Trim the random suffix first, keeping at least 8 hex
+      # characters to avoid collisions, then shorten the basename if that is not
+      # enough. Recomputing the basename from the trimmed suffix would just let
+      # it grow back, so trim the already-sliced basename instead.
       if tmp_path.length >= 260 && Gem.win_platform?
-        keep = [tmp_suffix.bytesize - (tmp_path.length - 259), ".tmp.".bytesize + 8].max
-        tmp_suffix = tmp_suffix.byteslice(0, keep)
-        tmp_path = File.join(dirname, ".#{basename.byteslice(0, 254 - tmp_suffix.bytesize)}#{tmp_suffix}")
+        overflow = tmp_path.length - 259
+        trim = [tmp_suffix.bytesize - (".tmp.".bytesize + 8), overflow].min
+        tmp_suffix = tmp_suffix.byteslice(0, tmp_suffix.bytesize - trim)
+        overflow -= trim
+        base_slice = base_slice.byteslice(0, [base_slice.bytesize - overflow, 0].max) if overflow > 0
+        tmp_path = File.join(dirname, ".#{base_slice}#{tmp_suffix}")
       end
 
       flags = File::RDWR | File::CREAT | File::EXCL | File::BINARY

--- a/spec/bundler/cli_spec.rb
+++ b/spec/bundler/cli_spec.rb
@@ -237,6 +237,7 @@ RSpec.describe "bundle executable" do
     context "when the latest version is greater than the current version" do
       let(:latest_version) { "222.0" }
       it "prints the version warning" do
+        skip "temp dir is on a different drive than the source tree" if tmp_and_source_on_different_drives?
         bundle "fail", env: { "BUNDLER_VERSION" => bundler_version }, raise_on_error: false
         expect(err).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.
@@ -264,6 +265,7 @@ To update to the most recent version, run `bundle update --bundler`
       context "and is a pre-release" do
         let(:latest_version) { "222.0.0.pre.4" }
         it "prints the version warning" do
+          skip "temp dir is on a different drive than the source tree" if tmp_and_source_on_different_drives?
           bundle "fail", env: { "BUNDLER_VERSION" => bundler_version }, raise_on_error: false
           expect(err).to start_with(<<-EOS.strip)
 The latest bundler is #{latest_version}, but you are currently running #{bundler_version}.

--- a/spec/bundler/env_spec.rb
+++ b/spec/bundler/env_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe Bundler::Env do
       let(:output) { described_class.report(print_gemfile: true) }
 
       it "prints the config with redacted values" do
+        skip "temp dir is on a different drive than the source tree" if tmp_and_source_on_different_drives?
         expect(output).to include("https://localgemserver.test")
         expect(output).to include("user:[REDACTED]")
         expect(output).to_not include("user:pass")
@@ -131,6 +132,7 @@ RSpec.describe Bundler::Env do
       let(:output) { described_class.report(print_gemfile: true) }
 
       it "prints the config with redacted values" do
+        skip "temp dir is on a different drive than the source tree" if tmp_and_source_on_different_drives?
         expect(output).to include("https://localgemserver.test")
         expect(output).to include("[REDACTED]:x-oauth-basic")
         expect(output).to_not include("api_token:x-oauth-basic")

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Bundler::ParallelInstaller do
       # The make jobserver is a GNU make feature. On Windows extensions are built
       # with nmake, which has no `-j` jobserver, so the per-gem slot count never
       # appears in the build output.
-      skip "The make jobserver is not available on Windows (nmake)" if Gem.win_platform?
+      skip "The make jobserver is not available on Windows (nmake)" if /mswin/.match?(RUBY_PLATFORM)
 
       # When run under a parent make that already passes `-j` (e.g. ruby/ruby's
       # `make test-bundler-parallel`), RubyGems' extension builder sees the

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Bundler::ParallelInstaller do
       # The make jobserver is a GNU make feature. On Windows extensions are built
       # with nmake, which has no `-j` jobserver, so the per-gem slot count never
       # appears in the build output.
-      skip "The make jobserver is not available on Windows (nmake)" if /mswin/.match?(RUBY_PLATFORM)
+      skip "The make jobserver is not available on Windows (nmake)" if RUBY_PLATFORM.include?("mswin")
 
       # When run under a parent make that already passes `-j` (e.g. ruby/ruby's
       # `make test-bundler-parallel`), RubyGems' extension builder sees the

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Bundler::ParallelInstaller do
       # The make jobserver is a GNU make feature. On Windows extensions are built
       # with nmake, which has no `-j` jobserver, so the per-gem slot count never
       # appears in the build output.
-      skip "The make jobserver is not available on Windows (nmake)" if RUBY_PLATFORM.include?("mswin")
+      skip "The make jobserver is not available on Windows (nmake)" if mswin?
 
       # When run under a parent make that already passes `-j` (e.g. ruby/ruby's
       # `make test-bundler-parallel`), RubyGems' extension builder sees the

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -83,6 +83,11 @@ RSpec.describe Bundler::ParallelInstaller do
         skip "This example is runnable when RubyGems::Installer implements `build_jobs`"
       end
 
+      # The make jobserver is a GNU make feature. On Windows extensions are built
+      # with nmake, which has no `-j` jobserver, so the per-gem slot count never
+      # appears in the build output.
+      skip "The make jobserver is not available on Windows (nmake)" if Gem.win_platform?
+
       # When run under a parent make that already passes `-j` (e.g. ruby/ruby's
       # `make test-bundler-parallel`), RubyGems' extension builder sees the
       # inherited MAKEFLAGS as "jobs already requested" and skips appending its

--- a/spec/bundler/lockfile_parser_spec.rb
+++ b/spec/bundler/lockfile_parser_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Bundler::LockfileParser do
     let(:platforms) { [Gem::Platform::RUBY] }
     let(:bundler_version) { Gem::Version.new("1.12.0.rc.2") }
     let(:ruby_version) { "ruby 2.1.3p242" }
-    let(:lockfile_path) { Bundler.default_lockfile.relative_path_from(Dir.pwd) }
+    let(:lockfile_path) { Bundler::SharedHelpers.relative_lockfile_path }
     let(:rake_sha256_checksum) do
       Bundler::Checksum.from_lock(
         "sha256=814828c34f1315d7e7b7e8295184577cc4e969bad6156ac069d02d63f58d82e8",

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Bundler::SharedHelpers do
   describe "#default_bundle_dir" do
     context ".bundle does not exist" do
       it "returns nil" do
+        skip "temp dir is on a different drive than the source tree" if tmp_and_source_on_different_drives?
         expect(subject.default_bundle_dir).to be_nil
       end
     end

--- a/spec/commands/cache_spec.rb
+++ b/spec/commands/cache_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "prints a warn when using legacy windows rubies" do
-      skip "the legacy windows platform gem is not cached for the current mswin platform" if Gem.win_platform?
+      skip "the legacy windows platform gem is not cached for the current mswin platform" if /mswin/.match?(RUBY_PLATFORM)
       gemfile <<-D
         source "https://gem.repo1"
         gem 'myrack', :platforms => [:ruby_20, :x64_mingw_20]

--- a/spec/commands/cache_spec.rb
+++ b/spec/commands/cache_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "prints a warn when using legacy windows rubies" do
+      skip "the legacy windows platform gem is not cached for the current mswin platform" if Gem.win_platform?
       gemfile <<-D
         source "https://gem.repo1"
         gem 'myrack', :platforms => [:ruby_20, :x64_mingw_20]

--- a/spec/commands/cache_spec.rb
+++ b/spec/commands/cache_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "prints a warn when using legacy windows rubies" do
-      skip "the legacy windows platform gem is not cached for the current mswin platform" if /mswin/.match?(RUBY_PLATFORM)
+      skip "the legacy windows platform gem is not cached for the current mswin platform" if RUBY_PLATFORM.include?("mswin")
       gemfile <<-D
         source "https://gem.repo1"
         gem 'myrack', :platforms => [:ruby_20, :x64_mingw_20]

--- a/spec/commands/cache_spec.rb
+++ b/spec/commands/cache_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "bundle cache" do
     end
 
     it "prints a warn when using legacy windows rubies" do
-      skip "the legacy windows platform gem is not cached for the current mswin platform" if RUBY_PLATFORM.include?("mswin")
+      skip "the legacy windows platform gem is not cached for the current mswin platform" if mswin?
       gemfile <<-D
         source "https://gem.repo1"
         gem 'myrack', :platforms => [:ruby_20, :x64_mingw_20]

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "works when exec'ing to rubygems" do
-    skip "https://github.com/ruby/rubygems/issues/3351" if RUBY_PLATFORM.include?("mswin")
+    skip "https://github.com/ruby/rubygems/issues/3351" if mswin?
     install_gemfile "source \"https://gem.repo1\"; gem \"myrack\""
     bundle "exec #{gem_cmd} --version"
     expect(out).to eq(Gem::VERSION)
@@ -205,7 +205,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses version provided by ruby" do
-        skip "https://github.com/ruby/rubygems/issues/3351" if RUBY_PLATFORM.include?("mswin")
+        skip "https://github.com/ruby/rubygems/issues/3351" if mswin?
         bundle "exec erb --version"
 
         expect(stdboth).to eq(default_erb_version)
@@ -634,7 +634,7 @@ RSpec.describe "bundle exec" do
 
   describe "with gems bundled via :path with invalid gemspecs" do
     it "outputs the gemspec validation errors" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if RUBY_PLATFORM.include?("mswin")
+      skip "https://github.com/ruby/rubygems/issues/3351" if mswin?
       build_lib "foo"
 
       gemspec = lib_path("foo-1.0").join("foo.gemspec").to_s
@@ -695,7 +695,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "works" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if RUBY_PLATFORM.include?("mswin")
+      skip "https://github.com/ruby/rubygems/issues/3351" if mswin?
       bundle "exec #{gem_cmd} uninstall foo"
       expect(out).to eq("Successfully uninstalled foo-1.0")
     end
@@ -717,7 +717,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "does not load plugins outside of the bundle" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if RUBY_PLATFORM.include?("mswin")
+      skip "https://github.com/ruby/rubygems/issues/3351" if mswin?
       bundle "exec #{gem_cmd} -v"
       expect(out).not_to include("FAIL")
     end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "works when exec'ing to rubygems" do
+    skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
     install_gemfile "source \"https://gem.repo1\"; gem \"myrack\""
     bundle "exec #{gem_cmd} --version"
     expect(out).to eq(Gem::VERSION)
@@ -204,6 +205,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses version provided by ruby" do
+        skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
         bundle "exec erb --version"
 
         expect(stdboth).to eq(default_erb_version)
@@ -632,6 +634,7 @@ RSpec.describe "bundle exec" do
 
   describe "with gems bundled via :path with invalid gemspecs" do
     it "outputs the gemspec validation errors" do
+      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
       build_lib "foo"
 
       gemspec = lib_path("foo-1.0").join("foo.gemspec").to_s
@@ -692,6 +695,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "works" do
+      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
       bundle "exec #{gem_cmd} uninstall foo"
       expect(out).to eq("Successfully uninstalled foo-1.0")
     end
@@ -713,6 +717,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "does not load plugins outside of the bundle" do
+      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
       bundle "exec #{gem_cmd} -v"
       expect(out).not_to include("FAIL")
     end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "works when exec'ing to rubygems" do
-    skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+    skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
     install_gemfile "source \"https://gem.repo1\"; gem \"myrack\""
     bundle "exec #{gem_cmd} --version"
     expect(out).to eq(Gem::VERSION)
@@ -205,7 +205,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses version provided by ruby" do
-        skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+        skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
         bundle "exec erb --version"
 
         expect(stdboth).to eq(default_erb_version)
@@ -634,7 +634,7 @@ RSpec.describe "bundle exec" do
 
   describe "with gems bundled via :path with invalid gemspecs" do
     it "outputs the gemspec validation errors" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+      skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
       build_lib "foo"
 
       gemspec = lib_path("foo-1.0").join("foo.gemspec").to_s
@@ -695,7 +695,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "works" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+      skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
       bundle "exec #{gem_cmd} uninstall foo"
       expect(out).to eq("Successfully uninstalled foo-1.0")
     end
@@ -717,7 +717,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "does not load plugins outside of the bundle" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if Gem.win_platform?
+      skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
       bundle "exec #{gem_cmd} -v"
       expect(out).not_to include("FAIL")
     end

--- a/spec/commands/exec_spec.rb
+++ b/spec/commands/exec_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "bundle exec" do
   end
 
   it "works when exec'ing to rubygems" do
-    skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
+    skip "https://github.com/ruby/rubygems/issues/3351" if RUBY_PLATFORM.include?("mswin")
     install_gemfile "source \"https://gem.repo1\"; gem \"myrack\""
     bundle "exec #{gem_cmd} --version"
     expect(out).to eq(Gem::VERSION)
@@ -205,7 +205,7 @@ RSpec.describe "bundle exec" do
       end
 
       it "uses version provided by ruby" do
-        skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
+        skip "https://github.com/ruby/rubygems/issues/3351" if RUBY_PLATFORM.include?("mswin")
         bundle "exec erb --version"
 
         expect(stdboth).to eq(default_erb_version)
@@ -634,7 +634,7 @@ RSpec.describe "bundle exec" do
 
   describe "with gems bundled via :path with invalid gemspecs" do
     it "outputs the gemspec validation errors" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
+      skip "https://github.com/ruby/rubygems/issues/3351" if RUBY_PLATFORM.include?("mswin")
       build_lib "foo"
 
       gemspec = lib_path("foo-1.0").join("foo.gemspec").to_s
@@ -695,7 +695,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "works" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
+      skip "https://github.com/ruby/rubygems/issues/3351" if RUBY_PLATFORM.include?("mswin")
       bundle "exec #{gem_cmd} uninstall foo"
       expect(out).to eq("Successfully uninstalled foo-1.0")
     end
@@ -717,7 +717,7 @@ RSpec.describe "bundle exec" do
     end
 
     it "does not load plugins outside of the bundle" do
-      skip "https://github.com/ruby/rubygems/issues/3351" if /mswin/.match?(RUBY_PLATFORM)
+      skip "https://github.com/ruby/rubygems/issues/3351" if RUBY_PLATFORM.include?("mswin")
       bundle "exec #{gem_cmd} -v"
       expect(out).not_to include("FAIL")
     end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -1352,7 +1352,7 @@ RSpec.describe "bundle install with gem sources" do
       # The make jobserver is a GNU make feature. On Windows extensions are built
       # with nmake, which has no `-j` jobserver (and an inherited `-j` MAKEFLAGS
       # even breaks nmake), so the slot count these examples assert never appears.
-      skip "The make jobserver is not available on Windows (nmake)" if /mswin/.match?(RUBY_PLATFORM)
+      skip "The make jobserver is not available on Windows (nmake)" if RUBY_PLATFORM.include?("mswin")
 
       @old_makeflags = ENV["MAKEFLAGS"]
       @gemspec = nil

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -1352,7 +1352,7 @@ RSpec.describe "bundle install with gem sources" do
       # The make jobserver is a GNU make feature. On Windows extensions are built
       # with nmake, which has no `-j` jobserver (and an inherited `-j` MAKEFLAGS
       # even breaks nmake), so the slot count these examples assert never appears.
-      skip "The make jobserver is not available on Windows (nmake)" if Gem.win_platform?
+      skip "The make jobserver is not available on Windows (nmake)" if /mswin/.match?(RUBY_PLATFORM)
 
       @old_makeflags = ENV["MAKEFLAGS"]
       @gemspec = nil

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -1352,7 +1352,7 @@ RSpec.describe "bundle install with gem sources" do
       # The make jobserver is a GNU make feature. On Windows extensions are built
       # with nmake, which has no `-j` jobserver (and an inherited `-j` MAKEFLAGS
       # even breaks nmake), so the slot count these examples assert never appears.
-      skip "The make jobserver is not available on Windows (nmake)" if RUBY_PLATFORM.include?("mswin")
+      skip "The make jobserver is not available on Windows (nmake)" if mswin?
 
       @old_makeflags = ENV["MAKEFLAGS"]
       @gemspec = nil

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -1349,6 +1349,11 @@ RSpec.describe "bundle install with gem sources" do
         skip "This example is runnable when RubyGems::Installer implements `build_jobs`"
       end
 
+      # The make jobserver is a GNU make feature. On Windows extensions are built
+      # with nmake, which has no `-j` jobserver (and an inherited `-j` MAKEFLAGS
+      # even breaks nmake), so the slot count these examples assert never appears.
+      skip "The make jobserver is not available on Windows (nmake)" if Gem.win_platform?
+
       @old_makeflags = ENV["MAKEFLAGS"]
       @gemspec = nil
 

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -1286,7 +1286,6 @@ RSpec.describe "bundle lock" do
   end
 
   it "does not conflict on ruby requirements when adding new platforms" do
-    skip "the raygun-apm fixture has no x64-mswin64 variant for the current platform" if RUBY_PLATFORM.include?("mswin")
     build_repo4 do
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x86_64-linux"
@@ -1300,6 +1299,11 @@ RSpec.describe "bundle lock" do
 
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x64-mingw-ucrt"
+        s.required_ruby_version = "< #{next_ruby_minor}.dev"
+      end
+
+      build_gem "raygun-apm", "1.0.78" do |s|
+        s.platform = "x64-mswin64"
         s.required_ruby_version = "< #{next_ruby_minor}.dev"
       end
     end

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -1286,7 +1286,7 @@ RSpec.describe "bundle lock" do
   end
 
   it "does not conflict on ruby requirements when adding new platforms" do
-    skip "the raygun-apm fixture has no x64-mswin64 variant for the current platform" if Gem.win_platform?
+    skip "the raygun-apm fixture has no x64-mswin64 variant for the current platform" if /mswin/.match?(RUBY_PLATFORM)
     build_repo4 do
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x86_64-linux"

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -1286,7 +1286,7 @@ RSpec.describe "bundle lock" do
   end
 
   it "does not conflict on ruby requirements when adding new platforms" do
-    skip "the raygun-apm fixture has no x64-mswin64 variant for the current platform" if /mswin/.match?(RUBY_PLATFORM)
+    skip "the raygun-apm fixture has no x64-mswin64 variant for the current platform" if RUBY_PLATFORM.include?("mswin")
     build_repo4 do
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x86_64-linux"

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -1286,6 +1286,7 @@ RSpec.describe "bundle lock" do
   end
 
   it "does not conflict on ruby requirements when adding new platforms" do
+    skip "the raygun-apm fixture has no x64-mswin64 variant for the current platform" if Gem.win_platform?
     build_repo4 do
       build_gem "raygun-apm", "1.0.78" do |s|
         s.platform = "x86_64-linux"

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -232,6 +232,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if Gem.win_platform?
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
@@ -249,6 +250,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if Gem.win_platform?
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
-      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if RUBY_PLATFORM.include?("mswin")
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if mswin?
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
@@ -250,7 +250,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
-      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if RUBY_PLATFORM.include?("mswin")
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if mswin?
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
-      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if /mswin/.match?(RUBY_PLATFORM)
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if RUBY_PLATFORM.include?("mswin")
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
@@ -250,7 +250,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
-      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if /mswin/.match?(RUBY_PLATFORM)
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if RUBY_PLATFORM.include?("mswin")
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)

--- a/spec/commands/pristine_spec.rb
+++ b/spec/commands/pristine_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
-      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if Gem.win_platform?
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if /mswin/.match?(RUBY_PLATFORM)
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)
@@ -250,7 +250,7 @@ RSpec.describe "bundle pristine" do
     # This just verifies that the generated Makefile from the c_ext gem makes
     # use of the build_args from the bundle config
     it "applies the config when installing the gem" do
-      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if Gem.win_platform?
+      skip "the generated Makefile uses MSVC `-libpath:` syntax instead of `-L` on Windows" if /mswin/.match?(RUBY_PLATFORM)
       bundle "pristine"
 
       makefile_contents = File.read(c_ext_dir.join("Makefile").to_s)

--- a/spec/install/global_cache_spec.rb
+++ b/spec/install/global_cache_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe "global gem caching" do
     end
 
     it "uses a shorter path for the cache to not hit filesystem limits" do
+      skip "Windows without long path support cannot create the long cache path" if Gem.win_platform?
       install_gemfile <<-G, artifice: "compact_index", verbose: true
         source "http://#{"a" * 255}.test"
         gem "myrack"
@@ -82,17 +83,19 @@ RSpec.describe "global gem caching" do
       # the more verbose and explicit approach. This whole ensure block can be
       # removed once/if https://bugs.ruby-lang.org/issues/21177 is fixed, and
       # once the fix propagates to all supported rubies.
-      File.delete cached_gem
-      Dir.rmdir source_cache
+      if cached_gem
+        File.delete cached_gem
+        Dir.rmdir source_cache
 
-      File.delete compact_index_cache_path.join(source_segment, "info", "myrack")
-      Dir.rmdir compact_index_cache_path.join(source_segment, "info")
-      File.delete compact_index_cache_path.join(source_segment, "info-etags", "myrack-92f3313ce5721296f14445c3a6b9c073")
-      Dir.rmdir compact_index_cache_path.join(source_segment, "info-etags")
-      Dir.rmdir compact_index_cache_path.join(source_segment, "info-special-characters")
-      File.delete compact_index_cache_path.join(source_segment, "versions")
-      File.delete compact_index_cache_path.join(source_segment, "versions.etag")
-      Dir.rmdir compact_index_cache_path.join(source_segment)
+        File.delete compact_index_cache_path.join(source_segment, "info", "myrack")
+        Dir.rmdir compact_index_cache_path.join(source_segment, "info")
+        File.delete compact_index_cache_path.join(source_segment, "info-etags", "myrack-92f3313ce5721296f14445c3a6b9c073")
+        Dir.rmdir compact_index_cache_path.join(source_segment, "info-etags")
+        Dir.rmdir compact_index_cache_path.join(source_segment, "info-special-characters")
+        File.delete compact_index_cache_path.join(source_segment, "versions")
+        File.delete compact_index_cache_path.join(source_segment, "versions.etag")
+        Dir.rmdir compact_index_cache_path.join(source_segment)
+      end
     end
 
     describe "when the same gem from different sources is installed" do

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -132,6 +132,7 @@ module Spec
     # When the temp dir is on a different drive than the source tree, examples
     # that compare or look up paths across the two cannot be set up correctly.
     def tmp_and_source_on_different_drives?
+      return false unless Gem.win_platform?
       drive = ->(path) { path.to_s[%r{\A[a-zA-Z]:}]&.upcase }
       drive[tmp_root] != drive[source_root]
     end

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -127,6 +127,15 @@ module Spec
       end
     end
 
+    # On Windows there is no relative path between different drives, and much of
+    # the spec setup (temp home, bundled app, caches) lives under the temp dir.
+    # When the temp dir is on a different drive than the source tree, examples
+    # that compare or look up paths across the two cannot be set up correctly.
+    def tmp_and_source_on_different_drives?
+      drive = ->(path) { path.to_s[%r{\A[a-zA-Z]:}]&.upcase }
+      drive[tmp_root] != drive[source_root]
+    end
+
     # Bump this version whenever you make a breaking change to the spec setup
     # that requires regenerating tmp/.
 

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -133,7 +133,7 @@ module Spec
     # that compare or look up paths across the two cannot be set up correctly.
     def tmp_and_source_on_different_drives?
       return false unless Gem.win_platform?
-      drive = ->(path) { path.to_s[%r{\A[a-zA-Z]:}]&.upcase }
+      drive = ->(path) { path.to_s[/\A[a-zA-Z]:/]&.upcase }
       drive[tmp_root] != drive[source_root]
     end
 

--- a/spec/support/platforms.rb
+++ b/spec/support/platforms.rb
@@ -28,6 +28,13 @@ module Spec
       [:jruby, :windows, :ruby].find {|tag| tag != local_tag }
     end
 
+    # The mswin build uses nmake and MSVC, which differ from the mingw build in
+    # ways several specs need to skip (no make jobserver, MSVC Makefile syntax,
+    # extensionless executables, mswin-only fixtures).
+    def mswin?
+      RUBY_PLATFORM.include?("mswin")
+    end
+
     def local_ruby_engine
       RUBY_ENGINE
     end

--- a/spec/support/subprocess.rb
+++ b/spec/support/subprocess.rb
@@ -38,7 +38,7 @@ module Spec
       dir = options[:dir]
       env = options[:env] || {}
 
-      command_execution = CommandExecution.new(cmd.to_s, timeout: options[:timeout] || 60)
+      command_execution = CommandExecution.new(cmd.to_s, timeout: options[:timeout] || (Gem.win_platform? ? 120 : 60))
 
       open3_opts = {}
       open3_opts[:chdir] = dir if dir


### PR DESCRIPTION
These changes were authored directly in ruby/ruby while getting the Bundler spec suite and RubyGems to pass on the Windows mswin build, and they belong in the canonical repository as well. This brings them back without the ruby/ruby commit prefixes, preserving the original authorship.

Most of the commits guard mswin-specific limitations in the Bundler specs, namely the absent nmake jobserver, the MSVC Makefile syntax, extensionless executables, cross-drive temp paths, and the MAX_PATH cap, so the suite skips what cannot pass there while still running on mingw. The one runtime change keeps the AtomicFileWriter temporary path within MAX_PATH so a write near the limit no longer fails with ENOENT.

The final commit rewrites a couple of match? and regexp-literal forms that this repository's rubocop flags but ruby/ruby does not lint. It carries no behavior change.
