### PR TITLE
Publish bundler command reference to guides on release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -335,20 +335,30 @@ namespace "guides" do
   end
 
   task "update" => %w[tmp/guides.rubygems.org] do
-    lib_dir = File.join Dir.pwd, "lib"
+    rubygems_dir = Dir.pwd
+    env = {
+      "BUNDLE_GEMFILE" => nil,
+      "RUBYOPT" => "--disable-gems -I#{File.join(rubygems_dir, "lib")}",
+      "RUBYGEMS_DIR" => rubygems_dir,
+    }
 
     chdir "tmp/guides.rubygems.org" do
-      ruby "-I", lib_dir, "-S", "rake", "-N", "command_guide"
-      ruby "-I", lib_dir, "-S", "rake", "-N", "spec_guide"
+      sh env, "bundle", "install"
+      sh env, "bundle", "exec", "rake", "command_reference"
+      sh env, "bundle", "exec", "rake", "spec_guide"
+
+      # `bundle install` may rewrite the lockfile (BUNDLED WITH), which would
+      # leave the checkout dirty and break future pulls
+      sh "git", "checkout", "--", "Gemfile.lock"
     end
   end
 
   task "commit" => %w[tmp/guides.rubygems.org] do
     chdir "tmp/guides.rubygems.org" do
-      sh "git", "diff", "--quiet"
+      sh "git", "add", "command-reference.md", "specification-reference.md", "command-reference"
+      sh "git", "diff", "--cached", "--quiet"
     rescue StandardError
-      sh "git", "commit", "command-reference.md", "specification-reference.md",
-         "-m", "Rebuild for RubyGems #{v}"
+      sh "git", "commit", "-m", "Rebuild for RubyGems #{v}"
     end
   end
 


### PR DESCRIPTION
rubygems/guides#492 added a `command_reference` umbrella task that renders the bundler man pages into `command-reference/` in addition to the existing `command_guide`. This switches `guides:update` to run it through `bundle install` and `bundle exec` inside the guides checkout, because `bundler_reference` needs `nronn` and `nokogiri`, mirroring the invocation guides CI uses. `guides:commit` now stages paths with `git add` and checks `git diff --cached --quiet`, so HTML files for newly added `bundle` subcommands are committed even when untracked. Verified locally against a fresh guides clone, including the no-change and untracked-file paths and `DRYRUN=1` push. Releases run from the stable branch, so this needs a backport to 4.0 before 4.0.18.

Generated with [Claude Code](https://claude.com/claude-code)
