### PR TITLE
Fail `bundle check` when frozen mode needs lockfile changes

### DIFF
--- a/lib/bundler/cli/check.rb
+++ b/lib/bundler/cli/check.rb
@@ -12,6 +12,7 @@ module Bundler
       Bundler.settings.set_command_option_if_given :path, options[:path]
 
       definition = Bundler.definition
+      definition.ensure_equivalent_gemfile_and_lockfile
       definition.validate_runtime!
 
       begin
@@ -27,9 +28,6 @@ module Bundler
         Bundler.ui.error "The following gems are missing"
         not_installed.each {|s| Bundler.ui.error " * #{s.name} (#{s.version})" }
         Bundler.ui.warn "Install missing gems with `bundle install`"
-        exit 1
-      elsif !Bundler.default_lockfile.file? && Bundler.frozen_bundle?
-        Bundler.ui.error "This bundle has been frozen, but there is no #{SharedHelpers.relative_lockfile_path} present"
         exit 1
       else
         definition.lock(true) unless options[:"dry-run"]

--- a/spec/commands/check_spec.rb
+++ b/spec/commands/check_spec.rb
@@ -257,6 +257,58 @@ RSpec.describe "bundle check" do
 
     bundle :check, raise_on_error: false
     expect(last_command).to be_failure
+    expect(err).to include("Frozen mode is set, but there's no lockfile")
+  end
+
+  it "fails when frozen is set and the lockfile is missing a CHECKSUMS entry" do
+    system_gems "myrack-1.0.0", path: default_bundle_path
+
+    gemfile <<-G
+      source "https://gem.repo1"
+      gem "myrack"
+    G
+
+    lockfile <<-L
+      GEM
+        remote: https://gem.repo1/
+        specs:
+          myrack (1.0.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        myrack
+
+      CHECKSUMS
+
+      BUNDLED WITH
+        #{Bundler::VERSION}
+    L
+
+    bundle :check, env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+    expect(exitstatus).to eq(16)
+    expect(err).to include("Your lockfile is missing a CHECKSUMS entry for \"myrack\", but can't be updated because frozen mode is set")
+    expect(out).not_to include("The Gemfile's dependencies are satisfied")
+  end
+
+  it "fails when frozen is set and the Gemfile has changed" do
+    install_gemfile <<-G
+      source "https://gem.repo1"
+      gem "myrack"
+    G
+
+    gemfile <<-G
+      source "https://gem.repo1"
+      gem "myrack"
+      gem "rails"
+    G
+
+    bundle :check, env: { "BUNDLE_FROZEN" => "true" }, raise_on_error: false
+    expect(exitstatus).to eq(16)
+    expect(err).to include("frozen mode is set")
+    expect(err).to include("* rails")
+    expect(out).not_to include("The Gemfile's dependencies are satisfied")
   end
 
   describe "when locked" do


### PR DESCRIPTION
`BUNDLE_FROZEN=1 bundle check` printed "The Gemfile's dependencies are satisfied" and exited 0 even when the lockfile was missing a CHECKSUMS entry, because the check command never ran the frozen validation and `write_lock` only warns in frozen mode. This makes `bundle check` call `ensure_equivalent_gemfile_and_lockfile` like `bundle install` does, so it now fails with the same message and exit status 16. The dedicated branch for frozen mode without a lockfile is removed since `validate_platforms!` raised first and made it unreachable. Running the frozen validation before `validate_runtime!` also improves that case to report "Frozen mode is set, but there's no lockfile".

Fixes #9546
