### PR TITLE
Call Kernel.format explicitly in Gem::Deprecate wrapper

### DIFF
--- a/lib/rubygems/deprecate.rb
+++ b/lib/rubygems/deprecate.rb
@@ -110,7 +110,7 @@ module Gem
           msg = [
             "NOTE: #{target}#{name} is deprecated",
             repl == :none ? " with no replacement" : "; use #{repl} instead",
-            format(". It will be removed on or after %4d-%02d.", year, month),
+            Kernel.format(". It will be removed on or after %4d-%02d.", year, month),
             "\n#{target}#{name} called from #{Gem.location_of_caller.join(":")}",
           ]
           warn "#{msg.join}." unless Gem::Deprecate.skip

--- a/test/rubygems/test_deprecate.rb
+++ b/test/rubygems/test_deprecate.rb
@@ -102,6 +102,23 @@ class TestGemDeprecate < Gem::TestCase
     deprecate :foo_kwarg, :bar_kwarg, 2099, 3
   end
 
+  class ThingWithFormat
+    extend Gem::Deprecate
+    attr_accessor :message
+    def foo
+      @message = "foo"
+    end
+
+    def bar
+      @message = "bar"
+    end
+    deprecate :foo, :bar, 2099, 3
+
+    def format
+      raise "ThingWithFormat#format should not be called"
+    end
+  end
+
   def test_deprecated_method_calls_the_old_method
     capture_output do
       thing = Thing.new
@@ -159,6 +176,18 @@ class TestGemDeprecate < Gem::TestCase
     assert_match(/OtherThing#foo is deprecated; use bar instead\./, err)
     assert_match(/OtherThing#foo_arg is deprecated; use bar_arg instead\./, err)
     assert_match(/OtherThing#foo_kwarg is deprecated; use bar_kwarg instead\./, err)
+    assert_match(/on or after 2099-03/, err)
+  end
+
+  def test_deprecated_method_when_class_overrides_format
+    out, err = capture_output do
+      thing = ThingWithFormat.new
+      thing.foo
+      assert_equal "foo", thing.message
+    end
+
+    assert_equal "", out
+    assert_match(/ThingWithFormat#foo is deprecated; use bar instead\./, err)
     assert_match(/on or after 2099-03/, err)
   end
 end


### PR DESCRIPTION
The wrapper defined by `Gem::Deprecate#deprecate` runs in the instance context of the deprecating class, so the bare `format` call introduced in 132a56569d dispatches to the class's own `#format` method when it defines one and raises `ArgumentError`. Calling `Kernel.format` explicitly restores the previous behavior.

Fixes #9704

🤖 Generated with [Claude Code](https://claude.com/claude-code)
