### PR TITLE
Remove dead Cargo target helpers

### DIFF
--- a/lib/rubygems/ext/cargo_builder.rb
+++ b/lib/rubygems/ext/cargo_builder.rb
@@ -269,21 +269,12 @@ EOF
     LinkFlagConverter.convert(arg)
   end
 
-  def msvc_target?
-    makefile_config("target_os").include?("msvc")
-  end
-
   def darwin_target?
     makefile_config("target_os").include?("darwin")
   end
 
   def mingw_target?
     makefile_config("target_os").include?("mingw")
-  end
-
-  def win_target?
-    target_platform = RbConfig::CONFIG["target_os"]
-    !!Gem::WIN_PATTERNS.find {|r| target_platform =~ r }
   end
 
   # Interpolate substitution vars in the arg (i.e. $(DEFFILE))


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`Gem::Ext::CargoBuilder#msvc_target?` and `#win_target?` remain after their callers were removed. `msvc_target?` lost its last caller in 7223a5bf when link-flag handling moved to `LinkFlagConverter`; `win_target?` lost its last caller in 160a5154 when `SOEXT` lookup moved to `RbConfig`.

Repository-wide reference and exact literal searches found no remaining callers.

## What is your fix for the problem, implemented in this PR?

Remove the two unreachable private helpers.

Verification: `bin/test-unit test/rubygems/test_gem_ext_cargo_builder.rb` — 9 tests, 26 assertions, 0 failures, 0 errors, 5 platform-dependent pendings.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write tests — not applicable; this removes unreachable private methods and the existing focused tests cover Cargo builder behavior
- [x] Write code to solve the problem
- [x] Follow the current code style and write a meaningful commit message without tags