### PR TITLE
Respect Gemfile lockfile in `bundle lock`

### DIFF
--- a/lib/bundler/cli/lock.rb
+++ b/lib/bundler/cli/lock.rb
@@ -69,7 +69,7 @@ module Bundler
           puts definition.to_lock
         else
           file = options[:lockfile]
-          file = file ? Pathname.new(file).expand_path : Bundler.default_lockfile
+          file = file ? Pathname.new(file).expand_path : definition.lockfile
 
           puts "Writing lockfile to #{file}"
           definition.write_lock(file, false)

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -177,6 +177,23 @@ RSpec.describe "bundle lock" do
     expect(read_lockfile).to eq(expected_lockfile)
   end
 
+  it "writes the lockfile configured in the Gemfile" do
+    build_repo4 do
+      build_gem "foo", "1.0"
+    end
+
+    gemfile <<-G
+      source "https://gem.repo4"
+      gem "foo", "1.0"
+      lockfile "custom.lock"
+    G
+
+    bundle "lock"
+
+    expect(bundled_app("Gemfile.lock")).not_to exist
+    expect(bundled_app("custom.lock")).to exist
+  end
+
   it "prints a lockfile without fetching new checksums if the existing lockfile had no checksums" do
     gemfile_with_rails_weakling_and_foo_from_repo4
 


### PR DESCRIPTION
Fixes #9565.

## What was the end-user or developer problem that led to this PR?

As described in the issue linked above, when `Gemfile` specifies a custom lockfile name using `lockfile`, and the user runs `bundle lock`, the lock file gets written to `Gemfile.lock` instead of the specified name.


## What is your fix for the problem, implemented in this PR?

Use `definition.lockfile` as a fallback instead of `Bundler.default_lockfile`.

You can confirm the problem easily:

```shell-session
$ mkdir /tmp/test_bundle && cd /tmp/test_bundle

$ bundle --version
4.0.15

$ cat > Gemfile <<-G 
gem "rails"
lockfile "custom.lock"
G

$ bundle lock
Writing lockfile to /private/tmp/test_bundle/Gemfile.lock
Resolving dependencies...

$ ls
Gemfile      Gemfile.lock
```

I also wrote a test that would fail without the fix in this PR, and now passes.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/bundler/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
