### PR TITLE
Validate gem name before building compact index cache paths

### DIFF
--- a/lib/bundler/compact_index_client/cache.rb
+++ b/lib/bundler/compact_index_client/cache.rb
@@ -50,6 +50,7 @@ module Bundler
 
       def info_path(name)
         name = name.to_s
+        validate_name!(name)
         # TODO: converge this into the info_root by hashing all filenames like info_etag_path
         if /[^a-z0-9_-]/.match?(name)
           name += "-#{SharedHelpers.digest(:MD5).hexdigest(name).downcase}"
@@ -61,7 +62,17 @@ module Bundler
 
       def info_etag_path(name)
         name = name.to_s
+        validate_name!(name)
         @info_etag_root.join("#{name}-#{SharedHelpers.digest(:MD5).hexdigest(name).downcase}")
+      end
+
+      # Gem names come from the remote index and are not otherwise
+      # validated, so refuse anything that would escape the cache
+      # directory when used as a path component.
+      def validate_name!(name)
+        return if File.basename(name) == name
+
+        raise SecurityError, "malformed gem name: #{name.inspect}"
       end
 
       def mkdir(name)

--- a/lib/rubygems/compact_index_client/cache.rb
+++ b/lib/rubygems/compact_index_client/cache.rb
@@ -60,6 +60,7 @@ class Gem::CompactIndexClient
 
     def info_path(name)
       name = name.to_s
+      validate_name!(name)
       if /[^a-z0-9_-]/.match?(name)
         name += "-#{Digest::MD5.hexdigest(name).downcase}"
         @special_characters_info_root.join(name)
@@ -70,7 +71,17 @@ class Gem::CompactIndexClient
 
     def info_etag_path(name)
       name = name.to_s
+      validate_name!(name)
       @info_etag_root.join("#{name}-#{Digest::MD5.hexdigest(name).downcase}")
+    end
+
+    # Gem names come from the remote index and are not otherwise
+    # validated, so refuse anything that would escape the cache
+    # directory when used as a path component.
+    def validate_name!(name)
+      return if File.basename(name) == name
+
+      raise Gem::Exception, "malformed gem name: #{name.inspect}"
     end
 
     def checksum_for_file(path)

--- a/spec/bundler/compact_index_client/cache_spec.rb
+++ b/spec/bundler/compact_index_client/cache_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "bundler/compact_index_client"
+require "bundler/compact_index_client/cache"
+require "tmpdir"
+
+RSpec.describe Bundler::CompactIndexClient::Cache do
+  let(:directory) { Pathname.new(Dir.mktmpdir("compact_index")) }
+  let(:cache) { described_class.new(directory) }
+
+  it "rejects a gem name that would escape the cache directory" do
+    expect { cache.info("../../../../pwn") }.to raise_error(Bundler::SecurityError, /malformed gem name/)
+  end
+
+  it "accepts plain gem names, including special characters" do
+    expect { cache.info("rack") }.not_to raise_error
+    expect { cache.info("Rails.js") }.not_to raise_error
+  end
+end

--- a/spec/support/shards.rb
+++ b/spec/support/shards.rb
@@ -148,6 +148,7 @@ module Spec
       ],
       shard_d: [
         "spec/bundler/compact_index_client/cache_file_spec.rb",
+        "spec/bundler/compact_index_client/cache_spec.rb",
         "spec/bundler/rubygems_ext_spec.rb",
         "spec/bundler/resolver/cooldown_spec.rb",
         "spec/install/cooldown_spec.rb",

--- a/test/rubygems/test_gem_compact_index_client_cache.rb
+++ b/test/rubygems/test_gem_compact_index_client_cache.rb
@@ -113,6 +113,29 @@ class TestGemCompactIndexClientCache < Gem::TestCase
     assert_equal "a 1.0.0\n", @dir.join("info", "a").read
   end
 
+  def test_info_rejects_name_escaping_cache_directory
+    fetcher = FakeFetcher.new("1.0.0\n")
+    cache = Gem::CompactIndexClient::Cache.new(@dir, fetcher)
+
+    e = assert_raise Gem::Exception do
+      cache.info("../../../../pwn", "no-match")
+    end
+
+    assert_includes e.message, "malformed gem name"
+    assert_empty fetcher.requests
+  end
+
+  def test_fetch_info_rejects_name_escaping_cache_directory
+    fetcher = FakeFetcher.new("1.0.0\n")
+    cache = Gem::CompactIndexClient::Cache.new(@dir, fetcher)
+
+    assert_raise Gem::Exception do
+      cache.fetch_info("../pwn")
+    end
+
+    assert_empty fetcher.requests
+  end
+
   def test_info_with_special_characters_uses_hashed_path
     fetcher = FakeFetcher.new("1.0.0\n")
     cache = Gem::CompactIndexClient::Cache.new(@dir, fetcher)


### PR DESCRIPTION
`Bundler::CompactIndexClient::Cache` builds info cache paths by joining the gem name into the cache directory. The name comes from the remote index, either versions lines or transitive dependency names in info files, and is never validated, so a name like `../../../../pwn` escapes the cache directory because the special-characters branch keeps the raw name and only appends an MD5 suffix. `info_etag_path` embeds the raw name the same way. This rejects any name that is not a plain basename before constructing the path, matching the `fetch_spec` guard from 56ed326cb2, and applies the same guard to the independent `Gem::CompactIndexClient::Cache` port. Existing cache files keep their names, so no cache is invalidated.
