### PR TITLE
Pend on more transient network errors in TestGemBundledCA

### DIFF
--- a/test/rubygems/test_bundled_ca.rb
+++ b/test/rubygems/test_bundled_ca.rb
@@ -33,7 +33,8 @@ class TestGemBundledCA < Gem::TestCase
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.cert_store = bundled_certificate_store
     http.get("/")
-  rescue Errno::ENOENT, Errno::ETIMEDOUT, SocketError, Gem::Net::OpenTimeout
+  rescue Errno::ENOENT, Errno::ETIMEDOUT, Errno::ECONNRESET, Errno::ECONNREFUSED,
+         EOFError, SocketError, Gem::Net::OpenTimeout
     pend "#{host} seems offline, I can't tell whether ssl would work."
   rescue OpenSSL::SSL::SSLError => e
     # Only fail for certificate verification errors


### PR DESCRIPTION
`test/rubygems/test_bundled_ca.rb` pends when a tested host looks offline, but the rescue list misses `Errno::ECONNRESET`. On ruby/ruby CI this test hits a connection reset during `SSL_connect` every few days, and the resulting error turns a whole `test-all` job red (https://github.com/ruby/ruby/actions/runs/29677940980, https://github.com/ruby/ruby/actions/runs/29448887362), which makes it look like a frequent source of flakiness. Launchable data for the last two weeks shows only 4 failures out of roughly 28,000 recorded executions, all transient network errors. This adds `Errno::ECONNRESET`, `Errno::ECONNREFUSED`, and `EOFError` to the pend rescue so temporary network trouble no longer fails the test, while certificate verification failures still flunk.
