### PR TITLE
Pin rdoc below 8 on JRuby in install CI

### DIFF
--- a/.github/workflows/install-rubygems.yml
+++ b/.github/workflows/install-rubygems.yml
@@ -52,8 +52,11 @@ jobs:
           ruby -Ilib -S rake install 2> errors.txt || (cat errors.txt && exit 1)
           test ! -s errors.txt || (cat errors.txt && exit 1)
       - name: Check generating documentation with a non default rdoc
+        # rdoc 8 depends on rbs, which ships a C extension that JRuby cannot
+        # build. Temporarily pin rdoc below 8 on JRuby until rbs provides a
+        # JRuby-compatible build.
         run: |
-          gem install rdoc
+          gem install ${{ matrix.ruby.name == 'jruby' && '"rdoc:<8"' || 'rdoc' }}
           gem rdoc rdoc | grep -q "Parsing documentation"
       - name: Run a local rubygems command
         run: gem list bundler


### PR DESCRIPTION
rdoc 8.0.0 (released 2026-06-26) added a runtime dependency on rbs, which ships a C extension that cannot be built on JRuby. As a result the install-rubygems workflow step `Check generating documentation with a non default rdoc` fails on the JRuby matrix entries when `gem install rdoc` tries to build `rbs-4.0.3`. The non-JRuby entries (3.2/3.3/3.4/truffleruby) can build the extension and still pass.

This pins rdoc below 8 on JRuby only, so it installs rdoc 7.2.0 which depends on erb/psych/tsort and pulls in no native extension. The other rubies keep installing the latest rdoc. The pin is a temporary CI workaround and should be removed once rbs provides a JRuby-compatible build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)