### PR TITLE
List missing subcommands in bundle(1) UTILITIES section

### DIFF
--- a/lib/bundler/man/bundle.1
+++ b/lib/bundler/man/bundle.1
@@ -54,6 +54,18 @@ Determine whether the requirements for your application are installed and availa
 \fBbundle show(1)\fR \fIbundle\-show\.1\.html\fR
 Show the source location of a particular gem in the bundle
 .TP
+\fBbundle info(1)\fR \fIbundle\-info\.1\.html\fR
+Show information for the given gem in your bundle
+.TP
+\fBbundle list(1)\fR \fIbundle\-list\.1\.html\fR
+List all the gems in the bundle
+.TP
+\fBbundle licenses(1)\fR \fIbundle\-licenses\.1\.html\fR
+Print the license of all gems in the bundle
+.TP
+\fBbundle fund(1)\fR \fIbundle\-fund\.1\.html\fR
+Lists information about gems seeking funding assistance
+.TP
 \fBbundle outdated(1)\fR \fIbundle\-outdated\.1\.html\fR
 Show all of the outdated gems in the current bundle
 .TP
@@ -78,8 +90,17 @@ Display platform compatibility information
 \fBbundle clean(1)\fR \fIbundle\-clean\.1\.html\fR
 Clean up unused gems in your Bundler directory
 .TP
+\fBbundle pristine(1)\fR \fIbundle\-pristine\.1\.html\fR
+Restores installed gems to their pristine condition
+.TP
 \fBbundle doctor(1)\fR \fIbundle\-doctor\.1\.html\fR
 Display warnings about common problems
+.TP
+\fBbundle env(1)\fR \fIbundle\-env\.1\.html\fR
+Print information about the environment Bundler is running under
+.TP
+\fBbundle issue(1)\fR \fIbundle\-issue\.1\.html\fR
+Get help reporting Bundler issues
 .TP
 \fBbundle remove(1)\fR \fIbundle\-remove\.1\.html\fR
 Removes gems from the Gemfile

--- a/lib/bundler/man/bundle.1.ronn
+++ b/lib/bundler/man/bundle.1.ronn
@@ -64,6 +64,18 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle show(1)`](bundle-show.1.html):
   Show the source location of a particular gem in the bundle
 
+* [`bundle info(1)`](bundle-info.1.html):
+  Show information for the given gem in your bundle
+
+* [`bundle list(1)`](bundle-list.1.html):
+  List all the gems in the bundle
+
+* [`bundle licenses(1)`](bundle-licenses.1.html):
+  Print the license of all gems in the bundle
+
+* [`bundle fund(1)`](bundle-fund.1.html):
+  Lists information about gems seeking funding assistance
+
 * [`bundle outdated(1)`](bundle-outdated.1.html):
   Show all of the outdated gems in the current bundle
 
@@ -88,8 +100,17 @@ We divide `bundle` subcommands into primary commands and utilities:
 * [`bundle clean(1)`](bundle-clean.1.html):
   Clean up unused gems in your Bundler directory
 
+* [`bundle pristine(1)`](bundle-pristine.1.html):
+  Restores installed gems to their pristine condition
+
 * [`bundle doctor(1)`](bundle-doctor.1.html):
   Display warnings about common problems
+
+* [`bundle env(1)`](bundle-env.1.html):
+  Print information about the environment Bundler is running under
+
+* [`bundle issue(1)`](bundle-issue.1.html):
+  Get help reporting Bundler issues
 
 * [`bundle remove(1)`](bundle-remove.1.html):
   Removes gems from the Gemfile


### PR DESCRIPTION
`bundle-env`, `bundle-fund`, `bundle-info`, `bundle-issue`, `bundle-licenses`, `bundle-list`, and `bundle-pristine` all have their own man pages but were never listed in the UTILITIES section of bundle(1), so they were not linked from the command index. This also matters for guides.rubygems.org, which renders bundle(1) as the index page of the Bundler command reference, leaving those seven pages orphaned. Each new entry reuses the one-line description from the corresponding man page. `bundle.1` was regenerated with `rake man:build`.

Generated with [Claude Code](https://claude.com/claude-code)
