### PR TITLE
Cache a shared git source only once per command

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -30,6 +30,7 @@ module Bundler
 
         @copied     = false
         @local      = false
+        @cached_app_cache_path = nil
       end
 
       def remote!
@@ -277,6 +278,11 @@ module Bundler
 
         app_cache_path = app_cache_path(custom_path)
 
+        # When several gems share a single git source, this is called once per
+        # gem. Copying the repository is expensive for large repos, so skip it
+        # if we already populated this cache during the same command.
+        return if @cached_app_cache_path == app_cache_path
+
         migrate = try_migrate ? bare_repo?(app_cache_path) : false
 
         set_cache_path!(nil) if migrate
@@ -288,6 +294,8 @@ module Bundler
         git_proxy.checkout if migrate || requires_checkout?
         git_proxy.copy_to(app_cache_path, @submodules)
         serialize_gemspecs_in(app_cache_path)
+
+        @cached_app_cache_path = app_cache_path
       end
 
       def checkout

--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -120,4 +120,33 @@ RSpec.describe Bundler::Source::Git do
       end
     end
   end
+
+  describe "#cache" do
+    let(:options) do
+      { "uri" => uri, "revision" => "123abc" }
+    end
+    let(:app_cache_path) { Pathname.new("vendor/cache/bar-123abc") }
+    let(:git_proxy_stub) do
+      instance_double(Bundler::Source::Git::GitProxy, revision: "123abc", copy_to: nil)
+    end
+
+    before do
+      allow(Bundler::Source::Git::GitProxy).to receive(:new).and_return(git_proxy_stub)
+      allow(Bundler.settings).to receive(:[]).and_call_original
+      allow(Bundler.settings).to receive(:[]).with(:cache_all).and_return(true)
+      allow(subject).to receive(:app_cache_path).and_return(app_cache_path)
+      allow(subject).to receive(:cache_path).and_return(Pathname.new("global/git/bar-123abc"))
+      allow(subject).to receive(:requires_checkout?).and_return(false)
+      allow(subject).to receive(:serialize_gemspecs_in)
+      allow(::Bundler::FileUtils).to receive(:rm_rf)
+    end
+
+    it "copies the repository only once when several gems share the same source" do
+      subject.cache(double("spec for gem a"))
+      subject.cache(double("spec for gem b"))
+
+      expect(git_proxy_stub).to have_received(:copy_to).once
+      expect(::Bundler::FileUtils).to have_received(:rm_rf).once
+    end
+  end
 end

--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -120,4 +120,32 @@ RSpec.describe Bundler::Source::Git do
       end
     end
   end
+
+  describe "#cache" do
+    let(:options) do
+      { "uri" => uri, "revision" => "123abc" }
+    end
+    let(:app_cache_path) { Pathname.new("vendor/cache/bar-123abc") }
+    let(:git_proxy_stub) do
+      instance_double(Bundler::Source::Git::GitProxy, revision: "123abc", copy_to: nil)
+    end
+
+    before do
+      allow(Bundler::Source::Git::GitProxy).to receive(:new).and_return(git_proxy_stub)
+      allow(Bundler.settings).to receive(:[]).and_call_original
+      allow(Bundler.settings).to receive(:[]).with(:cache_all).and_return(true)
+      allow(subject).to receive(:app_cache_path).and_return(app_cache_path)
+      allow(subject).to receive(:cache_path).and_return(Pathname.new("global/git/bar-123abc"))
+      allow(subject).to receive(:requires_checkout?).and_return(false)
+      allow(subject).to receive(:serialize_gemspecs_in)
+      allow(FileUtils).to receive(:rm_rf)
+    end
+
+    it "copies the repository only once when several gems share the same source" do
+      subject.cache(double("spec for gem a"))
+      subject.cache(double("spec for gem b"))
+
+      expect(git_proxy_stub).to have_received(:copy_to).once
+    end
+  end
 end

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -83,6 +83,29 @@ RSpec.describe "bundle cache with git" do
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
+  # The copy count is asserted in spec/bundler/source/git_spec.rb, which can
+  # observe `copy_to` in-process.
+  it "caches a repository shared by multiple gems" do
+    build_git "foo", path: lib_path("shared")
+    git = build_git "bar", path: lib_path("shared")
+    ref = git.ref_for("main", 11)
+
+    install_gemfile <<-G
+      source "https://gem.repo1"
+      git "#{lib_path("shared")}" do
+        gem "foo"
+        gem "bar"
+      end
+    G
+
+    bundle :cache
+
+    expect(bundled_app("vendor/cache/shared-#{ref}")).to exist
+
+    FileUtils.rm_r lib_path("shared")
+    expect(the_bundle).to include_gems "foo 1.0", "bar 1.0"
+  end
+
   it "tracks updates" do
     git = build_git "foo"
     old_ref = git.ref_for("main", 11)

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -83,6 +83,29 @@ RSpec.describe "bundle cache with git" do
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
+  it "caches a repository shared by multiple gems only once" do
+    build_lib "foo", path: lib_path("shared/foo")
+    build_lib "bar", path: lib_path("shared/bar")
+    build_git "foo", path: lib_path("shared")
+    git = build_git "bar", path: lib_path("shared")
+    ref = git.ref_for("main", 11)
+
+    install_gemfile <<-G
+      source "https://gem.repo1"
+      git "#{lib_path("shared")}" do
+        gem "foo"
+        gem "bar"
+      end
+    G
+
+    bundle :cache
+
+    expect(bundled_app("vendor/cache/shared-#{ref}")).to exist
+
+    FileUtils.rm_r lib_path("shared")
+    expect(the_bundle).to include_gems "foo 1.0", "bar 1.0"
+  end
+
   it "tracks updates" do
     git = build_git "foo"
     old_ref = git.ref_for("main", 11)

--- a/spec/cache/git_spec.rb
+++ b/spec/cache/git_spec.rb
@@ -83,7 +83,9 @@ RSpec.describe "bundle cache with git" do
     expect(the_bundle).to include_gems "foo 1.0"
   end
 
-  it "caches a repository shared by multiple gems only once" do
+  # The copy count is asserted in spec/bundler/source/git_spec.rb, which can
+  # observe `copy_to` in-process.
+  it "caches a repository shared by multiple gems" do
     build_lib "foo", path: lib_path("shared/foo")
     build_lib "bar", path: lib_path("shared/bar")
     build_git "foo", path: lib_path("shared")


### PR DESCRIPTION
When multiple gems come from a single `git` block, `Runtime#cache` invokes the shared `Source::Git` instance once per gem. `cache_to` had no idempotency, so it removed the just written cache and re-ran `git_proxy.copy_to`, cloning and checking out the whole worktree every time. For large repositories such as `rails` this made `bundle cache`, `bundle update`, and `bundle install` noticeably slower, showing the checkout progress once per gem even though only a single fetch was needed.

This memoizes the written app cache path on the source and skips the copy when the same path was already populated during the current command. The revision does not change within a single command run, so re-writing the same path is pure waste.

Fixes https://github.com/ruby/rubygems/issues/8592
