### PR TITLE
Avoid repeated base path expansion

### DIFF
--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -81,7 +81,10 @@ module Gem::Util
   # +base_path+ are not treated as part of the pattern.
 
   def self.glob_files_in_dir(glob, base_path)
-    Dir.glob(glob, base: base_path).map! {|f| File.expand_path(f, base_path) }
+    expanded_path = nil
+    Dir.glob(glob, base: base_path).map! do |f|
+      File.expand_path(f, expanded_path ||= File.expand_path(base_path))
+    end
   end
 
   ##


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`glob_files_in_dir` repeatedly expanded the same base path for every matched file, performing redundant work when processing multiple matches.

## What is your fix for the problem, implemented in this PR?

Expand the base path once and reuse it when expanding each matched file, while preserving path normalization.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
