### PR TITLE
Disable git background maintenance in bundler specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -147,6 +147,16 @@ RSpec.configure do |config|
       ENV["GIT_CONFIG_NOSYSTEM"] = "1"
     end
 
+    # Disable git background maintenance. Since Git 2.46, commands like
+    # `git commit` spawn a detached `git maintenance run --auto` process,
+    # which briefly creates `.git/objects/maintenance.lock`. That races with
+    # specs copying repositories with FileUtils.cp_r, causing flaky ENOENT
+    # failures. GIT_CONFIG_COUNT is available since Git 2.31 and silently
+    # ignored by older versions.
+    ENV["GIT_CONFIG_COUNT"] = "1"
+    ENV["GIT_CONFIG_KEY_0"] = "maintenance.auto"
+    ENV["GIT_CONFIG_VALUE_0"] = "false"
+
     # Don't wrap output in tests
     ENV["THOR_COLUMNS"] = "10000"
 


### PR DESCRIPTION
Since Git 2.46, commands like `git commit` spawn a detached `git maintenance run --auto` process that briefly creates `.git/objects/maintenance.lock`. Specs copying a just-committed repository with `FileUtils.cp_r` can observe that lock file disappearing between `readdir` and `lstat`, which surfaces as flaky `Errno::ENOENT` failures on macOS CI runners running newer Git.

This sets `maintenance.auto` to `false` for the spec harness through `GIT_CONFIG_COUNT`, which Git has honored since 2.31 and older versions ignore silently. The change was made directly in `ruby/ruby` and is forward-ported here so the two trees stay in sync.
