### PR TITLE
Open compact index cache in binary mode when appending

### DIFF
--- a/lib/bundler/compact_index_client/cache_file.rb
+++ b/lib/bundler/compact_index_client/cache_file.rb
@@ -103,7 +103,7 @@ module Bundler
       # Returns false without appending when no digests since appending is too error prone to do without digests.
       def append(data)
         return false unless digests?
-        open("a") {|f| f.write data }
+        open("ab") {|f| f.write data }
         verify && commit
       end
 

--- a/lib/rubygems/compact_index_client/cache_file.rb
+++ b/lib/rubygems/compact_index_client/cache_file.rb
@@ -99,7 +99,7 @@ class Gem::CompactIndexClient
     # Returns false without appending when no digests since appending is too error prone to do without digests.
     def append(data)
       return false unless digests?
-      open("a") {|f| f.write data }
+      open("ab") {|f| f.write data }
       verify && commit
     end
 

--- a/spec/bundler/compact_index_client/cache_file_spec.rb
+++ b/spec/bundler/compact_index_client/cache_file_spec.rb
@@ -2,6 +2,7 @@
 
 require "bundler/compact_index_client"
 require "bundler/compact_index_client/cache_file"
+require "tmpdir"
 
 RSpec.describe Bundler::CompactIndexClient::CacheFile do
   let(:path) { Pathname.new(Dir.mktmpdir("localpath")).join("versions") }

--- a/spec/bundler/compact_index_client/cache_file_spec.rb
+++ b/spec/bundler/compact_index_client/cache_file_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "bundler/compact_index_client"
+require "bundler/compact_index_client/cache_file"
+
+RSpec.describe Bundler::CompactIndexClient::CacheFile do
+  let(:path) { Pathname.new(Dir.mktmpdir("localpath")).join("versions") }
+
+  def sha256(data)
+    { "sha-256" => Digest::SHA256.base64digest(data) }
+  end
+
+  it "appends in binary mode so line endings are preserved" do
+    path.binwrite "created_at: 2026-06-10\n---\n"
+
+    appended = nil
+    described_class.copy(path) do |file|
+      file.digests = sha256("created_at: 2026-06-10\n---\nrake 13.0.0\n")
+      appended = file.append("rake 13.0.0\n")
+    end
+
+    expect(appended).to be_truthy
+    # On Windows a text-mode append rewrites the appended LF as CRLF while the
+    # digest is computed over the pre-write bytes, so verify passes but the file
+    # on disk is corrupted. Read raw bytes to catch any stray carriage return.
+    expect(path.binread).not_to include("\r")
+    expect(path.binread).to eq("created_at: 2026-06-10\n---\nrake 13.0.0\n")
+  end
+end

--- a/spec/support/shards.rb
+++ b/spec/support/shards.rb
@@ -143,6 +143,7 @@ module Spec
         "spec/bundler/ci_detector_spec.rb",
       ],
       shard_d: [
+        "spec/bundler/compact_index_client/cache_file_spec.rb",
         "spec/bundler/rubygems_ext_spec.rb",
         "spec/bundler/resolver/cooldown_spec.rb",
         "spec/install/cooldown_spec.rb",

--- a/test/rubygems/test_gem_compact_index_client_cache_file.rb
+++ b/test/rubygems/test_gem_compact_index_client_cache_file.rb
@@ -82,6 +82,23 @@ class TestGemCompactIndexClientCacheFile < Gem::TestCase
     assert_equal "abcdef", @path.read
   end
 
+  def test_append_writes_in_binary_mode
+    @path.binwrite "created_at: 2026-06-10\n---\n"
+
+    appended = nil
+    CacheFile.copy(@path) do |file|
+      file.digests = sha256("created_at: 2026-06-10\n---\nrake 13.0.0\n")
+      appended = file.append("rake 13.0.0\n")
+    end
+
+    assert appended
+    # On Windows a text-mode append rewrites the appended LF as CRLF while the
+    # digest is computed over the pre-write bytes, so verify passes but the file
+    # on disk is corrupted. Read raw bytes to catch any stray carriage return.
+    refute_includes @path.binread, "\r"
+    assert_equal "created_at: 2026-06-10\n---\nrake 13.0.0\n", @path.binread
+  end
+
   def test_append_with_mismatched_digests_keeps_original
     @path.binwrite "abc"
 


### PR DESCRIPTION
`CompactIndexClient::CacheFile#append` opened the temporary cache file with mode `"a"`. On Windows that is a text-mode stream, so every `"\n"` written into the appended range is silently rewritten as `"\r\n"`. Full writes already use the binary `"wb"` mode, so only the incremental append path is affected.

The corruption is invisible to the integrity check. `append` writes through `Gem::Package::DigestIO`, which hashes the logical bytes handed to `write`, not the bytes the operating system actually lands on disk. The digest therefore matches, `verify` returns true, and the mangled file is committed to the cache as if it were correct.

The failure compounds on the next update. The stray carriage returns inflate `file.size`, so the following ranged request (`file.size - 1`) restarts at the wrong offset and the reassembled `versions` index no longer matches the digest the server advertises, forcing a full multi-megabyte re-download. The per-gem `info` files keep failing their MD5 comparison against the raw index bytes, so they are refetched on every resolve. A full replace with `"wb"` heals the file momentarily, but the next incremental append corrupts it again, leaving Windows users in a permanent re-download loop.

The fix opens the append stream with `"ab"` so the appended range is written verbatim, matching the binary mode already used for full writes. The change is applied to both the Bundler and RubyGems copies of `CacheFile`.

## Tests

`test/rubygems/test_gem_compact_index_client_cache_file.rb` gains `test_append_writes_in_binary_mode`, which appends content containing an `"\n"` and asserts via `binread` that no `"\r"` reaches disk. On the unfixed code this fails on Windows with `"rake 13.0.0\r\n"`; with the fix it passes. A matching `spec/bundler/compact_index_client/cache_file_spec.rb` covers the Bundler copy. The existing append specs used newline-free payloads, which is why the corruption went unnoticed.
