### PR TITLE
Document pessimistic operator and eval_gemfile in gemfile(5)

### DIFF
--- a/lib/bundler/man/gemfile.5
+++ b/lib/bundler/man/gemfile.5
@@ -107,6 +107,8 @@ gem "nokogiri", ">= 1\.4\.2"
 gem "RedCloth", ">= 4\.1\.0", "< 4\.2\.0"
 .fi
 .IP "" 0
+.P
+Most version specifiers, like \fB>= 1\.0\fR, are self\-explanatory\. The pessimistic specifier \fB~>\fR constrains both a lower and an upper bound: \fB~> 2\.0\.3\fR is identical to \fB>= 2\.0\.3\fR and \fB< 2\.1\fR, and \fB~> 2\.1\fR is identical to \fB>= 2\.1\fR and \fB< 3\.0\fR\. A pessimistic specifier with a prerelease component, like \fB~> 2\.2\.beta\fR, will match prerelease versions like \fB2\.2\.beta\.12\fR\. \fB~> 0\fR is identical to \fB>= 0\.0\fR and \fB< 1\.0\fR\.
 .SS "REQUIRE AS"
 Each \fIgem\fR \fBMAY\fR specify files that should be used when autorequiring via \fBBundler\.require\fR\. You may pass an array with multiple files or \fBtrue\fR if the file you want \fBrequired\fR has the same name as \fIgem\fR or \fBfalse\fR to prevent any file from being autorequired\.
 .IP "" 4
@@ -460,6 +462,15 @@ The \fBgemspec\fR method adds any runtime dependencies as gem requirements in th
 The \fBgemspec\fR method supports optional \fB:path\fR, \fB:glob\fR, \fB:name\fR, and \fB:development_group\fR options, which control where bundler looks for the \fB\.gemspec\fR, the glob it uses to look for the gemspec (defaults to: \fB{,*,*/*}\.gemspec\fR), what named \fB\.gemspec\fR it uses (if more than one is present), and which group development dependencies are included in\.
 .P
 When a \fBgemspec\fR dependency encounters version conflicts during resolution, the local version under development will always be selected \-\- even if there are remote versions that better match other requirements for the \fBgemspec\fR gem\.
+.SH "EVAL_GEMFILE"
+A Gemfile \fBMAY\fR be split across multiple files\. The \fBeval_gemfile\fR method reads the contents of another file as if they appeared in the current Gemfile\. A relative path is resolved against the directory of the file containing the call\.
+.IP "" 4
+.nf
+eval_gemfile "another\.gemfile"
+.fi
+.IP "" 0
+.P
+This can be useful to run tests against multiple combinations of dependencies, or to load per\-developer gems from an untracked gemfile\.
 .SH "OVERRIDE"
 The \fBoverride\fR directive rewrites a constraint on another gem before resolution runs\. It targets the common case where an upstream gem's published metadata is too narrow on the current project's machine \-\- a stale upper bound, an unwanted floor, or a transitive pin that has to be lifted\.
 .IP "" 4

--- a/lib/bundler/man/gemfile.5.ronn
+++ b/lib/bundler/man/gemfile.5.ronn
@@ -137,6 +137,13 @@ Each _gem_ `MAY` have one or more version specifiers.
     gem "nokogiri", ">= 1.4.2"
     gem "RedCloth", ">= 4.1.0", "< 4.2.0"
 
+Most version specifiers, like `>= 1.0`, are self-explanatory. The pessimistic
+specifier `~>` constrains both a lower and an upper bound: `~> 2.0.3` is
+identical to `>= 2.0.3` and `< 2.1`, and `~> 2.1` is identical to `>= 2.1` and
+`< 3.0`. A pessimistic specifier with a prerelease component, like
+`~> 2.2.beta`, will match prerelease versions like `2.2.beta.12`. `~> 0` is
+identical to `>= 0.0` and `< 1.0`.
+
 ### REQUIRE AS
 
 Each _gem_ `MAY` specify files that should be used when autorequiring via
@@ -540,6 +547,18 @@ for the gemspec (defaults to: `{,*,*/*}.gemspec`), what named `.gemspec` it uses
 When a `gemspec` dependency encounters version conflicts during resolution, the
 local version under development will always be selected -- even if there are
 remote versions that better match other requirements for the `gemspec` gem.
+
+## EVAL_GEMFILE
+
+A Gemfile `MAY` be split across multiple files. The `eval_gemfile` method reads
+the contents of another file as if they appeared in the current Gemfile. A
+relative path is resolved against the directory of the file containing the
+call.
+
+    eval_gemfile "another.gemfile"
+
+This can be useful to run tests against multiple combinations of dependencies,
+or to load per-developer gems from an untracked gemfile.
 
 ## OVERRIDE
 


### PR DESCRIPTION
The handwritten Gemfile guide on guides.rubygems.org is planned to be replaced by the generated gemfile(5) page. Comparing the two ahead of that, two pieces of the guide have no equivalent in the man page: the meaning of the pessimistic specifier `~>` and the `eval_gemfile` method. This ports both now so the replacement will not lose information, rewritten to match the man page style. The `~>` explanation goes into the `VERSION` section under `GEMS`, and `eval_gemfile` gets a new `EVAL_GEMFILE` section after `GEMSPEC`. I checked `Dsl#eval_gemfile` to confirm that relative paths are resolved against the directory of the file containing the call. The roff page was regenerated with `rake man:build` pinned to the current `MAN_PAGES_DATE`, so only `gemfile.5` changes.
