### PR TITLE
Raise FormatError for a corrupt checksums.yaml.gz

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -360,7 +360,15 @@ EOM
 
   def digest(entry) # :nodoc:
     algorithms = if @checksums
-      @checksums.to_h {|algorithm, _| [algorithm, Gem::Security.create_digest(algorithm)] }
+      unless @checksums.is_a?(Hash)
+        raise Gem::Package::FormatError.new "checksums.yaml.gz is not a mapping", @gem
+      end
+
+      @checksums.to_h do |algorithm, _|
+        [algorithm, Gem::Security.create_digest(algorithm)]
+      rescue OpenSSL::Digest::DigestError => e
+        raise Gem::Package::FormatError.new e.message, @gem
+      end
     elsif Gem::Security::DIGEST_NAME
       { Gem::Security::DIGEST_NAME => Gem::Security.create_digest(Gem::Security::DIGEST_NAME) }
     end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1005,6 +1005,75 @@ class TestGemPackage < Gem::Package::TarTestCase
                  e.message
   end
 
+  def test_verify_checksums_unknown_algorithm
+    gem = util_gem_with_checksums "notanalgo" => { "data.tar.gz" => "bogus" }
+
+    File.open "unknown_algorithm.gem", "wb" do |io|
+      io.write gem.string
+    end
+
+    package = Gem::Package.new "unknown_algorithm.gem"
+
+    e = nil
+    capture_output do
+      e = assert_raise Gem::Package::FormatError do
+        package.verify
+      end
+    end
+
+    assert_match "unsupported digest algorithm", e.message
+  end
+
+  def test_verify_checksums_not_a_mapping
+    gem = util_gem_with_checksums %w[not a mapping]
+
+    File.open "checksums_list.gem", "wb" do |io|
+      io.write gem.string
+    end
+
+    package = Gem::Package.new "checksums_list.gem"
+
+    e = nil
+    capture_output do
+      e = assert_raise Gem::Package::FormatError do
+        package.verify
+      end
+    end
+
+    assert_match "checksums.yaml.gz is not a mapping", e.message
+  end
+
+  def util_gem_with_checksums(checksums)
+    data_tgz = util_tar_gz do |tar|
+      tar.add_file "lib/code.rb", 0o444 do |io|
+        io.write "# lib/code.rb"
+      end
+    end
+
+    data_tgz = data_tgz.string
+
+    util_tar do |tar|
+      tar.add_file "metadata.gz", 0o444 do |io|
+        io.write Gem::Util.gzip(@spec.to_yaml)
+      end
+
+      tar.add_file "data.tar.gz", 0o444 do |io|
+        io.write data_tgz
+      end
+
+      tar.add_file "checksums.yaml.gz", 0o444 do |io|
+        Zlib::GzipWriter.wrap io do |gz_io|
+          if Gem.use_psych?
+            gz_io.write Psych.dump(checksums)
+          else
+            gz_io.write Gem::YAMLSerializer.dump(checksums)
+          end
+        end
+      end
+    end
+  end
+
+
   def test_verify_checksum_missing
     data_tgz = util_tar_gz do |tar|
       tar.add_file "lib/code.rb", 0o444 do |io|


### PR DESCRIPTION
`Gem::Package#verify` is documented to raise `Gem::Package::FormatError` when a package is corrupt, and its rescue list maps the corruption errors it knows about (`Errno::ENOENT`, `Zlib::GzipFile::Error`, `EOFError`, `TarInvalidError`) onto that. Two cases coming out of `checksums.yaml.gz` aren't in that list, so they escape as raw exceptions instead.

`read_checksums` YAML-loads `checksums.yaml.gz` straight out of the `.gem`, so both the top-level shape and the algorithm names are whatever the file happens to contain. `digest` then calls `.to_h` on that value and passes each key to `Gem::Security.create_digest` without checking either one:

```ruby
@checksums.to_h {|algorithm, _| [algorithm, Gem::Security.create_digest(algorithm)] }
```

So for a gem whose checksums file is corrupt:

- a key that isn't an OpenSSL digest name raises `OpenSSL::Digest::DigestError`
- a non-Hash YAML root raises `NoMethodError` on `.to_h`

Both surface with a backtrace rather than the `FormatError` callers rescue. Driving the real `Gem::Package.new(path).verify` on ruby 4.0.6 before the change:

```text
unknown algorithm key  => UNCAUGHT OpenSSL::Digest::DigestError: unsupported digest algorithm: notanalgo
YAML list root         => UNCAUGHT OpenSSL::Digest::DigestError: unsupported digest algorithm: a
YAML string root       => UNCAUGHT NoMethodError: undefined method 'to_h' for an instance of String
```

and after:

```text
unknown algorithm key  => HANDLED FormatError: unsupported digest algorithm: notanalgo
YAML list root         => HANDLED FormatError: checksums.yaml.gz is not a mapping
YAML string root       => HANDLED FormatError: checksums.yaml.gz is not a mapping
```

To be clear about scope: the package is rejected either way, so this only changes the error type, not whether a corrupt gem gets through. Older rubygems had a broad `rescue StandardError` in `verify` that mapped these onto `FormatError`; the narrower rescue list doesn't cover them, so this restores that behaviour for the two cases without widening the rescue again.

The fix checks the shape before mapping it and converts a bad algorithm name into a `FormatError`, so `digest` reports corruption the same way the rest of the verify path does. I put it in `digest` rather than adding to `verify`'s rescue list, since `verify_entry` is `digest`'s only caller and rescuing `NoMethodError` at the `verify` level would mask unrelated bugs.

Tests build a gem with an unknown algorithm key and one with a non-mapping checksums root, both through the existing `util_tar`/`util_tar_gz` helpers, and assert `FormatError` from the real `verify` path. They fail before the change with the raw `OpenSSL::Digest::DigestError` and pass after. `ruby -Ilib -Itest test/rubygems/test_gem_package.rb` is green (60 tests, 0 failures; 58 on master before these two).
