### PR TITLE
Skip empty checksum values in compact index metadata

### DIFF
--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -153,8 +153,13 @@ module Bundler
         next unless v
         case k.to_s
         when "checksum"
+          # Some registries send empty checksum values, treat them as if the
+          # checksum was not included at all
+          checksum = v.last
+          next unless checksum
+
           begin
-            @checksum = Checksum.from_api(v.last, @spec_fetcher.uri)
+            @checksum = Checksum.from_api(checksum, @spec_fetcher.uri)
           rescue ArgumentError => e
             raise ArgumentError, "Invalid checksum for #{full_name}: #{e.message}"
           end

--- a/spec/bundler/endpoint_specification_spec.rb
+++ b/spec/bundler/endpoint_specification_spec.rb
@@ -71,6 +71,34 @@ RSpec.describe Bundler::EndpointSpecification do
       end
     end
 
+    context "when the metadata has an empty checksum value" do
+      let(:metadata) { { "checksum" => [] } }
+
+      it "leaves checksum as nil without raising" do
+        expect(subject.checksum).to be_nil
+      end
+    end
+
+    context "when the metadata has a nil checksum value" do
+      let(:metadata) { { "checksum" => nil } }
+
+      it "leaves checksum as nil without raising" do
+        expect(subject.checksum).to be_nil
+      end
+    end
+
+    context "when the metadata has an invalid checksum value" do
+      let(:metadata) { { "checksum" => ["xyz"] } }
+      let(:spec_fetcher) { double(:spec_fetcher, uri: "https://rubygems.org") }
+
+      it "raises an error mentioning the invalid checksum" do
+        expect { subject }.to raise_error(
+          Bundler::GemspecError,
+          a_string_including("Invalid checksum for foo-1.0.0")
+        )
+      end
+    end
+
     context "when the metadata has no created_at" do
       let(:metadata) { { "checksum" => ["abc"] } }
       let(:spec_fetcher) { double(:spec_fetcher, uri: "https://rubygems.org") }

--- a/spec/install/gemfile/git_spec.rb
+++ b/spec/install/gemfile/git_spec.rb
@@ -137,9 +137,12 @@ RSpec.describe "bundle install with git sources" do
       sha = git.ref_for("main", 11)
       spec_file = scoped_gem_path(bundled_app("vendor/dir[1]")).join("bundler/gems/foo-1.0-#{sha}/foo.gemspec")
       expect(spec_file).to exist
-      ruby_code = Gem::Specification.load(spec_file.to_s).to_ruby
+      # Serialize with the RubyGems that wrote the file, since `#to_ruby`
+      # output differs across RubyGems versions
+      ruby "print Gem::Specification.load(#{spec_file.to_s.dump}).to_ruby"
+      ruby_code = out
       file_code = File.read(spec_file)
-      expect(file_code).to eq(ruby_code)
+      expect(file_code.strip).to eq(ruby_code)
     end
 
     it "does not update the git source implicitly" do


### PR DESCRIPTION
Compact index `/info` files served by some registries such as GitHub Package Registry can contain empty checksum entries like `2.0.1 |checksum:`. The parser turns that into `["checksum", []]` and `EndpointSpecification#parse_metadata` passed the resulting `nil` digest to `Checksum.from_api`, crashing resolution with a `NoMethodError` wrapped in a `GemspecError`. An empty or missing checksum value is now treated the same as an absent checksum key, so resolution continues with the checksum left unset. Non-empty invalid values still raise the existing `Invalid checksum for ...` error.

Fixes #9677
