### PR TITLE
Avoid space-containing absolute path in RUBYOPT

### DIFF
--- a/lib/bundler/shared_helpers.rb
+++ b/lib/bundler/shared_helpers.rb
@@ -347,7 +347,12 @@ module Bundler
 
     def set_rubyopt
       rubyopt = [ENV["RUBYOPT"]].compact
-      setup_require = "-r#{File.expand_path("setup", __dir__)}"
+      setup_path = File.expand_path("setup", __dir__)
+      # RUBYOPT is split on whitespace with no quoting mechanism, so an
+      # absolute path containing spaces would be torn apart. Fall back to
+      # requiring by feature name; set_rubylib puts our lib directory first
+      # on the child's load path.
+      setup_require = /\s/.match?(setup_path) ? "-rbundler/setup" : "-r#{setup_path}"
       return if !rubyopt.empty? && rubyopt.first.include?(setup_require)
       rubyopt.unshift setup_require
       Bundler::SharedHelpers.set_env "RUBYOPT", rubyopt.join(" ")

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -404,6 +404,7 @@ RSpec.describe Bundler::SharedHelpers do
 
       before do
         allow(File).to receive(:expand_path).and_return("#{install_path}/bundler/setup")
+        allow(Gem).to receive(:bin_path).and_return("#{install_path}/bundler/setup")
       end
 
       # RUBYOPT is split on whitespace with no quoting mechanism, so an

--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -399,6 +399,33 @@ RSpec.describe Bundler::SharedHelpers do
       it_behaves_like "ENV['RUBYOPT'] gets set correctly"
     end
 
+    context "when bundler install path contains whitespace" do
+      let(:install_path) { "/opt/ruby with space/lib" }
+
+      before do
+        allow(File).to receive(:expand_path).and_return("#{install_path}/bundler/setup")
+      end
+
+      # RUBYOPT is split on whitespace with no quoting mechanism, so an
+      # absolute -r path containing spaces would make every child ruby fail
+      # to boot with "invalid switch in RUBYOPT".
+      it "requires bundler/setup by feature name instead of absolute path" do
+        subject.set_bundle_environment
+        expect(ENV["RUBYOPT"].split(" ")).to start_with("-rbundler/setup")
+      end
+
+      it "does not inject the space-containing path into RUBYOPT" do
+        subject.set_bundle_environment
+        expect(ENV["RUBYOPT"]).not_to include(install_path)
+      end
+
+      it "is idempotent" do
+        subject.set_bundle_environment
+        subject.set_bundle_environment
+        expect(ENV["RUBYOPT"].split(" ").grep(%r{\A-r.*bundler/setup\z}).length).to eq(1)
+      end
+    end
+
     context "ENV['RUBYLIB'] does not exist" do
       before { ENV.delete("RUBYLIB") }
 


### PR DESCRIPTION
`Bundler::SharedHelpers#set_rubyopt` injects `-r<absolute path to bundler/setup>` into `RUBYOPT`. Ruby splits `RUBYOPT` on whitespace with no quoting mechanism, so when bundler lives under an install prefix containing a space (for example `C:\Program Files`), the path tears apart and every child ruby spawned under `bundle exec` dies at boot with `invalid switch in RUBYOPT: -i`.

The absolute path was introduced in a5da088a6d so that child processes never leak to a different bundler copy. That property is kept for all currently working setups: the absolute form is still used whenever the path has no whitespace. Only in the space-containing case, which today fails unconditionally, does `set_rubyopt` fall back to requiring `bundler/setup` by feature name. `set_rubylib` already puts bundler's lib directory first on the child's load path via `RUBYLIB` (which is `PATH_SEPARATOR`-separated and therefore safe with spaces), so the child still resolves the same bundler copy. When bundler is the default gem in `rubylibdir`, `RUBYLIB` is not modified and the feature name resolves through the same ruby's default load path, again the same copy. The `BUNDLER_SETUP` variable is unaffected since it is consumed as a plain `require` argument in `lib/rubygems.rb` where spaces are harmless.

Verified on Windows with a mswin Ruby 4.0.5 and the patched bundler copied under `V:\tmp\ruby with space\patched lib\`:

```
bundler dir = "V:/tmp/ruby with space/patched lib/bundler"
RUBYOPT = "-rbundler/setup"
RUBYLIB = "V:/tmp/ruby with space/patched lib"
child: child ok, Bundler loaded from V:/tmp/ruby with space/patched lib/bundler/shared_helpers.rb
OK site5: child ruby boots and loads the intended bundler copy
control: old-style RUBYOPT child => exit 1, ruby.exe: invalid switch in RUBYOPT: -i (RuntimeError)
```

Related to #9695, which fixes the argv quoting half of the same space-path breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
