### PR TITLE
Validate spec name before writing to the spec cache

### DIFF
--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -109,6 +109,13 @@ class Gem::Source
 
     spec_file_name = name_tuple.spec_name
 
+    # The name tuple comes from a remote index and is not otherwise
+    # validated, so refuse anything that would escape the spec cache
+    # directory when used as a path component.
+    if File.basename(spec_file_name) != spec_file_name
+      raise Gem::Exception, "malformed spec name: #{spec_file_name.inspect}"
+    end
+
     source_uri = enforce_trailing_slash(uri) + "#{Gem::MARSHAL_SPEC_DIR}#{spec_file_name}"
 
     cache_dir = cache_dir source_uri

--- a/test/rubygems/test_gem_source.rb
+++ b/test/rubygems/test_gem_source.rb
@@ -121,6 +121,19 @@ class TestGemSource < Gem::TestCase
     assert_equal @specs["a-1"].full_name, spec.full_name
   end
 
+  def test_fetch_spec_path_traversal
+    escape = File.expand_path(File.join(Gem.spec_cache_dir, "..", "owned.gemspec"))
+
+    name_tuple = tuple("../owned", Gem::Version.new(1), "ruby")
+
+    e = assert_raise Gem::Exception do
+      @source.fetch_spec name_tuple
+    end
+
+    assert_includes e.message, "malformed spec name"
+    refute File.exist?(escape), "spec must not be written outside the spec cache"
+  end
+
   def test_load_specs
     released = @source.load_specs(:released).map(&:full_name)
     assert_equal %W[a-2 a-1 b-2], released


### PR DESCRIPTION
Gem::Source#fetch_spec builds the local spec cache path directly from the name tuple returned by a remote index. That name is never validated for use as a path component, so a name containing path separators or `..` makes fetch_spec write the downloaded gemspec bytes outside `Gem.spec_cache_dir`, before the Marshal payload is ever loaded.

This adds a basename check at the single write site: any spec name that is not a plain basename is rejected before the cache path is constructed. Guarding here covers every crafted component (name, version, platform) at once, rather than filtering each index parser separately.