### PR TITLE
Exercise more Windows-skipped specs in RubyGems and Bundler

### DIFF
--- a/spec/install/deploy_spec.rb
+++ b/spec/install/deploy_spec.rb
@@ -44,8 +44,6 @@ RSpec.describe "install in deployment or frozen mode" do
   end
 
   it "works when you bundle exec bundle" do
-    skip "doesn't find bundle" if Gem.win_platform?
-
     bundle :install
     bundle_config "deployment true"
     bundle :install

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -427,8 +427,6 @@ RSpec.describe "bundle install with git sources" do
     context "when the branch starts with a `#`" do
       let(:branch) { "#149/redirect-url-fragment" }
       it "works" do
-        skip "git does not accept this" if Gem.win_platform?
-
         update_git("foo", path: repo, branch: branch)
 
         install_gemfile <<-G
@@ -481,8 +479,6 @@ RSpec.describe "bundle install with git sources" do
     context "when the tag starts with a `#`" do
       let(:tag) { "#149/redirect-url-fragment" }
       it "works" do
-        skip "git does not accept this" if Gem.win_platform?
-
         update_git("foo", path: repo, tag: tag)
 
         install_gemfile <<-G

--- a/spec/install/yanked_spec.rb
+++ b/spec/install/yanked_spec.rb
@@ -54,8 +54,6 @@ RSpec.context "when installing a bundle that includes yanked gems" do
     end
 
     before do
-      skip "Materialization on Windows is not yet strict, so the example does not detect the gem has been yanked" if Gem.win_platform?
-
       build_repo4 do
         build_gem "foo", "1.0.0"
         build_gem "foo", "1.0.1"

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1901,22 +1901,14 @@ class TestGemInstaller < Gem::InstallerTestCase
   end
 
   def test_pre_install_checks_malicious_extensions_before_eval
-    pend "mswin environment disallow to create file contained the carriage return code." if Gem.win_platform?
-
     spec = util_spec "malicious", "1"
-    def spec.full_name # so the spec is buildable
-      "malicious-1"
-    end
-
     def spec.validate(*args); end
     spec.extensions = ["malicious\n``"]
 
-    util_build_gem spec
-
-    gem = File.join(@gemhome, "cache", spec.file_name)
+    installer = Gem::Installer.for_spec spec
+    installer.gem_home = @gemhome
 
     use_ui @ui do
-      installer = Gem::Installer.at gem
       e = assert_raise Gem::InstallError do
         installer.pre_install_checks
       end


### PR DESCRIPTION
The malicious extensions installer check was skipped on Windows because the example built a gem on disk, and the extension name embeds a newline that cannot become a file name there. Building the installer from the in-memory spec with Installer.for_spec runs verify_spec before the spec is eval'd without the newline ever reaching disk, so the check now runs on every platform.

A handful of Bundler install specs still carried Windows skips that no longer apply. Materialization now falls back from a yanked platform-specific locked spec to the generic variant, bundle exec bundle resolves the bundle executable, and git on Windows accepts branch and tag names starting with a hash, so those examples pass as is.

Both changes are forward-ported from ruby/ruby.
