### PR TITLE
Redact URI userinfo from settings names in Bundler User-Agent

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -215,7 +215,13 @@ module Bundler
           agent << " #{ruby.engine}/#{ruby.versions_string(engine_version)}"
         end
 
-        agent << " options/#{Bundler.settings.all.join(",")}"
+        # Some settings keys embed a URI (e.g. `mirror.<uri>`) whose userinfo can
+        # carry credentials. Strip the userinfo before advertising the setting
+        # names so we don't leak secrets to every gem source we talk to.
+        options = Bundler.settings.all.map do |key|
+          key.include?("://") ? key.gsub(%r{//[^/@]+@}, "//") : key
+        end
+        agent << " options/#{options.join(",")}"
 
         agent << " ci/#{cis.join(",")}" if cis.any?
 

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -141,6 +141,19 @@ RSpec.describe Bundler::Fetcher do
       expect(fetcher.user_agent).to match(%r{options/foo,bar})
     end
 
+    it "strips userinfo from settings keys that embed a URI" do
+      allow(Bundler.settings).to receive(:all).and_return(
+        %w[foo mirror.http://user:token@example.org/ mirror.https://token@example.net/]
+      )
+      options = fetcher.user_agent.split(" ").find {|x| x.start_with?("options/") }
+
+      expect(options).not_to include("token")
+      expect(options).not_to include("user:")
+      expect(options).to include("mirror.http://example.org/")
+      expect(options).to include("mirror.https://example.net/")
+      expect(options).to include("foo")
+    end
+
     describe "include CI information" do
       it "from one CI" do
         with_env_vars("CI" => nil, "JENKINS_URL" => "foo") do


### PR DESCRIPTION
Bundler builds the `options/` segment of its User-Agent from `Bundler.settings.all`, which lists the names of the settings in use. Mirror settings embed a URI directly in the key, such as `mirror.http://user:token@host/`, so the URI userinfo becomes part of the setting name. Since the User-Agent is sent to every gem source Bundler contacts, those embedded credentials can reach unrelated sources.

This strips the userinfo from any settings key that embeds a URI while the User-Agent is assembled. The telemetry stays useful because the setting name and host are preserved and only the credentials are dropped. The redaction is scoped to the User-Agent. `Bundler.settings.all` still returns the real keys, which `local_overrides` and `gem_mirrors` depend on.

A spec covers mirror keys carrying userinfo and confirms plain keys are unaffected.
