### PR TITLE
Escape glob metacharacters in install paths when globbing

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -141,7 +141,7 @@ module Bundler
         end
       end
 
-      Dir[cache_path.join("*/.git")].each do |git_dir|
+      Gem::Util.glob_files_in_dir("*/.git", cache_path.to_s).each do |git_dir|
         FileUtils.rm_rf(git_dir)
         FileUtils.touch(File.expand_path("../.bundlecache", git_dir))
       end
@@ -159,13 +159,13 @@ module Bundler
     end
 
     def clean(dry_run = false)
-      gem_bins             = Dir["#{Gem.dir}/bin/*"]
-      git_dirs             = Dir["#{Gem.dir}/bundler/gems/*"]
-      git_cache_dirs       = Dir["#{Gem.dir}/cache/bundler/git/*"]
-      gem_dirs             = Dir["#{Gem.dir}/gems/*"]
-      gem_files            = Dir["#{Gem.dir}/cache/*.gem"]
-      gemspec_files        = Dir["#{Gem.dir}/specifications/*.gemspec"]
-      extension_dirs       = Dir["#{Gem.dir}/extensions/*/*/*"] + Dir["#{Gem.dir}/bundler/gems/extensions/*/*/*"]
+      gem_bins             = Gem::Util.glob_files_in_dir("bin/*", Gem.dir)
+      git_dirs             = Gem::Util.glob_files_in_dir("bundler/gems/*", Gem.dir)
+      git_cache_dirs       = Gem::Util.glob_files_in_dir("cache/bundler/git/*", Gem.dir)
+      gem_dirs             = Gem::Util.glob_files_in_dir("gems/*", Gem.dir)
+      gem_files            = Gem::Util.glob_files_in_dir("cache/*.gem", Gem.dir)
+      gemspec_files        = Gem::Util.glob_files_in_dir("specifications/*.gemspec", Gem.dir)
+      extension_dirs       = Gem::Util.glob_files_in_dir("extensions/*/*/*", Gem.dir) + Gem::Util.glob_files_in_dir("bundler/gems/extensions/*/*/*", Gem.dir)
       spec_gem_paths       = []
       # need to keep git sources around
       spec_git_paths       = @definition.spec_git_paths
@@ -232,7 +232,7 @@ module Bundler
     private
 
     def prune_gem_cache(resolve, cache_path)
-      cached = Dir["#{cache_path}/*.gem"]
+      cached = Gem::Util.glob_files_in_dir("*.gem", cache_path.to_s)
 
       cached = cached.delete_if do |path|
         spec = Bundler.rubygems.spec_from_gem path
@@ -257,7 +257,7 @@ module Bundler
     end
 
     def prune_git_and_path_cache(resolve, cache_path)
-      cached = Dir["#{cache_path}/*/.bundlecache"]
+      cached = Gem::Util.glob_files_in_dir("*/.bundlecache", cache_path.to_s)
 
       cached = cached.delete_if do |path|
         name = File.basename(File.dirname(path))
@@ -283,7 +283,7 @@ module Bundler
       # Add man/ subdirectories from activated bundles to MANPATH for man(1)
       manuals = $LOAD_PATH.filter_map do |path|
         man_subdir = path.sub(/lib$/, "man")
-        man_subdir unless Dir[man_subdir + "/man?/"].empty?
+        man_subdir unless Dir.glob("man?/", base: man_subdir).empty?
       end
 
       return if manuals.empty?

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -325,7 +325,7 @@ module Bundler
 
       def serialize_gemspecs_in(destination)
         destination = destination.expand_path(Bundler.root) if destination.relative?
-        Dir["#{destination}/#{@glob}"].each do |spec_path|
+        Gem::Util.glob_files_in_dir(@glob, destination.to_s).each do |spec_path|
           # Evaluate gemspecs and cache the result. Gemspecs
           # in git might require git or other dependencies.
           # The gemspecs we cache should already be evaluated.

--- a/lib/bundler/source/rubygems.rb
+++ b/lib/bundler/source/rubygems.rb
@@ -406,7 +406,7 @@ module Bundler
         @cached_specs ||= begin
           idx = Index.new
 
-          Dir["#{cache_path}/*.gem"].each do |gemfile|
+          Gem::Util.glob_files_in_dir("*.gem", cache_path.to_s).each do |gemfile|
             s ||= Bundler.rubygems.spec_from_gem(gemfile)
             s.source = self
             idx << s

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -306,9 +306,7 @@ class Gem::BasicSpecification
   # Return all files in this gem that match for +glob+.
 
   def matches_for_glob(glob) # TODO: rename?
-    glob = File.join(lib_dirs_glob, glob)
-
-    Dir[glob]
+    Gem::Util.glob_files_in_dir(File.join(lib_dirs, glob), full_gem_path)
   end
 
   ##
@@ -323,17 +321,7 @@ class Gem::BasicSpecification
   # for this spec.
 
   def lib_dirs_glob
-    dirs = if raw_require_paths
-      if raw_require_paths.size > 1
-        "{#{raw_require_paths.join(",")}}"
-      else
-        raw_require_paths.first
-      end
-    else
-      "lib" # default value for require_paths for bundler/inline
-    end
-
-    "#{full_gem_path}/#{dirs}"
+    "#{full_gem_path}/#{lib_dirs}"
   end
 
   ##
@@ -363,6 +351,22 @@ class Gem::BasicSpecification
   end
 
   private
+
+  ##
+  # Returns the require_paths of this gem as a string usable in Dir.glob,
+  # relative to full_gem_path.
+
+  def lib_dirs
+    if raw_require_paths
+      if raw_require_paths.size > 1
+        "{#{raw_require_paths.join(",")}}"
+      else
+        raw_require_paths.first
+      end
+    else
+      "lib" # default value for require_paths for bundler/inline
+    end
+  end
 
   def have_extensions?
     !extensions.empty?

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -76,7 +76,9 @@ module Gem::Util
 
   ##
   # Globs for files matching +pattern+ inside of +directory+,
-  # returning absolute paths to the matching files.
+  # returning absolute paths to the matching files. Unlike a plain
+  # Dir.glob with an interpolated path, glob metacharacters in
+  # +base_path+ are not treated as part of the pattern.
 
   def self.glob_files_in_dir(glob, base_path)
     Dir.glob(glob, base: base_path).map! {|f| File.expand_path(f, base_path) }

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -46,6 +46,34 @@ RSpec.describe "bundle clean" do
     expect(vendored_gems("bin/myrackup")).to exist
   end
 
+  it "removes unused gems when the bundle path contains glob metacharacters" do
+    gemfile <<-G
+      source "https://gem.repo1"
+
+      gem "thin"
+      gem "foo"
+    G
+
+    bundle_config "path vendor/dir[1]"
+    bundle_config "clean false"
+    bundle "install"
+
+    gemfile <<-G
+      source "https://gem.repo1"
+
+      gem "thin"
+    G
+    bundle "install"
+
+    bundle :clean
+
+    expect(out).to include("Removing foo (1.0)")
+
+    metachar_vendored_gems = scoped_gem_path(bundled_app("vendor/dir[1]"))
+    expect(metachar_vendored_gems.join("gems/foo-1.0")).not_to exist
+    expect(metachar_vendored_gems.join("gems/thin-1.0")).to exist
+  end
+
   it "removes old version of gem if unused" do
     gemfile <<-G
       source "https://gem.repo1"

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -119,6 +119,26 @@ RSpec.describe "bundle install with git sources" do
       expect(file_code).to eq(ruby_code)
     end
 
+    it "caches the evaluated gemspec when the bundle path contains glob metacharacters" do
+      bundle_config "path vendor/dir[1]"
+      install_base_gemfile
+      git = update_git "foo" do |s|
+        s.executables = ["foobar"] # we added this the first time, so keep it now
+        s.files = ["bin/foobar"] # updating git nukes the files list
+        foospec = s.to_ruby.gsub(/s\.files.*/, 's.files = `git ls-files -z`.split("\x0")')
+        s.write "foo.gemspec", foospec
+      end
+
+      bundle "update foo"
+
+      sha = git.ref_for("main", 11)
+      spec_file = scoped_gem_path(bundled_app("vendor/dir[1]")).join("bundler/gems/foo-1.0-#{sha}/foo.gemspec")
+      expect(spec_file).to exist
+      ruby_code = Gem::Specification.load(spec_file.to_s).to_ruby
+      file_code = File.read(spec_file)
+      expect(file_code).to eq(ruby_code)
+    end
+
     it "does not update the git source implicitly" do
       install_base_gemfile
       update_git "foo"

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -118,6 +118,31 @@ class TestStubSpecification < Gem::TestCase
     assert_equal code_rb, stub.matches_for_glob("code*").first
   end
 
+  def test_matches_for_glob_with_glob_metacharacters_in_gem_dir
+    base_dir = File.join @tempdir, "dir[1]"
+    gems_dir = File.join base_dir, "gems"
+    spec_dir = File.join base_dir, "specifications"
+    FileUtils.mkdir_p spec_dir
+
+    spec = File.join spec_dir, "stub-2.gemspec"
+    File.write spec, <<~STUB
+      # -*- encoding: utf-8 -*-
+      # stub: stub 2 ruby lib
+
+      Gem::Specification.new do |s|
+        s.name = 'stub'
+        s.version = Gem::Version.new '2'
+      end
+    STUB
+
+    stub = Gem::StubSpecification.gemspec_stub spec, base_dir, gems_dir
+    code_rb = File.join stub.gem_dir, "lib", "code.rb"
+    FileUtils.mkdir_p File.dirname code_rb
+    FileUtils.touch code_rb
+
+    assert_equal code_rb, stub.matches_for_glob("code*").first
+  end
+
   def test_matches_for_glob_with_bundler_inline
     stub = stub_with_extension
     code_rb = File.join stub.gem_dir, "lib", "code.rb"


### PR DESCRIPTION
Install paths interpolated directly into `Dir[...]` silently match nothing when the path contains glob metacharacters such as `[`, `]`, `{` or `}`, which are legal in directory names. On Windows this happens in practice with user names like `foo[1]`, which browsers produce when deduplicating download names. The affected sites were `Gem::BasicSpecification#matches_for_glob`, which made gem plugins silently fail to load and `Gem.find_files` return nothing, `Bundler::Source::Git#serialize_gemspecs_in`, which skipped gemspec serialization for git gems, and the globs behind `bundle clean` and `bundle cache`, which lost track of the files they manage.

This applies the same fix as 7fe7e7b26c, which addressed the identical problem for the `gemspec` DSL and the path source: glob through `Gem::Util.glob_files_in_dir`, which passes the directory as the `base:` argument of `Dir.glob` so only the intended pattern part is treated as a glob. The returned paths keep the same absolute form as before because both `Gem.dir` and `full_gem_path` are already expanded.

Each of the three paths is covered by a new test using a `dir[1]` directory, and all of them fail before the fix. A few remaining interpolated globs in secondary commands (`gem contents`, `gem stale`, `gem setup`, the certificate trust dir, `bundle doctor`) are left for a follow-up since they are not on the install path.
