### PR TITLE
Forward-port RubyGems/Bundler changes made directly in ruby/ruby

### DIFF
--- a/spec/bundler/mirror_spec.rb
+++ b/spec/bundler/mirror_spec.rb
@@ -298,15 +298,13 @@ RSpec.describe Bundler::Settings::TCPSocketProbe do
 
   context "with a listening TCP Server" do
     def with_server_and_mirror
-      server = TCPServer.new("0.0.0.0", 0)
-      mirror = Bundler::Settings::Mirror.new("http://0.0.0.0:#{server.addr[1]}", 1)
+      server = TCPServer.new("127.0.0.1", 0)
+      mirror = Bundler::Settings::Mirror.new("http://127.0.0.1:#{server.addr[1]}", 1)
       yield server, mirror
       server.close unless server.closed?
     end
 
     it "probes the server correctly" do
-      skip "obscure error" if Gem.win_platform?
-
       with_server_and_mirror do |server, mirror|
         expect(server.closed?).to be_falsey
         expect(probe.replies?(mirror)).to be_truthy

--- a/spec/commands/add_spec.rb
+++ b/spec/commands/add_spec.rb
@@ -153,9 +153,10 @@ RSpec.describe "bundle add" do
 
   describe "with --git and --ref" do
     it "adds dependency with specified git source and branch" do
-      bundle "add foo --git=#{lib_path("foo-2.0")} --ref=#{revision_for(lib_path("foo-2.0"))}"
+      ref = revision_for(lib_path("foo-2.0"))
+      bundle "add foo --git=#{lib_path("foo-2.0")} --ref=#{ref}"
 
-      expect(bundled_app_gemfile.read).to match(/gem "foo", ">= 2\.0", git: "#{lib_path("foo-2.0")}", ref: "#{revision_for(lib_path("foo-2.0"))}"/)
+      expect(bundled_app_gemfile.read).to match(/gem "foo", ">= 2\.0", git: "#{lib_path("foo-2.0")}", ref: "#{ref}"/)
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -229,9 +230,10 @@ RSpec.describe "bundle add" do
 
   describe "with --git and --ref and --glob" do
     it "adds dependency with specified git source and branch" do
-      bundle "add foo --git=#{lib_path("foo-2.0")} --ref=#{revision_for(lib_path("foo-2.0"))} --glob='./*.gemspec'"
+      ref = revision_for(lib_path("foo-2.0"))
+      bundle "add foo --git=#{lib_path("foo-2.0")} --ref=#{ref} --glob='./*.gemspec'"
 
-      expect(bundled_app_gemfile.read).to match(%r{gem "foo", ">= 2\.0", git: "#{lib_path("foo-2.0")}", ref: "#{revision_for(lib_path("foo-2.0"))}", glob: "\./\*\.gemspec"})
+      expect(bundled_app_gemfile.read).to match(%r{gem "foo", ">= 2\.0", git: "#{lib_path("foo-2.0")}", ref: "#{ref}", glob: "\./\*\.gemspec"})
       expect(the_bundle).to include_gems "foo 2.0"
     end
   end
@@ -397,7 +399,7 @@ RSpec.describe "bundle add" do
 
   describe "when a gem is added which is already specified in Gemfile with version" do
     it "shows an error when added with different version requirement" do
-      install_gemfile <<-G
+      lock_gemfile <<-G
         source "https://gem.repo2"
         gem "myrack", "1.0"
       G
@@ -409,7 +411,7 @@ RSpec.describe "bundle add" do
     end
 
     it "shows error when added without version requirements" do
-      install_gemfile <<-G
+      lock_gemfile <<-G
         source "https://gem.repo2"
         gem "myrack", "1.0"
       G
@@ -424,7 +426,7 @@ RSpec.describe "bundle add" do
 
   describe "when a gem is added which is already specified in Gemfile without version" do
     it "shows an error when added with different version requirement" do
-      install_gemfile <<-G
+      lock_gemfile <<-G
         source "https://gem.repo2"
         gem "myrack"
       G

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -704,8 +704,9 @@ RSpec.describe "bundle lock" do
         build_gem "qux", %w[1.0.0 1.0.1 1.1.0 2.0.0]
       end
 
-      # establish a lockfile set to 1.4.3
-      install_gemfile <<-G
+      # establish a lockfile set to 1.4.3 (these examples only assert on the
+      # generated lockfile, so resolve-and-lock without the install)
+      lock_gemfile <<-G
         source "https://gem.repo4"
         gem 'foo', '1.4.3'
         gem 'bar', '2.0.3'
@@ -988,7 +989,7 @@ RSpec.describe "bundle lock" do
     end
 
     simulate_platform "x86_64-darwin-22" do
-      install_gemfile <<~G
+      lock_gemfile <<~G
         source "https://gem.repo4"
 
         gem "nokogiri"

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -43,9 +43,16 @@ RSpec.describe "bundle gem" do
   let(:gem_name) { "mygem" }
 
   before do
-    git("config --global user.name 'Bundler User'")
-    git("config --global user.email user@example.com")
-    git("config --global github.user bundleuser")
+    # Write the global git config directly instead of shelling out to `git
+    # config --global` three times per example: this `before` runs for every
+    # example in the file, and each `git` call is a separate subprocess.
+    File.write(home(".gitconfig"), <<~GITCONFIG)
+      [user]
+      name = Bundler User
+      email = user@example.com
+      [github]
+      user = bundleuser
+    GITCONFIG
 
     bundle_config_global "gem.mit false"
     bundle_config_global "gem.test false"

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -86,8 +86,10 @@ RSpec.describe "bundle outdated" do
         end
       G
 
-      update_repo2 { build_gem "activesupport", "3.0" }
-      update_repo2 { build_gem "terranova", "9" }
+      update_repo2 do
+        build_gem "activesupport", "3.0"
+        build_gem "terranova", "9"
+      end
 
       bundle "outdated", raise_on_error: false
 
@@ -122,8 +124,10 @@ RSpec.describe "bundle outdated" do
     it "shows the location of the latest version's gemspec if installed" do
       bundle_config "clean false"
 
-      update_repo2 { build_gem "activesupport", "3.0" }
-      update_repo2 { build_gem "terranova", "9" }
+      update_repo2 do
+        build_gem "activesupport", "3.0"
+        build_gem "terranova", "9"
+      end
 
       install_gemfile <<-G
         source "https://gem.repo2"

--- a/spec/install/gemfile/path_spec.rb
+++ b/spec/install/gemfile/path_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe "bundle install with explicit source paths" do
       s.add_dependency "graphql", "~> 2.0"
     end
 
-    bundle "install", dir: lib_path("foo")
+    bundle "lock", dir: lib_path("foo")
     expect(lockfile_path).to read_as(original_lockfile.gsub("foo (0.1.0)", "foo (0.1.1)"))
   end
 
@@ -510,8 +510,6 @@ RSpec.describe "bundle install with explicit source paths" do
     gemfile <<-G
       gem "foo", "1.0", :path => "#{lib_path("foo-1.0")}"
     G
-
-    expect(the_bundle).to include_gems "foo 1.0"
 
     expect(the_bundle).to include_gems "foo 1.0"
   end

--- a/spec/install/gemfile/specific_platform_spec.rb
+++ b/spec/install/gemfile/specific_platform_spec.rb
@@ -558,7 +558,7 @@ RSpec.describe "bundle install with specific platforms" do
     it "adds the foreign platform" do
       simulate_platform "x86_64-darwin-15" do
         setup_multiplatform_gem
-        install_gemfile(google_protobuf)
+        lock_gemfile(google_protobuf)
         bundle "lock --add-platform=x64-mingw-ucrt"
 
         expect(the_bundle.locked_platforms).to include("x64-mingw-ucrt", "universal-darwin")
@@ -572,7 +572,7 @@ RSpec.describe "bundle install with specific platforms" do
     it "falls back on plain ruby when that version doesn't have a platform-specific gem" do
       simulate_platform "x86_64-darwin-15" do
         setup_multiplatform_gem
-        install_gemfile(google_protobuf)
+        lock_gemfile(google_protobuf)
         bundle "lock --add-platform=java"
 
         expect(the_bundle.locked_platforms).to include("java", "universal-darwin")
@@ -938,7 +938,7 @@ RSpec.describe "bundle install with specific platforms" do
     end
 
     simulate_platform "x86_64-linux" do
-      install_gemfile <<~G
+      lock_gemfile <<~G
         source "https://gem.repo4"
 
         gem "native_tool"

--- a/spec/install/gems/dependency_api_spec.rb
+++ b/spec/install/gems/dependency_api_spec.rb
@@ -157,7 +157,6 @@ RSpec.describe "gemcutter's dependency API" do
       "actionpack 2.3.2",
       "actionmailer 2.3.2",
       "activeresource 2.3.2",
-      "activesupport 2.3.2",
       "thin 1.0.0",
       "myrack 1.0.0",
       "rails 2.3.2"

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe "bundle install" do
     end
 
     it "displays the ref of the gem repository when using branch~num as a ref" do
-      skip "maybe branch~num notation doesn't work on Windows' git" if Gem.win_platform?
-
       build_git "foo", "1.0", path: lib_path("foo")
       rev = revision_for(lib_path("foo"))[0..6]
       update_git "foo", "2.0", path: lib_path("foo"), gemspec: true

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "the lockfile format" do
       c.checksum(gem_repo2, "myrack", "1.0.0")
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2"
 
       gem "myrack"
@@ -149,7 +149,7 @@ RSpec.describe "the lockfile format" do
         myrack
     L
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2"
 
       gem "myrack", "> 0"
@@ -220,7 +220,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "generates a simple lockfile for a single source, gem with dependencies" do
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
 
       gem "myrack-obama"
@@ -251,7 +251,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "generates a simple lockfile for a single source, gem with a version requirement" do
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
 
       gem "myrack-obama", ">= 1.0"
@@ -477,7 +477,7 @@ RSpec.describe "the lockfile format" do
   it "generates a simple lockfile for a single pinned source, gem with a version requirement" do
     git = build_git "foo"
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo1"
       gem "foo", :git => "#{lib_path("foo-1.0")}"
     G
@@ -554,7 +554,7 @@ RSpec.describe "the lockfile format" do
       c.no_checksum "foo", "1.0"
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo1"
       git "#{lib_path("foo-1.0")}" do
         gem "foo"
@@ -591,7 +591,7 @@ RSpec.describe "the lockfile format" do
       c.no_checksum "foo", "1.0"
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo1"
       gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "omg"
     G
@@ -627,7 +627,7 @@ RSpec.describe "the lockfile format" do
       c.no_checksum "foo", "1.0"
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo1"
       gem "foo", :git => "#{lib_path("foo-1.0")}", :tag => "omg"
     G
@@ -748,7 +748,7 @@ RSpec.describe "the lockfile format" do
       c.no_checksum "foo", "1.0"
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo1"
       gem "foo", :path => "#{lib_path("foo-1.0")}"
     G
@@ -820,7 +820,7 @@ RSpec.describe "the lockfile format" do
       c.checksum gem_repo2, "myrack", "1.0.0"
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
 
       gem "myrack"
@@ -859,7 +859,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "removes redundant sources" do
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
 
       gem "myrack", :source => "https://gem.repo2/"
@@ -887,7 +887,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "lists gems alphabetically" do
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
 
       gem "thin"
@@ -930,7 +930,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "orders dependencies' dependencies in alphabetical order" do
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
 
       gem "rails"
@@ -989,7 +989,7 @@ RSpec.describe "the lockfile format" do
       end
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2"
       gem 'double_deps'
     G
@@ -1020,7 +1020,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "does not add the :require option to the lockfile" do
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
 
       gem "myrack-obama", ">= 1.0", :require => "myrack/obama"
@@ -1051,7 +1051,7 @@ RSpec.describe "the lockfile format" do
   end
 
   it "does not add the :group option to the lockfile" do
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
 
       gem "myrack-obama", ">= 1.0", :group => :test
@@ -1088,7 +1088,7 @@ RSpec.describe "the lockfile format" do
       c.no_checksum "foo", "1.0"
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo1"
       path "foo" do
         gem "foo"
@@ -1123,7 +1123,7 @@ RSpec.describe "the lockfile format" do
       c.no_checksum "foo", "1.0"
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo1"
       path "../foo" do
         gem "foo"
@@ -1154,7 +1154,7 @@ RSpec.describe "the lockfile format" do
   it "stores relative paths when the path is provided in an absolute fashion but is relative" do
     build_lib "foo", path: bundled_app("foo")
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo1"
       path File.expand_path("foo", __dir__) do
         gem "foo"
@@ -1193,7 +1193,7 @@ RSpec.describe "the lockfile format" do
       c.no_checksum "foo", "1.0"
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo1"
       gemspec :path => "../foo"
     G
@@ -1240,7 +1240,7 @@ RSpec.describe "the lockfile format" do
         #{Bundler::VERSION}
     G
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
 
       gem "myrack"
@@ -1318,7 +1318,7 @@ RSpec.describe "the lockfile format" do
     end
 
     simulate_platform "universal-java-16" do
-      install_gemfile <<-G
+      lock_gemfile <<-G
         source "https://gem.repo2"
         gem "platform_specific"
       G
@@ -1353,12 +1353,12 @@ RSpec.describe "the lockfile format" do
       c.checksum(gem_repo2, "myrack", "1.0.0")
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
       gem "myrack"
     G
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
       gem "myrack"
       gem "activesupport"
@@ -1388,7 +1388,7 @@ RSpec.describe "the lockfile format" do
       c.checksum(gem_repo2, "myrack", "1.0.0")
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
       gem "myrack"
       gem "myrack"
@@ -1416,7 +1416,7 @@ RSpec.describe "the lockfile format" do
       c.checksum(gem_repo2, "myrack", "1.0.0")
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
       gem "myrack", "1.0"
       gem "myrack", "1.0"
@@ -1444,7 +1444,7 @@ RSpec.describe "the lockfile format" do
       c.checksum(gem_repo2, "myrack", "1.0.0")
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
       gem "myrack", "1.0", :group => :one
       gem "myrack", "1.0", :group => :two
@@ -1494,7 +1494,7 @@ RSpec.describe "the lockfile format" do
       c.checksum(gem_repo2, "myrack", "0.9.1")
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
       gem "myrack", "> 0.9", "< 1.0"
     G
@@ -1521,7 +1521,7 @@ RSpec.describe "the lockfile format" do
       c.checksum(gem_repo2, "myrack", "0.9.1")
     end
 
-    install_gemfile <<-G
+    lock_gemfile <<-G
       source "https://gem.repo2/"
       ruby '#{Gem.ruby_version}'
       gem "myrack", "> 0.9", "< 1.0"

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "major deprecations" do
 
   context "bundle check --path" do
     before do
-      install_gemfile <<-G
+      gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G
@@ -117,7 +117,7 @@ RSpec.describe "major deprecations" do
 
   context "bundle check --path=" do
     before do
-      install_gemfile <<-G
+      gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G
@@ -137,7 +137,7 @@ RSpec.describe "major deprecations" do
 
   context "bundle binstubs --path=" do
     before do
-      install_gemfile <<-G
+      gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G
@@ -157,7 +157,7 @@ RSpec.describe "major deprecations" do
 
   context "bundle cache --all" do
     before do
-      install_gemfile <<-G
+      gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G
@@ -177,7 +177,7 @@ RSpec.describe "major deprecations" do
 
   context "bundle cache --no-all" do
     before do
-      install_gemfile <<-G
+      gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G
@@ -197,7 +197,7 @@ RSpec.describe "major deprecations" do
 
   context "bundle cache --path" do
     before do
-      install_gemfile <<-G
+      gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G
@@ -217,7 +217,7 @@ RSpec.describe "major deprecations" do
 
   context "bundle cache --path=" do
     before do
-      install_gemfile <<-G
+      gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G
@@ -237,7 +237,7 @@ RSpec.describe "major deprecations" do
 
   context "bundle cache --frozen" do
     before do
-      install_gemfile <<-G
+      gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G
@@ -257,7 +257,7 @@ RSpec.describe "major deprecations" do
 
   context "bundle cache --no-prune" do
     before do
-      install_gemfile <<-G
+      gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G
@@ -437,7 +437,7 @@ RSpec.describe "major deprecations" do
     before do
       bundle_config "path vendor/bundle"
 
-      install_gemfile <<-G
+      gemfile <<-G
         source "https://gem.repo1"
         gem "myrack"
       G

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -175,6 +175,26 @@ RSpec.configure do |config|
     reset!
   end
 
+  # Opt-in per-example runtime log (set BUNDLER_SPEC_RUNTIME_LOG to a file path).
+  # Each parallel worker appends one "<seconds>\t<file>" line per example to its
+  # own "<path>.<TEST_ENV_NUMBER>" file (a single shared file would hit Windows
+  # cross-process sharing violations), so the heaviest specs can be found after a
+  # full run. turbo_tests only writes its own --runtime-log when invoked with the
+  # bare "spec" path, which the build never does, so it produces no log otherwise.
+  if (runtime_log = ENV["BUNDLER_SPEC_RUNTIME_LOG"])
+    worker = ENV["TEST_ENV_NUMBER"].to_s
+    worker = "1" if worker.empty?
+    runtime_log = "#{runtime_log}.#{worker}"
+    config.before(:each) { @__runtime_start = Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+    config.after(:each) do |example|
+      next unless @__runtime_start
+      dt = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @__runtime_start
+      File.write(runtime_log, "#{format("%.4f", dt)}\t#{example.metadata[:file_path]}\n", mode: "a")
+    rescue StandardError
+      # never let runtime logging break a test run
+    end
+  end
+
   Spec::Shards::EXAMPLE_MAPPINGS.each do |tag, file_paths|
     file_pattern = Regexp.union(file_paths.map {|path| Regexp.new(Regexp.escape(path) + "$") })
 

--- a/spec/support/shards.rb
+++ b/spec/support/shards.rb
@@ -52,6 +52,8 @@ module Spec
         "spec/bundler/ui_spec.rb",
         "spec/bundler/plugin/source_list_spec.rb",
         "spec/bundler/source/path_spec.rb",
+        "spec/lock/lockfile_spec.rb",
+        "spec/runtime/inline_spec.rb",
       ],
       shard_b: [
         "spec/install/gemfile/git_spec.rb",
@@ -64,7 +66,6 @@ module Spec
         "spec/plugins/install_spec.rb",
         "spec/commands/binstubs_spec.rb",
         "spec/install/gems/flex_spec.rb",
-        "spec/runtime/inline_spec.rb",
         "spec/commands/post_bundle_message_spec.rb",
         "spec/runtime/executable_spec.rb",
         "spec/lock/git_spec.rb",
@@ -107,7 +108,6 @@ module Spec
         "spec/commands/cache_spec.rb",
         "spec/commands/check_spec.rb",
         "spec/commands/list_spec.rb",
-        "spec/install/path_spec.rb",
         "spec/bundler/cli_spec.rb",
         "spec/install/bundler_spec.rb",
         "spec/install/git_spec.rb",
@@ -148,7 +148,6 @@ module Spec
         "spec/install/cooldown_spec.rb",
         "spec/commands/outdated_spec.rb",
         "spec/commands/update_spec.rb",
-        "spec/lock/lockfile_spec.rb",
         "spec/install/deploy_spec.rb",
         "spec/install/gemfile/sources_spec.rb",
         "spec/runtime/self_management_spec.rb",
@@ -194,6 +193,7 @@ module Spec
         "spec/install/gems/no_install_plugin_spec.rb",
         "spec/bundler/override_spec.rb",
         "spec/install/gemfile/override_spec.rb",
+        "spec/install/path_spec.rb",
       ],
     }.freeze
   end

--- a/test/rubygems/test_gem_compact_index_client_cache_file.rb
+++ b/test/rubygems/test_gem_compact_index_client_cache_file.rb
@@ -123,13 +123,12 @@ class TestGemCompactIndexClientCacheFile < Gem::TestCase
   end
 
   def test_write_preserves_permissions
-    pend "chmod is unreliable on Windows" if Gem.win_platform?
-
     @path.binwrite "old"
-    @path.chmod 0o600
+    @path.chmod 0o400
 
     CacheFile.write(@path, "new")
 
-    assert_equal 0o600, @path.stat.mode & 0o777
+    assert_equal "new", @path.binread
+    assert_equal 0, @path.stat.mode & 0o200, "expected CacheFile.write to preserve the original read-only permission"
   end
 end

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -3159,14 +3159,14 @@ duplicate dependency on c (>= 1.2.3, development), (~> 1.2) use:
   end
 
   def test_validate_files
-    pend "test_validate_files skipped on MS Windows (symlink)" if Gem.win_platform?
+    pend "Symlinks not supported or not enabled" unless symlink_supported?
     util_setup_validate
 
     @a1.files += ["lib", "lib2"]
     @a1.extensions << "ext/a/extconf.rb"
 
     Dir.chdir @tempdir do
-      FileUtils.ln_s "lib/code.rb", "lib2" unless vc_windows?
+      FileUtils.ln_s "lib/code.rb", "lib2"
 
       use_ui @ui do
         @a1.validate


### PR DESCRIPTION
Forward-port 15 commits that were made directly in ruby/ruby for RubyGems/Bundler. They are all DIRECT commits without a down-sync footer and were not yet on master.

The first four revisit Windows-only skips so the examples run on every platform. The mirror socket spec now probes 127.0.0.1 instead of 0.0.0.0, the validate_files test is gated on symlink_supported? rather than a Windows skip, the CacheFile permission test asserts the read-only bit, and the branch~num git ref spec no longer skips on Windows.

The remaining eleven optimize the Bundler spec runtime. Examples that only assert on the lockfile switch from install to lock, redundant subprocesses and assertions are trimmed, the newgem global git config is written in-process, and the shards are rebalanced by measured runtime. An opt-in per-example runtime log via BUNDLER_SPEC_RUNTIME_LOG is also added.

Each commit is byte-identical to its ruby/ruby original, and rubocop reports no offenses across all files. The two test/rubygems tests and the mirror/path/lockfile Bundler specs were run locally and pass.