### PR TITLE
Skip the make job server when using BSD make

### DIFF
--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -125,7 +125,7 @@ module Bundler
       # every native extension build with `fatal error U1065: invalid option
       # '-'`. Skip the jobserver when nmake is in use. Other Windows toolchains
       # such as mingw use GNU make and keep working through the inherited pipe.
-      return yield if nmake?
+      return yield if nmake? || bsd_make?
 
       begin
         r, w = IO.pipe
@@ -153,6 +153,12 @@ module Bundler
       make = ENV["MAKE"] || ENV["make"]
       make ||= "nmake" if RUBY_PLATFORM.include?("mswin")
       /\bnmake/i.match?(make.to_s)
+    end
+
+    def bsd_make?
+      return false unless Gem.freebsd_platform?
+      make = ENV["MAKE"] || ENV["make"] || "make"
+      !/\bgmake/i.match?(make)
     end
 
     def install_serially

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -251,4 +251,50 @@ RSpec.describe Bundler::ParallelInstaller do
       expect(makeflags_during).to eq(makeflags_before)
     end
   end
+
+  describe "make jobserver on BSD" do
+    # BSD make (the default `make` on FreeBSD) can't parse the GNU
+    # `--jobserver-auth` and aborts every native extension build, so the
+    # jobserver must be skipped there.
+    it "leaves MAKEFLAGS untouched" do
+      parallel_installer = Bundler::ParallelInstaller.new(nil, [], 5, false, false)
+
+      makeflags_before = ENV["MAKEFLAGS"]
+      makeflags_during = :not_yielded
+
+      old_make = ENV["MAKE"]
+      ENV.delete("MAKE")
+      allow(Gem).to receive(:freebsd_platform?).and_return(true)
+      begin
+        parallel_installer.send(:with_jobserver) do
+          makeflags_during = ENV["MAKEFLAGS"]
+        end
+      ensure
+        ENV["MAKE"] = old_make
+      end
+
+      expect(makeflags_during).to eq(makeflags_before)
+    end
+
+    # A BSD user who opts into gmake gets a make that understands the
+    # jobserver, so it should still be set up.
+    it "sets up the jobserver when gmake is used" do
+      parallel_installer = Bundler::ParallelInstaller.new(nil, [], 5, false, false)
+
+      makeflags_during = :not_yielded
+
+      old_make = ENV["MAKE"]
+      ENV["MAKE"] = "gmake"
+      allow(Gem).to receive(:freebsd_platform?).and_return(true)
+      begin
+        parallel_installer.send(:with_jobserver) do
+          makeflags_during = ENV["MAKEFLAGS"]
+        end
+      ensure
+        ENV["MAKE"] = old_make
+      end
+
+      expect(makeflags_during).to include("--jobserver-auth=")
+    end
+  end
 end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Like nmake (#9630), BSD make can't parse the GNU `--jobserver-auth` flag in MAKEFLAGS and aborts native extension builds with:

    make: argument 'observer-auth=6,7' to option '-j' must be a positive number

## What is your fix for the problem, implemented in this PR?

Skip the jobserver on BSD platforms, unless gmake is explicitly being used. Similar in approach to #9630 for nmake.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
