### PR TITLE
Resolve Bundler release paths lazily in prepare_release

### DIFF
--- a/tool/changelog.rb
+++ b/tool/changelog.rb
@@ -40,7 +40,7 @@ end
 class Changelog
   def self.for_rubygems(version)
     @for_rubygems ||= new(
-      File.expand_path("../CHANGELOG.md", __dir__),
+      ["../CHANGELOG.md"],
       "rubygems",
       version,
     )
@@ -48,15 +48,21 @@ class Changelog
 
   def self.for_bundler(version)
     @for_bundler ||= new(
-      File.expand_path("../CHANGELOG-bundler.md", __dir__),
+      # Bundler's changelog was flattened to CHANGELOG-bundler.md at the repo
+      # root on master, but keeps its traditional bundler/CHANGELOG.md path on
+      # the 4.0 and earlier release branches. The release task loads this tool
+      # from the default branch and cuts the changelog after switching to the
+      # release branch, so the real path is resolved lazily in #file against
+      # the release branch working tree.
+      ["../CHANGELOG-bundler.md", "../bundler/CHANGELOG.md"],
       "bundler",
       version,
     )
   end
 
-  def initialize(file, config_key, version)
+  def initialize(files, config_key, version)
     @version = Gem::Version.new(version)
-    @file = File.expand_path(file)
+    @files = Array(files).map {|file| File.expand_path(file, __dir__) }
     config = Psych.load_file(File.expand_path("../.changelog.yml", __dir__))
     @config = config[config_key]
     @level = @version.segments[2] != 0 ? :patch : :minor_or_major
@@ -110,7 +116,7 @@ class Changelog
       released_notes_until(previous_version),
     ].join("\n") + "\n"
 
-    File.write(@file, full_new_changelog)
+    File.write(file, full_new_changelog)
   end
 
   def unreleased_notes_for(included_pull_requests, extra_entry:)
@@ -250,7 +256,15 @@ class Changelog
   end
 
   def content
-    File.read(@file)
+    File.read(file)
+  end
+
+  # Resolved against the working tree at read/write time rather than at
+  # construction, because the release task cuts the changelog only after
+  # switching to the release branch. Picks the first candidate that exists so
+  # the flattened master path and the traditional subtree path both work.
+  def file
+    @files.find {|candidate| File.exist?(candidate) } || @files.first
   end
 
   def release_section_token

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -80,8 +80,21 @@ class Release
       @version = Gem::Version.new(version)
       @stable_branch = stable_branch
       @changelog = Changelog.for_bundler(version)
-      @version_files = [File.expand_path("../lib/bundler/version.rb", __dir__)]
+      # Bundler's version file was flattened to lib/bundler/version.rb on
+      # master, but stays at bundler/lib/bundler/version.rb on the 4.0 and
+      # earlier release branches. The release task loads this tool from the
+      # default branch and bumps versions after switching to the release
+      # branch, so the real path is resolved lazily in #version_files against
+      # the release branch working tree.
+      @version_file_candidates = [
+        File.expand_path("../lib/bundler/version.rb", __dir__),
+        File.expand_path("../bundler/lib/bundler/version.rb", __dir__),
+      ]
       @tag_prefix = "bundler-v"
+    end
+
+    def version_files
+      [@version_file_candidates.find {|candidate| File.exist?(candidate) } || @version_file_candidates.first]
     end
 
     def extra_entry


### PR DESCRIPTION
`rake prepare_release` fails when preparing a 4.0 or earlier release. The task loads the release tooling from `master`, then checks out a release branch cut from the stable branch and cuts changelogs and bumps versions against that working tree. Bundler was flattened on `master`, so its changelog lives at `CHANGELOG-bundler.md` and its version file at `lib/bundler/version.rb`, but the 4.0 and earlier branches keep the old subtree layout at `bundler/CHANGELOG.md` and `bundler/lib/bundler/version.rb`. Because `Changelog` and `Release::Bundler` resolved those paths at construction time on `master`, they pointed at the flattened paths and failed with `Errno::ENOENT` after the checkout.

This resolves the two Bundler paths lazily at read and write time instead, after the release branch is checked out. `Changelog` now keeps a list of candidate paths and picks the first that exists in the working tree through a private `#file`, and `Release::Bundler#version_files` does the same for its version file. The flattened `master` path and the traditional subtree path both resolve correctly. The rubygems side paths are identical on both layouts and stay untouched.
