### PR TITLE
Fix bundle outdated --groups to actually group output

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -192,7 +192,7 @@ module Bundler
         )
       end
 
-      print_indented([table_header] + data)
+      print_indented([table_header] + data, !options_include_groups)
     end
 
     def print_gem(current_spec, active_spec, dependency, groups)
@@ -294,7 +294,7 @@ module Bundler
       version_section.to_a[0].to_i
     end
 
-    def print_indented(matrix)
+    def print_indented(matrix, sort = true)
       header = matrix[0]
       data = matrix[1..-1]
 
@@ -304,7 +304,7 @@ module Bundler
 
       Bundler.ui.info justify(header, column_sizes)
 
-      data.sort_by! {|row| row[0] }
+      data.sort_by! {|row| row[0] } if sort
 
       data.each do |row|
         Bundler.ui.info justify(row, column_sizes)

--- a/spec/commands/outdated_spec.rb
+++ b/spec/commands/outdated_spec.rb
@@ -274,6 +274,7 @@ RSpec.describe "bundle outdated" do
       build_repo2 do
         build_git "foo", path: lib_path("foo")
         build_git "zebra", path: lib_path("zebra")
+        build_gem "zondrian", "1.2"
       end
 
       install_gemfile <<-G
@@ -284,6 +285,7 @@ RSpec.describe "bundle outdated" do
         group :development, :test do
           gem 'activesupport', '2.3.5'
           gem "duradura", '7.0'
+          gem "zondrian", '1.2'
         end
       G
     end
@@ -298,15 +300,17 @@ RSpec.describe "bundle outdated" do
         build_gem "activesupport", "3.0"
         build_gem "terranova", "9"
         build_gem "duradura", "8.0"
+        build_gem "zondrian", "1.3"
       end
 
       bundle "outdated --groups", raise_on_error: false
 
       expected_output = <<~TABLE.strip
         Gem            Current  Latest  Requested  Groups             Release Date
+        terranova      8        9       = 8        default
         activesupport  2.3.5    3.0     = 2.3.5    development, test
         duradura       7.0      8.0     = 7.0      development, test
-        terranova      8        9       = 8        default
+        zondrian       1.2      1.3     = 1.2      development, test
       TABLE
 
       expect(out).to end_with(expected_output)


### PR DESCRIPTION
# Purpose
Update `bundle outdated --groups` to produce its table of output actually sorted _by group_.

# Analysis
`print_indented` unconditionally sorted table rows by gem name, discarding the group clustering that --groups had already computed, so --groups produced output identical to plain outdated (#9333). Skip that re-sort when a --group/--groups option is active, since specs_for_outdated_check already sorts by name and group_by preserves that order within each group.

## What was the end-user or developer problem that led to this PR?
A (correct) observation in #9333 that `bundle outdated --groups` was not actually grouping at all.

## What is your fix for the problem, implemented in this PR?
* Update the existing test on this to assert a more obviously failing result - because listing the gems alphabetically also resulted in them being accidentally "grouped"
* Add a `sort = true` second positional parameter to `print_indented!`, which controls whether to sort its results before printing
* in `print_gems_table`, determine whether to sort based on the `options_include_groups` attr, which is true if `--groups` or `--group foo` is supplied.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
