### PR TITLE
Raise FormatError for a corrupt checksums.yaml.gz in Package#verify

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -366,7 +366,11 @@ EOM
 
       @checksums.to_h do |algorithm, _|
         [algorithm, Gem::Security.create_digest(algorithm)]
-      rescue OpenSSL::Digest::DigestError => e
+      rescue StandardError => e
+        # The algorithm name comes from the gem's own checksums.yaml.gz, so an
+        # unusable one means the gem is malformed rather than that something
+        # went wrong on our side.  OpenSSL raises RuntimeError for an unknown
+        # digest name, and the class differs across engines, so match broadly.
         raise Gem::Package::FormatError.new e.message, @gem
       end
     elsif Gem::Security::DIGEST_NAME

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -366,11 +366,13 @@ EOM
 
       @checksums.to_h do |algorithm, _|
         [algorithm, Gem::Security.create_digest(algorithm)]
-      rescue StandardError => e
+      rescue StandardError, NotImplementedError => e
         # The algorithm name comes from the gem's own checksums.yaml.gz, so an
         # unusable one means the gem is malformed rather than that something
-        # went wrong on our side.  OpenSSL raises RuntimeError for an unknown
-        # digest name, and the class differs across engines, so match broadly.
+        # went wrong on our side.  The error class differs across engines: CRuby
+        # raises RuntimeError for an unknown digest name, jruby-openssl raises
+        # NotImplementedError, which is a ScriptError and not covered by a bare
+        # StandardError rescue.
         raise Gem::Package::FormatError.new e.message, @gem
       end
     elsif Gem::Security::DIGEST_NAME

--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -360,7 +360,15 @@ EOM
 
   def digest(entry) # :nodoc:
     algorithms = if @checksums
-      @checksums.to_h {|algorithm, _| [algorithm, Gem::Security.create_digest(algorithm)] }
+      unless @checksums.is_a?(Hash)
+        raise Gem::Package::FormatError.new "corrupt checksums.yaml.gz", @gem
+      end
+
+      @checksums.to_h do |algorithm, _|
+        [algorithm, Gem::Security.create_digest(algorithm)]
+      rescue OpenSSL::Digest::DigestError => e
+        raise Gem::Package::FormatError.new e.message, @gem
+      end
     elsif Gem::Security::DIGEST_NAME
       { Gem::Security::DIGEST_NAME => Gem::Security.create_digest(Gem::Security::DIGEST_NAME) }
     end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1005,6 +1005,100 @@ class TestGemPackage < Gem::Package::TarTestCase
                  e.message
   end
 
+  def test_verify_checksum_bad_algorithm
+    data_tgz = util_tar_gz do |tar|
+      tar.add_file "lib/code.rb", 0o444 do |io|
+        io.write "# lib/code.rb"
+      end
+    end
+
+    data_tgz = data_tgz.string
+
+    gem = util_tar do |tar|
+      metadata_gz = Gem::Util.gzip @spec.to_yaml
+
+      tar.add_file "metadata.gz", 0o444 do |io|
+        io.write metadata_gz
+      end
+
+      tar.add_file "data.tar.gz", 0o444 do |io|
+        io.write data_tgz
+      end
+
+      bad_checksums = {
+        "this-is-not-a-digest-name" => {
+          "data.tar.gz" => "0",
+          "metadata.gz" => "0",
+        },
+      }
+      tar.add_file "checksums.yaml.gz", 0o444 do |io|
+        Zlib::GzipWriter.wrap io do |gz_io|
+          if Gem.use_psych?
+            gz_io.write Psych.dump(bad_checksums)
+          else
+            gz_io.write Gem::YAMLSerializer.dump(bad_checksums)
+          end
+        end
+      end
+    end
+
+    File.open "bad_algorithm.gem", "wb" do |io|
+      io.write gem.string
+    end
+
+    package = Gem::Package.new "bad_algorithm.gem"
+
+    capture_output do
+      assert_raise Gem::Package::FormatError do
+        package.verify
+      end
+    end
+  end
+
+  def test_verify_checksums_not_a_mapping
+    data_tgz = util_tar_gz do |tar|
+      tar.add_file "lib/code.rb", 0o444 do |io|
+        io.write "# lib/code.rb"
+      end
+    end
+
+    data_tgz = data_tgz.string
+
+    gem = util_tar do |tar|
+      metadata_gz = Gem::Util.gzip @spec.to_yaml
+
+      tar.add_file "metadata.gz", 0o444 do |io|
+        io.write metadata_gz
+      end
+
+      tar.add_file "data.tar.gz", 0o444 do |io|
+        io.write data_tgz
+      end
+
+      tar.add_file "checksums.yaml.gz", 0o444 do |io|
+        Zlib::GzipWriter.wrap io do |gz_io|
+          gz_io.write "just a string, not a mapping\n"
+        end
+      end
+    end
+
+    File.open "checksums_not_a_mapping.gem", "wb" do |io|
+      io.write gem.string
+    end
+
+    package = Gem::Package.new "checksums_not_a_mapping.gem"
+
+    e = nil
+    capture_output do
+      e = assert_raise Gem::Package::FormatError do
+        package.verify
+      end
+    end
+
+    assert_equal "corrupt checksums.yaml.gz in checksums_not_a_mapping.gem",
+                 e.message
+  end
+
   def test_verify_checksum_missing
     data_tgz = util_tar_gz do |tar|
       tar.add_file "lib/code.rb", 0o444 do |io|


### PR DESCRIPTION
Gem::Package#verify is documented to raise Gem::Package::FormatError when a .gem is corrupt, and it maps the corruption errors it knows about (Zlib::GzipFile::Error, EOFError, TarInvalidError, Errno::ENOENT) onto that. Two corrupt checksums.yaml.gz shapes get past it as raw exceptions:

- `#digest` builds its algorithm set with `@checksums.to_h {|algorithm, _| ... }`. `@checksums` comes straight out of checksums.yaml.gz, so if that YAML's root isn't a mapping (a scalar, say) `.to_h` raises NoMethodError.
- each top level key goes to `Gem::Security.create_digest`, ie `OpenSSL::Digest.new(algorithm)`. A key that isn't a known digest name raises out of OpenSSL. RuntimeError on CRuby, NotImplementedError on jruby-openssl.

Neither is on verify's rescue list, so the caller gets a raw error and a backtrace instead of FormatError.

Correction to what this description used to say: I claimed it was a regression from an older broad `rescue StandardError` in verify. That was wrong, I hadn't checked. v2.0.0, v2.4.0, v2.7.0, v3.0.0 and v3.3.0 all have the same narrow rescue list, so these two shapes were never covered in the first place.

The patch guards the checksums structure in `#digest` instead: reject a non mapping root, and turn a failed digest construction into FormatError. That leaves verify's deliberately narrow rescue list alone rather than widening it back to a catch all.

Scope is just the error type. The gem is rejected either way, a corrupt or mistyped checksums file never verifies. This only makes it fail with the documented FormatError rather than an OpenSSL or NoMethodError, which matters if you rescue FormatError around `Gem::Package.new(path).verify` on gems you didn't build yourself.

Two regression tests, unknown algorithm name and non mapping root. Both raise the raw error on master and FormatError with the patch. `ruby -Itest -Ilib test/rubygems/test_gem_package.rb` is green on ruby 4.0.
