### PR TITLE
Remove dead Bundler helpers

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -758,7 +758,6 @@ module Bundler
       config[:current_command] = original_command
     end
 
-
     def print_command
       return unless Bundler.ui.debug?
       cmd = current_command

--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -758,8 +758,6 @@ module Bundler
       config[:current_command] = original_command
     end
 
-    def current_command=(command)
-    end
 
     def print_command
       return unless Bundler.ui.debug?

--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -63,7 +63,6 @@ module Bundler
         headers
       end
 
-
       def etag_from_response(response)
         return unless response["ETag"]
         etag = response["ETag"].delete_prefix("W/")

--- a/lib/bundler/compact_index_client/updater.rb
+++ b/lib/bundler/compact_index_client/updater.rb
@@ -63,9 +63,6 @@ module Bundler
         headers
       end
 
-      def etag_for_request(etag_path)
-        etag_path.read.tap(&:chomp!) if etag_path.file?
-      end
 
       def etag_from_response(response)
         return unless response["ETag"]

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -344,7 +344,6 @@ module Bundler
       split_specific_setting_for(name)[0]
     end
 
-
     def split_specific_setting_for(name)
       name.split(".")
     end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -344,9 +344,6 @@ module Bundler
       split_specific_setting_for(name)[0]
     end
 
-    def specific_gem_for(name)
-      split_specific_setting_for(name)[1]
-    end
 
     def split_specific_setting_for(name)
       name.split(".")

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -410,9 +410,6 @@ module Bundler
         options["revision"]
       end
 
-      def cached?
-        cache_path.exist?
-      end
 
       def git_proxy
         @git_proxy ||= GitProxy.new(cache_path, uri, options, locked_revision, self)

--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -410,7 +410,6 @@ module Bundler
         options["revision"]
       end
 
-
       def git_proxy
         @git_proxy ||= GitProxy.new(cache_path, uri, options, locked_revision, self)
       end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Four private Bundler helpers remain despite having no callers:

- `current_command=` was added as an empty method in f3f505c0 and has never been called. Command state is changed directly through the config hash.
- `etag_for_request` was added in a3ef6d9e but never called. The updater reads the ETag path inline instead.
- `specific_gem_for` was renamed from the misspelled `specfic_gem_for` in 74688805, but neither spelling has a caller.
- `cached?` has had no caller since `Source::Git` was extracted in 7908ec26.

Repository-wide reference and exact literal searches found no dynamic call sites for these names.

## What is your fix for the problem, implemented in this PR?

Remove the four unreachable helpers.

Verification: `bin/rspec spec/bundler/compact_index_client/updater_spec.rb spec/bundler/settings_spec.rb spec/bundler/source/git_spec.rb spec/other/cli_dispatch_spec.rb spec/bundler/cli_spec.rb` — 102 examples, 0 failures.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write tests — not applicable; this removes unreachable private methods and the existing focused specs cover surrounding behavior
- [x] Write code to solve the problem
- [x] Follow the current code style and write a meaningful commit message without tags