### PR TITLE
Normalize CRLF line breaks when parsing YAML in Gem::YAMLSerializer

### DIFF
--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -815,7 +815,9 @@ module Gem
       end
 
       def emit_string(str, indent, quote: false)
-        if str.include?("\n")
+        # A CR cannot be represented in a block scalar because parsing
+        # normalizes CRLF line breaks to LF, so quote and escape instead.
+        if str.include?("\n") && !str.include?("\r")
           emit_block_scalar(str, indent)
         elsif needs_quoting?(str, quote)
           " #{quote_string(str)}\n"

--- a/lib/rubygems/yaml_serializer.rb
+++ b/lib/rubygems/yaml_serializer.rb
@@ -52,7 +52,7 @@ module Gem
       }.freeze
 
       def initialize(source)
-        @lines = source.split("\n")
+        @lines = source.split(/\r?\n/)
         @anchors = {}
         @depth = 0
         strip_document_prefix

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -1100,6 +1100,18 @@ class TestGemSafeYAML < Gem::TestCase
     assert_equal "data", result["other"]
   end
 
+  def test_load_crlf_with_sequence
+    yaml = <<~YAML.gsub("\n", "\r\n")
+      ---
+      nested_hash:
+        contains_array:
+        - "quoted item"
+        - plain item
+    YAML
+
+    assert_equal({ "nested_hash" => { "contains_array" => ["quoted item", "plain item"] } }, yaml_load(yaml))
+  end
+
   def test_load_version_requirement_old_tag
     yaml = <<~YAML
       !ruby/object:Gem::Version::Requirement

--- a/test/rubygems/test_gem_safe_yaml.rb
+++ b/test/rubygems/test_gem_safe_yaml.rb
@@ -1100,6 +1100,11 @@ class TestGemSafeYAML < Gem::TestCase
     assert_equal "data", result["other"]
   end
 
+  def test_dump_crlf_string_roundtrip
+    obj = { "pem" => "line one\r\nline two\r\n" }
+    assert_equal obj, yaml_load(yaml_dump(obj))
+  end
+
   def test_load_crlf_with_sequence
     yaml = <<~YAML.gsub("\n", "\r\n")
       ---


### PR DESCRIPTION
`Gem::YAMLSerializer` splits the source on LF alone, which leaves a trailing CR on every line of a CRLF document. The empty-value check then sees the stray CR as a non-empty scalar and folds the following indented lines into a single plain scalar, so nested mappings and sequences collapse into one string. For example `Gem::YAMLSerializer.load("a:\r\n  b: c\r\n")` returns `"a: b: c"` instead of `{"a" => {"b" => "c"}}`. This patch splits on `/\r?\n/` so the CR is treated as part of the line break, matching both the YAML spec and Psych. The existing CRLF test only covered a flat mapping, which happens to survive the stray CR, so a test with a nested mapping and sequence is added.
