### PR TITLE
Content addressable gems support

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -140,16 +140,42 @@ class Gem::BasicSpecification
   end
 
   ##
-  # Returns the full name (name-version) of this Gem.  Platform information
-  # is included (name-version-platform) if it is specified and not the
-  # default Ruby platform.
+  # Returns the full name (name-version) of this Gem.  For a content-addressable
+  # gem (one targeting a single Ruby ABI on a non-default platform), the content
+  # address takes the platform's place (name-version-<content-address>).
+  # Otherwise platform information is included (name-version-platform) unless it
+  # is the default Ruby platform.
 
   def full_name
-    if platform == Gem::Platform::RUBY || platform.nil?
+    if content_addressable?
+      "#{name}-#{version}-#{content_address}"
+    elsif platform == Gem::Platform::RUBY || platform.nil?
       "#{name}-#{version}"
     else
       "#{name}-#{version}-#{platform}"
     end
+  end
+
+  ##
+  # The content address (a hex prefix of the gem file's SHA256) used in place of
+  # the platform in #full_name for a Gem that targets one CRuby ABI
+
+  def content_address
+    raise NotImplementedError
+  end
+
+  ##
+  # True if this Gem is content-addressable, i.e. it carries a
+  # content address.
+
+  def content_addressable?
+    !content_address.nil?
+  end
+
+  CONTENT_ADDRESS = /\A[0-9a-f]{8,64}\z/ # :nodoc:
+
+  def self.content_address?(string) # :nodoc:
+    string.is_a?(String) && CONTENT_ADDRESS.match?(string)
   end
 
   ##

--- a/lib/rubygems/commands/fetch_command.rb
+++ b/lib/rubygems/commands/fetch_command.rb
@@ -93,6 +93,8 @@ then repackaging it.
         specs_and_sources = filtered unless filtered.empty?
       end
 
+      specs_and_sources = prefer_content_addressed(specs_and_sources)
+
       spec, source = specs_and_sources.max_by {|s,| s }
 
       if spec.nil?
@@ -105,5 +107,17 @@ then repackaging it.
     end
 
     exit_code
+  end
+
+  def prefer_content_addressed(specs_and_sources)
+    return specs_and_sources unless specs_and_sources.any? {|s,| s.content_addressable? }
+
+    compatible = specs_and_sources.select do |spec,|
+      spec.required_ruby_version.satisfied_by?(Gem.ruby_version)
+    end
+    specs_and_sources = compatible unless compatible.empty?
+
+    skinny = specs_and_sources.select {|s,| s.content_addressable? }
+    skinny.empty? ? specs_and_sources : skinny
   end
 end

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -114,6 +114,9 @@ class Gem::Installer
 
     def copy_to(path)
     end
+
+    def gem
+    end
   end
 
   ##
@@ -266,6 +269,8 @@ class Gem::Installer
   #     specifications/<gem-version>.gemspec #=> the Gem::Specification
 
   def install
+    assign_content_address
+
     pre_install_checks
 
     run_pre_install_hooks
@@ -965,6 +970,25 @@ class Gem::Installer
   end
 
   private
+
+  def assign_content_address
+    address = content_address_from_filename(@package.gem&.path)
+    spec.content_address = address if address
+  end
+
+  def content_address_from_filename(path)
+    return unless path
+
+    token = File.basename(path, ".gem").split("-").last
+    return unless Gem::BasicSpecification.content_address?(token)
+
+    require "digest"
+    unless Digest::SHA256.file(path).hexdigest.start_with?(token)
+      raise Gem::InstallError, "content address mismatch for #{File.basename(path)}"
+    end
+
+    token
+  end
 
   def user_install_dir
     # never install to user home in --build-root mode

--- a/lib/rubygems/name_tuple.rb
+++ b/lib/rubygems/name_tuple.rb
@@ -6,16 +6,17 @@
 # wrap the data returned from the indexes.
 
 class Gem::NameTuple
-  def initialize(name, version, platform = Gem::Platform::RUBY)
+  def initialize(name, version, platform = Gem::Platform::RUBY, content_address = nil)
     @name = name
     @version = version
 
     platform &&= platform.to_s
     platform = Gem::Platform::RUBY if !platform || platform.empty?
     @platform = platform
+    @content_address = content_address
   end
 
-  attr_reader :name, :version, :platform
+  attr_reader :name, :version, :platform, :content_address
 
   ##
   # Turn an array of [name, version, platform] into an array of
@@ -46,11 +47,15 @@ class Gem::NameTuple
   # of Gem::Specification#full_name.
 
   def full_name
-    case @platform
-    when nil, "", Gem::Platform::RUBY
-      "#{@name}-#{@version}"
+    if @content_address
+      "#{@name}-#{@version}-#{@content_address}"
     else
-      "#{@name}-#{@version}-#{@platform}"
+      case @platform
+      when nil, "", Gem::Platform::RUBY
+        "#{@name}-#{@version}"
+      else
+        "#{@name}-#{@version}-#{@platform}"
+      end
     end
   end
 
@@ -59,6 +64,13 @@ class Gem::NameTuple
 
   def match_platform?
     Gem::Platform.match_gem? @platform, @name
+  end
+
+  ##
+  # Indicate if this NameTuple is content-addressable (carries a content address).
+
+  def content_addressable?
+    !@content_address.nil?
   end
 
   ##
@@ -94,8 +106,8 @@ class Gem::NameTuple
   alias_method :to_s, :inspect # :nodoc:
 
   def <=>(other)
-    [@name, @version, Gem::Platform.sort_priority(@platform)] <=>
-      [other.name, other.version, Gem::Platform.sort_priority(other.platform)]
+    [@name, @version, Gem::Platform.sort_priority(@platform), @content_address.to_s] <=>
+      [other.name, other.version, Gem::Platform.sort_priority(other.platform), other.content_address.to_s]
   end
 
   include Comparable
@@ -109,7 +121,8 @@ class Gem::NameTuple
     when self.class
       @name == other.name &&
         @version == other.version &&
-        @platform == other.platform
+        @platform == other.platform &&
+        @content_address == other.content_address
     when Array
       to_a == other
     else
@@ -120,6 +133,6 @@ class Gem::NameTuple
   alias_method :eql?, :==
 
   def hash
-    to_a.hash
+    [@name, @version, @platform, @content_address].hash
   end
 end

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -396,10 +396,11 @@ class Gem::Resolver
       next installed.first if installed.length == 1
       candidates = installed if installed.any?
 
-      # Among remaining candidates, prefer the most specific platform, then the
-      # earlier-supplied source.
+      # Prefer the most specific platform; among equally specific candidates
+      # prefer a content-addressable (skinny) variant, then the earlier source.
       candidates.min_by do |s|
         [Gem::Platform.platform_specificity_match(s.platform, Gem::Platform.local),
+         s.content_addressable? ? 0 : 1,
          source_rank[s.source]]
       end
     end

--- a/lib/rubygems/resolver/activation_request.rb
+++ b/lib/rubygems/resolver/activation_request.rb
@@ -154,6 +154,6 @@ class Gem::Resolver::ActivationRequest
   private
 
   def name_tuple
-    @name_tuple ||= Gem::NameTuple.new(name, version, platform)
+    @name_tuple ||= Gem::NameTuple.new(name, version, platform, @spec.content_address)
   end
 end

--- a/lib/rubygems/resolver/api_set.rb
+++ b/lib/rubygems/resolver/api_set.rb
@@ -108,12 +108,12 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
       []
     end
 
-    infos.each do |_, number, platform, dependencies, requirements|
-      platform ||= "ruby"
+    infos.each do |_, number, suffix, dependencies, requirements|
+      suffix ||= "ruby"
       dependencies = dependencies.map {|dep_name, reqs| [dep_name, reqs.join(", ")] }
       requirements = requirements.map {|req_name, reqs| [req_name.to_sym, reqs] }.to_h
 
-      @data[name] << { name: name, number: number, platform: platform, dependencies: dependencies, requirements: requirements }
+      @data[name] << { name: name, number: number, suffix: suffix, dependencies: dependencies, requirements: requirements }
     end
 
     @data[name]

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -31,8 +31,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
     @set = set
     @name = api_data[:name]
     @version = Gem::Version.new(api_data[:number]).freeze
-    @platform = Gem::Platform.new(api_data[:platform]).freeze
-    @original_platform = api_data[:platform].freeze
+    assign_platform api_data
     @dependencies = api_data[:dependencies].map do |name, ver|
       Gem::Dependency.new(name, ver.split(/\s*,\s*/)).freeze
     end.freeze
@@ -46,11 +45,12 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
       @set          == other.set &&
       @name         == other.name &&
       @version      == other.version &&
-      @platform     == other.platform
+      @platform     == other.platform &&
+      @content_address == other.content_address
   end
 
   def hash
-    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash
+    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash ^ @content_address.hash
   end
 
   def fetch_development_dependencies # :nodoc:
@@ -97,6 +97,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
       s.version  = @version
       s.platform = @platform
       s.original_platform = @original_platform
+      s.content_address = @content_address
       s.required_ruby_version = @required_ruby_version
       s.required_rubygems_version = @required_rubygems_version
 
@@ -111,6 +112,28 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
   end
 
   private
+
+  def required_platform_from(requirement)
+    operator, platform = Array(requirement).last.to_s.strip.split(/\s+/, 2)
+    return unless operator == "=" && platform
+
+    Gem::Platform.new(platform)
+  end
+
+  def assign_platform(api_data)
+    suffix = api_data[:suffix].freeze
+    required_platform = required_platform_from(api_data.dig(:requirements, :platform))
+
+    if required_platform
+      @content_address = suffix
+      @platform = required_platform.freeze
+      @original_platform = required_platform.to_s.freeze
+    else
+      @content_address = nil
+      @platform = Gem::Platform.new(suffix).freeze
+      @original_platform = suffix
+    end
+  end
 
   def parse_created_at(value)
     value = value.first if value.is_a?(Array)

--- a/lib/rubygems/resolver/spec_specification.rb
+++ b/lib/rubygems/resolver/spec_specification.rb
@@ -24,6 +24,13 @@ class Gem::Resolver::SpecSpecification < Gem::Resolver::Specification
   end
 
   ##
+  # The content address of the backing gem
+
+  def content_address
+    spec.content_address
+  end
+
+  ##
   # The required_ruby_version constraint for this specification
 
   def required_ruby_version

--- a/lib/rubygems/resolver/specification.rb
+++ b/lib/rubygems/resolver/specification.rb
@@ -64,6 +64,7 @@ class Gem::Resolver::Specification
   # Sets default instance variables for the specification.
 
   def initialize
+    @content_address = nil
     @created_at   = nil
     @dependencies = nil
     @name         = nil
@@ -89,6 +90,15 @@ class Gem::Resolver::Specification
 
   def full_name
     "#{@name}-#{@version}"
+  end
+
+  ##
+  # The content address of a content-addressable gem, or nil for ordinary gems.
+
+  attr_reader :content_address
+
+  def content_addressable?
+    !content_address.nil?
   end
 
   ##

--- a/lib/rubygems/safe_marshal.rb
+++ b/lib/rubygems/safe_marshal.rb
@@ -51,7 +51,7 @@ module Gem
         @name @requirement @prerelease @version_requirement @version_requirements @type
         @force_ruby_platform
       ],
-      "Gem::NameTuple" => %w[@name @version @platform],
+      "Gem::NameTuple" => %w[@name @version @platform @content_address],
       "Gem::Platform" => %w[@os @cpu @version],
       "Psych::PrivateType" => %w[@value @type_id],
       "YAML::PrivateType" => %w[@value @type_id],

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -123,7 +123,10 @@ class Gem::Source
              rescue StandardError
                nil
              end
-      return spec if spec
+      if spec
+        spec.content_address = name_tuple.content_address if name_tuple.content_address
+        return spec
+      end
     end
 
     source_uri.path << ".rz"
@@ -142,7 +145,9 @@ class Gem::Source
 
     Gem.load_safe_marshal
     # TODO: Investigate setting Gem::Specification#loaded_from to a URI
-    Gem::SafeMarshal.safe_load spec
+    spec = Gem::SafeMarshal.safe_load spec
+    spec.content_address = name_tuple.content_address if name_tuple.content_address
+    spec
   end
 
   ##
@@ -258,7 +263,14 @@ class Gem::Source
         version = Gem::Version.new(version_string)
         next if version.prerelease? != (type == :prerelease)
 
-        Gem::NameTuple.new(name, version, platform || "ruby")
+        if Gem::BasicSpecification.content_address?(platform)
+          # The /versions index carries the content address in the platform slot,
+          # not the real platform. Record it as the content address (which keeps
+          # variants distinct) and let the fetched spec supply the real platform.
+          Gem::NameTuple.new(name, version, platform, platform)
+        else
+          Gem::NameTuple.new(name, version, platform || "ruby")
+        end
       end
 
       gem_tuples = max_versions_by_platform(gem_tuples) if type == :latest

--- a/lib/rubygems/spec_fetcher.rb
+++ b/lib/rubygems/spec_fetcher.rb
@@ -99,7 +99,7 @@ class Gem::SpecFetcher
 
       found[source] = specs.select do |tup|
         if dependency.match?(tup)
-          if matching_platform && !Gem::Platform.match_gem?(tup.platform, tup.name)
+          if matching_platform && !tup.content_addressable? && !Gem::Platform.match_gem?(tup.platform, tup.name)
             pm = (
               rejected_specs[dependency] ||= \
                 Gem::PlatformMismatch.new(tup.name, tup.version))

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -836,10 +836,24 @@ class Gem::Specification < Gem::BasicSpecification
       next versions if versions.nonzero?
       platforms = Gem::Platform.sort_priority(b.platform) <=> Gem::Platform.sort_priority(a.platform)
       next platforms if platforms.nonzero?
+      content = _compare_content_address(a, b)
+      next content if content.nonzero?
       default_gem = a.default_gem_priority <=> b.default_gem_priority
       next default_gem if default_gem.nonzero?
       a.base_dir_priority(gem_path) <=> b.base_dir_priority(gem_path)
     end
+  end
+
+  def self._compare_content_address(a, b) # :nodoc:
+    return 0 unless a.content_addressable? || b.content_addressable?
+
+    _content_address_priority(a) <=> _content_address_priority(b)
+  end
+
+  def self._content_address_priority(spec) # :nodoc:
+    full = spec.to_spec
+    built_for_running_ruby = full && full.required_ruby_version.satisfied_by?(Gem.ruby_version)
+    [built_for_running_ruby ? 0 : 1, spec.content_addressable? ? 0 : 1]
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -407,6 +407,13 @@ class Gem::Specification < Gem::BasicSpecification
 
   attr_accessor :metadata
 
+  ##
+  # The content address of a platformed gem that targets one Ruby ABI: a hex
+  # prefix of the gem's SHA256 that stands in for the platform in the .gem file
+  # name.  Assigned at install time, not declared in the gemspec.
+
+  attr_accessor :content_address # :nodoc:
+
   ######################################################################
   # :section: Optional gemspec attributes
 
@@ -1949,6 +1956,7 @@ class Gem::Specification < Gem::BasicSpecification
     @loaded_from = nil
     @original_platform = nil
     @installed_by_version = nil
+    @content_address = nil
 
     set_nil_attributes_to_nil
     set_not_nil_attributes_to_default_values
@@ -2370,9 +2378,11 @@ class Gem::Specification < Gem::BasicSpecification
   def to_ruby
     result = []
     result << "# -*- encoding: utf-8 -*-"
-    result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{platform} #{raw_require_paths.join("\0")}"
+    slot = content_addressable? ? content_address : platform
+    result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{slot} #{raw_require_paths.join("\0")}"
     result << "#{Gem::StubSpecification::PREFIX}#{extensions.join "\0"}" unless
       extensions.empty?
+    result << "#{Gem::StubSpecification::TARGET_PREFIX}platform=#{platform}" if content_addressable?
     result << nil
     result << "Gem::Specification.new do |s|"
 
@@ -2381,6 +2391,7 @@ class Gem::Specification < Gem::BasicSpecification
     unless platform.nil? || platform == Gem::Platform::RUBY
       result << "  s.platform = #{ruby_code original_platform}"
     end
+    result << "  s.content_address = #{ruby_code content_address}" if content_addressable?
     result << ""
     result << "  s.required_rubygems_version = #{ruby_code required_rubygems_version} if s.respond_to? :required_rubygems_version="
 

--- a/lib/rubygems/specification_policy.rb
+++ b/lib/rubygems/specification_policy.rb
@@ -434,6 +434,8 @@ or set it to nil if you don't want to specify a license.
     # TODO: raise at some given date
     warning "deprecated autorequire specified" if @specification.autorequire
 
+    warning "content_address is assigned automatically at install time; remove it from your gemspec" if @specification.content_address
+
     @specification.executables.each do |executable|
       validate_executable(executable)
       validate_shebang_line_in(executable)

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -10,11 +10,14 @@ class Gem::StubSpecification < Gem::BasicSpecification
   PREFIX = "# stub: "
 
   # :nodoc:
+  TARGET_PREFIX = "# stub-target: "
+
+  # :nodoc:
   OPEN_MODE = "r:UTF-8:-"
 
   class StubLine # :nodoc: all
     attr_reader :name, :version, :platform, :require_paths, :extensions,
-                :full_name
+                :full_name, :content_address
 
     NO_EXTENSIONS = [].freeze
 
@@ -33,7 +36,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
       "lib" => ["lib"].freeze,
     }.freeze
 
-    def initialize(data, extensions)
+    def initialize(data, extensions, target = nil)
       parts          = data[PREFIX.length..-1].split(" ", 4)
       @name          = -parts[0]
       @version       = if Gem::Version.correct?(parts[1])
@@ -42,12 +45,15 @@ class Gem::StubSpecification < Gem::BasicSpecification
         Gem::Version.new(0)
       end
 
-      @platform      = Gem::Platform.new parts[2]
-      @extensions    = extensions
-      @full_name     = if platform == Gem::Platform::RUBY
+      suffix           = parts[2]
+      @extensions      = extensions
+      target_platform  = target && target["platform"]
+      @platform        = Gem::Platform.new(target_platform || suffix)
+      @content_address = Gem::BasicSpecification.content_address?(suffix) ? suffix : nil
+      @full_name       = if @platform == Gem::Platform::RUBY
         "#{name}-#{version}"
       else
-        "#{name}-#{version}-#{platform}"
+        "#{name}-#{version}-#{suffix}"
       end
 
       path_list = parts.last
@@ -110,18 +116,24 @@ class Gem::StubSpecification < Gem::BasicSpecification
           file.readline # discard encoding line
           stubline = file.readline
           if stubline.start_with?(PREFIX)
-            extline = file.readline
+            extensions = StubLine::NO_EXTENSIONS
+            target = nil
 
-            extensions =
-              if extline.delete_prefix!(PREFIX)
-                extline.chomp!
-                extline.split "\0"
+            loop do
+              line = file.readline
+              if line.delete_prefix!(TARGET_PREFIX)
+                line.chomp!
+                target = parse_target(line)
+              elsif line.delete_prefix!(PREFIX)
+                line.chomp!
+                extensions = line.split "\0"
               else
-                StubLine::NO_EXTENSIONS
+                break
               end
+            end
 
             stubline.chomp! # readline(chomp: true) allocates 3x as much as .readline.chomp!
-            @data = StubLine.new stubline, extensions
+            @data = StubLine.new stubline, extensions, target
           end
         rescue EOFError
         end
@@ -134,6 +146,15 @@ class Gem::StubSpecification < Gem::BasicSpecification
   end
 
   private :data
+
+  def parse_target(line)
+    line.split(" ").each_with_object({}) do |pair, target|
+      key, value = pair.split("=", 2)
+      target[key] = value if value
+    end
+  end
+
+  private :parse_target
 
   def raw_require_paths # :nodoc:
     data.require_paths
@@ -178,6 +199,10 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
   def full_name
     data.full_name
+  end
+
+  def content_address
+    data.content_address
   end
 
   ##

--- a/test/rubygems/test_gem_commands_fetch_command.rb
+++ b/test/rubygems/test_gem_commands_fetch_command.rb
@@ -12,6 +12,30 @@ class TestGemCommandsFetchCommand < Gem::TestCase
     @cmd = Gem::Commands::FetchCommand.new
   end
 
+  def test_prefer_content_addressed
+    fat = util_spec("a", "1") {|s| s.platform = "arm64-darwin" }
+    s33 = util_spec("a", "1") do |s|
+      s.platform = "arm64-darwin"
+      s.content_address = "3a41cc2c08"
+      s.required_ruby_version = "~> 3.3.0"
+    end
+    s34 = util_spec("a", "1") do |s|
+      s.platform = "arm64-darwin"
+      s.content_address = "bd0ec167"
+      s.required_ruby_version = "~> 3.4.0"
+    end
+    pairs = [[fat, nil], [s33, nil], [s34, nil]]
+
+    Gem.stub :ruby_version, Gem::Version.new("3.4.5") do
+      chosen = @cmd.send(:prefer_content_addressed, pairs).map {|s,| s.content_address }
+      assert_equal ["bd0ec167"], chosen, "the running-Ruby skinny"
+    end
+
+    # No content-addressable candidates: leave the set untouched.
+    plain = [[fat, nil]]
+    assert_same plain, @cmd.send(:prefer_content_addressed, plain)
+  end
+
   def test_execute
     specs = spec_fetcher do |fetcher|
       fetcher.gem "a", 2

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -291,6 +291,47 @@ class TestGemInstaller < Gem::InstallerTestCase
     assert_equal "a requires b (> 2)", e.message
   end
 
+  def test_install_assigns_content_address_from_filename
+    require "digest"
+    _, a_gem = util_gem "a", 2
+    address = Digest::SHA256.file(a_gem).hexdigest[0, 8]
+    skinny = File.join(File.dirname(a_gem), "a-2-#{address}.gem")
+    FileUtils.cp a_gem, skinny
+
+    installer = Gem::Installer.at skinny, install_dir: @gemhome, force: true
+    spec = installer.install
+
+    assert_equal address, spec.content_address
+    assert spec.content_addressable?
+    assert_equal "a-2-#{address}", spec.full_name
+    assert_path_exist File.join(@gemhome, "gems", "a-2-#{address}")
+    assert_path_exist File.join(@gemhome, "specifications", "a-2-#{address}.gemspec")
+  end
+
+  def test_install_raises_when_content_address_token_does_not_match_sha
+    _, a_gem = util_gem "a", 2
+    bogus = File.join(File.dirname(a_gem), "a-2-deadbeef.gem")
+    FileUtils.cp a_gem, bogus
+
+    installer = Gem::Installer.at bogus, install_dir: @gemhome, force: true
+
+    e = assert_raise Gem::InstallError do
+      installer.install
+    end
+    assert_match "content address mismatch", e.message
+  end
+
+  def test_install_does_not_content_address_ordinary_gem
+    _, a_gem = util_gem "a", 2
+
+    installer = Gem::Installer.at a_gem, install_dir: @gemhome, force: true
+    spec = installer.install
+
+    refute spec.content_addressable?
+    assert_nil spec.content_address
+    assert_equal "a-2", spec.full_name
+  end
+
   def test_ensure_loadable_spec
     a, a_gem = util_gem "a", 2 do |s|
       s.add_dependency "garbage ~> 5"

--- a/test/rubygems/test_gem_name_tuple.rb
+++ b/test/rubygems/test_gem_name_tuple.rb
@@ -16,6 +16,24 @@ class TestGemNameTuple < Gem::TestCase
 
     n = Gem::NameTuple.new "a", Gem::Version.new(0), "other"
     assert_equal "a-0-other", n.full_name
+
+    n = Gem::NameTuple.new "a", Gem::Version.new(0), "arm64-darwin", "bd0ec167"
+    assert_equal "a-0-bd0ec167", n.full_name
+  end
+
+  def test_content_address_variants_are_distinct
+    a = Gem::NameTuple.new "a", Gem::Version.new(0), "arm64-darwin", "bd0ec167"
+    b = Gem::NameTuple.new "a", Gem::Version.new(0), "arm64-darwin", "3a41cc2c08"
+
+    assert a.content_addressable?
+    refute Gem::NameTuple.new("a", Gem::Version.new(0), "ruby").content_addressable?
+    refute_equal a, b
+    refute_equal a.hash, b.hash
+    assert_equal 2, [a, b].uniq.size
+
+    same = Gem::NameTuple.new "a", Gem::Version.new(0), "arm64-darwin", "bd0ec167"
+    assert_equal a, same
+    assert_equal a.hash, same.hash
   end
 
   def test_platform_normalization

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -285,6 +285,44 @@ class TestGemResolver < Gem::TestCase
     assert_resolves_to [a2], res
   end
 
+  def test_prefers_content_addressable_variant
+    set = Gem::Resolver::APISet.new
+    fat = Gem::Resolver::APISpecification.new(set,
+      { name: "a", number: "1", suffix: "arm64-darwin", dependencies: [], requirements: {} })
+    skinny = Gem::Resolver::APISpecification.new(set,
+      { name: "a", number: "1", suffix: "abc12345", dependencies: [],
+        requirements: { ruby: [">= 0"], platform: ["= arm64-darwin"] } })
+
+    resolver = Gem::Resolver.new [], set
+    all = Hash.new {|h, k| h[k] = [] }
+    all["a"] = [fat, skinny]
+    resolver.instance_variable_set(:@all_specs, all)
+
+    chosen = resolver.send(:build_spec_for_cache, "a")
+
+    assert_equal skinny, chosen[v(1)]
+  end
+
+  def test_prefers_more_specific_platform_over_content_addressable
+    util_set_arch "arm64-darwin-23" do
+      set = Gem::Resolver::APISet.new
+      fat = Gem::Resolver::APISpecification.new(set,
+        { name: "a", number: "1", suffix: "arm64-darwin-23", dependencies: [], requirements: {} })
+      skinny = Gem::Resolver::APISpecification.new(set,
+        { name: "a", number: "1", suffix: "abc12345", dependencies: [],
+          requirements: { ruby: [">= 0"], platform: ["= arm64-darwin"] } })
+
+      resolver = Gem::Resolver.new [], set
+      all = Hash.new {|h, k| h[k] = [] }
+      all["a"] = [skinny, fat]
+      resolver.instance_variable_set(:@all_specs, all)
+
+      chosen = resolver.send(:build_spec_for_cache, "a")
+
+      assert_equal fat, chosen[v(1)]
+    end
+  end
+
   def test_picks_best_platform
     is      = Gem::Resolver::IndexSpecification
     unknown = Gem::Platform.new "unknown"

--- a/test/rubygems/test_gem_resolver_activation_request.rb
+++ b/test/rubygems/test_gem_resolver_activation_request.rb
@@ -26,6 +26,19 @@ class TestGemResolverActivationRequest < Gem::TestCase
     assert act_req.development?
   end
 
+  def test_full_name
+    assert_equal "a-3", @req.full_name
+
+    set = Gem::Resolver::APISet.new
+    data = { name: "a", number: "1", suffix: "bd0ec167", dependencies: [],
+             requirements: { platform: ["= arm64-darwin"] } }
+    ca = Gem::Resolver::ActivationRequest.new(
+      Gem::Resolver::APISpecification.new(set, data), @dep
+    )
+
+    assert_equal "a-1-bd0ec167", ca.full_name
+  end
+
   def test_inspect
     assert_match "a-3",                         @req.inspect
     assert_match "from a (>= 0)",               @req.inspect

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -38,7 +38,7 @@ class TestGemResolverAPISet < Gem::TestCase
     data = [
       { name: "a",
         number: "1",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
     ]
 
@@ -61,11 +61,11 @@ class TestGemResolverAPISet < Gem::TestCase
     data = [
       { name: "a",
         number: "1",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
       { name: "a",
         number: "2.a",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
     ]
 
@@ -90,7 +90,7 @@ class TestGemResolverAPISet < Gem::TestCase
     data = [
       { name: "a",
         number: "1",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
     ]
 

--- a/test/rubygems/test_gem_resolver_api_specification.rb
+++ b/test/rubygems/test_gem_resolver_api_specification.rb
@@ -8,7 +8,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: Gem::Platform.local.to_s,
+      suffix: Gem::Platform.local.to_s,
       dependencies: [
         ["bundler",  "~> 1.0"],
         ["railties", "= 3.0.3"],
@@ -20,6 +20,8 @@ class TestGemResolverAPISpecification < Gem::TestCase
     assert_equal "rails",                   spec.name
     assert_equal Gem::Version.new("3.0.3"), spec.version
     assert_equal Gem::Platform.local,       spec.platform
+    refute spec.content_addressable?
+    assert_nil spec.content_address
 
     expected = [
       Gem::Dependency.new("bundler",  "~> 1.0"),
@@ -30,12 +32,31 @@ class TestGemResolverAPISpecification < Gem::TestCase
     assert_nil spec.created_at
   end
 
+  def test_initialize_content_addressable
+    set = Gem::Resolver::APISet.new
+    data = {
+      name: "darwin-demo",
+      number: "1.0.0",
+      suffix: "bd0ec167",
+      dependencies: [],
+      requirements: { ruby: ["~> 3.4.0"], platform: ["= arm64-darwin"] },
+    }
+
+    spec = Gem::Resolver::APISpecification.new set, data
+
+    assert spec.content_addressable?
+    assert_equal "bd0ec167", spec.content_address
+    assert_equal Gem::Platform.new("arm64-darwin"), spec.platform
+    assert_equal "darwin-demo-1.0.0-bd0ec167", spec.spec.full_name
+    assert_equal "bd0ec167", spec.spec.content_address
+  end
+
   def test_initialize_created_at
     set = Gem::Resolver::APISet.new
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
       requirements: { created_at: ["2026-06-05T10:30:45Z"] },
     }
@@ -50,7 +71,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
       requirements: { created_at: ["not a timestamp"] },
     }
@@ -65,7 +86,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
       requirements: { created_at: ["2026"] },
     }
@@ -93,7 +114,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [
         ["bundler",  "~> 1.0"],
         ["railties", "= 3.0.3"],
@@ -120,7 +141,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "a",
       number: "1",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
     }
 
@@ -131,7 +152,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "b",
       number: "1",
-      platform: "cpu-other_platform-1",
+      suffix: "cpu-other_platform-1",
       dependencies: [],
     }
 
@@ -142,7 +163,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "c",
       number: "1",
-      platform: Gem::Platform.local.to_s,
+      suffix: Gem::Platform.local.to_s,
       dependencies: [],
     }
 
@@ -156,7 +177,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "a",
       number: "1",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
     }
 
@@ -175,7 +196,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "a",
       number: "1",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
     }
 
@@ -199,7 +220,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "j",
       number: "1",
-      platform: "jruby",
+      suffix: "jruby",
       dependencies: [],
     }
 

--- a/test/rubygems/test_gem_resolver_installed_specification.rb
+++ b/test/rubygems/test_gem_resolver_installed_specification.rb
@@ -19,6 +19,17 @@ class TestGemResolverInstalledSpecification < Gem::TestCase
     assert_equal Gem::Platform::RUBY, spec.platform
   end
 
+  def test_content_address_delegates_to_spec
+    plain = Gem::Resolver::InstalledSpecification.new @set, util_spec("a")
+    refute plain.content_addressable?
+    assert_nil plain.content_address
+
+    skinny_spec = util_spec("a") {|s| s.content_address = "bd0ec167" }
+    skinny = Gem::Resolver::InstalledSpecification.new @set, skinny_spec
+    assert skinny.content_addressable?
+    assert_equal "bd0ec167", skinny.content_address
+  end
+
   def test_install
     a = util_spec "a"
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1952,6 +1952,57 @@ dependencies: []
     assert_equal Gem::Platform.new("arm64-darwin"), @a2.platform
   end
 
+  def test_resort_orders_content_addressed_variants_by_ruby_abi
+    fat = util_spec("a", "1") {|s| s.platform = "arm64-darwin" }
+    old = util_spec("a", "1") do |s|
+      s.platform = "arm64-darwin"
+      s.content_address = "3a41cc2c08"
+      s.required_ruby_version = "~> 3.3.0"
+    end
+    new = util_spec("a", "1") do |s|
+      s.platform = "arm64-darwin"
+      s.content_address = "bd0ec167"
+      s.required_ruby_version = "~> 3.4.0"
+    end
+
+    Gem.stub :ruby_version, Gem::Version.new("3.4.5") do
+      specs = [old, fat, new]
+      Gem::Specification._resort! specs
+      assert_equal "bd0ec167", specs.first.content_address, "running-Ruby skinny first"
+      assert specs[1].content_address.nil?, "then the compatible fat"
+    end
+
+    Gem.stub :ruby_version, Gem::Version.new("3.3.9") do
+      specs = [new, fat, old]
+      Gem::Specification._resort! specs
+      assert_equal "3a41cc2c08", specs.first.content_address
+    end
+  end
+
+  def test_resort_keeps_ordinary_duplicates_lazy
+    # A default gem plus an installed copy tie on name-version-platform but are
+    # not content-addressable; _resort! must not load their full specs.
+    a = util_spec("a", "1")
+    b = util_spec("a", "1")
+    [a, b].each do |s|
+      def s.to_spec
+        raise "to_spec must not be called for ordinary gems"
+      end
+    end
+
+    sorted = Gem::Specification._resort!([a, b]) # must not call to_spec
+    assert_equal 2, sorted.size
+  end
+
+  def test_content_address_priority_tolerates_missing_spec
+    spec = util_spec("a", "1") {|s| s.content_address = "bd0ec167" }
+    def spec.to_spec
+      nil
+    end
+
+    assert_equal [1, 0], Gem::Specification._content_address_priority(spec)
+  end
+
   def test_gem_build_complete_path
     expected = File.join @a1.extension_dir, "gem.build_complete"
     assert_equal expected, @a1.gem_build_complete_path

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1940,6 +1940,18 @@ dependencies: []
     end
   end
 
+  def test_content_addressable_full_name
+    refute @a2.content_addressable?
+    assert_nil @a2.content_address
+
+    @a2.platform = "arm64-darwin"
+    @a2.content_address = "bd0ec167"
+
+    assert @a2.content_addressable?
+    assert_equal "a-2-bd0ec167", @a2.full_name
+    assert_equal Gem::Platform.new("arm64-darwin"), @a2.platform
+  end
+
   def test_gem_build_complete_path
     expected = File.join @a1.extension_dir, "gem.build_complete"
     assert_equal expected, @a1.gem_build_complete_path
@@ -2513,6 +2525,22 @@ end
     assert_equal "old_platform", same_spec.original_platform
   end
 
+  def test_to_ruby_content_addressable
+    @a2.platform = "arm64-darwin"
+    @a2.content_address = "bd0ec167"
+
+    ruby_code = @a2.to_ruby
+    lines = ruby_code.lines
+
+    assert_equal "# stub: a 2 bd0ec167 lib\n", lines[1]
+    assert_includes ruby_code, "# stub-target: platform=arm64-darwin"
+    assert_includes ruby_code, %(s.content_address = "bd0ec167")
+
+    reloaded = eval ruby_code
+    assert_equal "bd0ec167", reloaded.content_address
+    assert_equal "a-2-bd0ec167", reloaded.full_name
+  end
+
   def test_to_yaml
     yaml_str = @a1.to_yaml
 
@@ -2677,6 +2705,21 @@ end
       end
 
       assert_match "#{w}:  deprecated autorequire specified\n",
+                   @ui.error, "error"
+    end
+  end
+
+  def test_validate_content_address_warns
+    util_setup_validate
+
+    Dir.chdir @tempdir do
+      @a1.content_address = "bd0ec167"
+
+      use_ui @ui do
+        @a1.validate
+      end
+
+      assert_match "content_address is assigned automatically at install time",
                    @ui.error, "error"
     end
   end

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -47,6 +47,19 @@ class TestStubSpecification < Gem::TestCase
     assert_equal v(0),                        stub.version
   end
 
+  def test_content_addressable_stub
+    refute @foo.content_addressable?
+    assert_nil @foo.content_address
+
+    stub = stub_content_addressed
+
+    assert stub.content_addressable?
+    assert_equal "bd0ec167", stub.content_address
+    assert_equal Gem::Platform.new("arm64-darwin"), stub.platform
+    assert_equal "skinny-1.0.0-bd0ec167", stub.full_name
+    assert_equal ["lib"], stub.require_paths
+  end
+
   def test_initialize_missing_stubline
     stub = Gem::StubSpecification.gemspec_stub(BAR, @base_dir, @gems_dir)
     assert_equal "bar", stub.name
@@ -212,6 +225,15 @@ class TestStubSpecification < Gem::TestCase
     refute_same real_bar, bar_default.to_spec
   end
 
+  def test_content_addressable_to_spec_carries_address
+    spec = stub_content_addressed.to_spec
+
+    assert_equal "bd0ec167", spec.content_address
+    assert spec.content_addressable?
+    assert_equal "skinny-1.0.0-bd0ec167", spec.full_name
+    assert_equal Gem::Platform.new("arm64-darwin"), spec.platform
+  end
+
   def test_to_spec_with_other_specs_loaded_does_not_warn
     real_foo = util_spec @foo.name, @foo.version
     real_foo.activate
@@ -230,6 +252,32 @@ class TestStubSpecification < Gem::TestCase
         Gem::Specification.new do |s|
           s.name = 'stub_v'
           s.version = Gem::Version.new '2'
+        end
+      STUB
+
+      io.flush
+
+      stub = Gem::StubSpecification.gemspec_stub io.path, @gemhome, File.join(@gemhome, "gems")
+
+      yield stub if block_given?
+
+      return stub
+    end
+  end
+
+  def stub_content_addressed
+    spec = File.join @gemhome, "specifications", "skinny-1.0.0-bd0ec167.gemspec"
+    File.open spec, "w" do |io|
+      io.write <<~STUB
+        # -*- encoding: utf-8 -*-
+        # stub: skinny 1.0.0 bd0ec167 lib
+        # stub-target: platform=arm64-darwin
+
+        Gem::Specification.new do |s|
+          s.name = 'skinny'
+          s.version = Gem::Version.new '1.0.0'
+          s.platform = 'arm64-darwin'
+          s.content_address = 'bd0ec167'
         end
       STUB
 


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

https://github.com/ruby/rubygems/issues/9654

## What is your fix for the problem, implemented in this PR?

Content-addressable ("skinny") gems put a content address (a SHA-256 prefix) where the platform normally goes in a gem's filename, so multiple per-Ruby-ABI builds can coexist for one version (`darwin-demo-1.0.0-bd0ec167.gem`). This adds the **consumer** side to RubyGems — resolve, install, activate, fetch. Building skinny gems is out of scope.

## Notable design decisions

- **Content address is a separate field, not overloaded onto `Gem::Platform`.** `@platform` stays the real platform; the content address is its own attribute and `full_name` becomes `name-version-<address>`. Putting the SHA inside the platform (the earlier `version_suffix` approach) feeds a non-platform value into `match_gem?`/specificity/sorting, where it parses to a bogus `os="unknown"` — so we keep those paths clean and thread one new field instead.

- **Real platform lives on a `# stub-target:` line, not a 5th `# stub:` field.** The platform slot on `# stub:` is already the content address, so the real platform has to go elsewhere. A separate `key=value` comment line is (1) ignored by older parsers instead of breaking the positional format, and (2) extensible — a future `ruby=~> 3.4.0` key could make activation ABI-aware with no full-spec load.

- **`content_address` is `:nodoc:` and not a gemspec attribute.** It's the SHA of the built `.gem`, so it can't be authored — excluded from `@@attributes`, and `gem build` warns if set (like `autorequire`). But `to_ruby` writes it into the installed gemspec body (like `installed_by_version`) so a loaded spec still carries it.

- **Install verifies and fails loud.** The filename token is re-hashed against the file; a mismatch raises `Gem::InstallError` rather than silently installing under the fat name. (Self-consistency check; the trust boundary is still the registry checksum.)

- **Specificity first, content-addressed as a tiebreak** — not "skinny always wins." `build_spec_for_cache` sorts by `[specificity, content_addressable?, source]`, so a more-specific fat still beats a less-specific skinny.

- **Activation is ABI-aware only when it must be.** When skinny variants of the same `name-version-platform` coexist in one GEM_HOME, `_resort!` prefers the running-Ruby build. It's reached only when name+version+platform all tie (only CA variants can) and loads a spec only when a CA variant is involved, so ordinary default+installed duplicates stay lazy — no hot-path regression.

- **`Gem::NameTuple` gains `content_address`** (in `==`/`hash`) so variants stay distinct and display correctly. `to_a` stays the 3-field wire tuple; the `SafeMarshal` allowlist gains the ivar — additive and backward-compatible.

<img width="1249" height="584" alt="Screenshot 2026-07-03 at 7 24 00 PM" src="https://github.com/user-attachments/assets/f5a4b32f-a9fb-4b33-b209-ca2ad82d6d55" />

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
