### PR TITLE
Create a single GitHub release covering RubyGems and Bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -754,7 +754,7 @@ namespace :bundler do
   task "build" => ["bundler:release:check_ruby_version"]
 
   desc "Push to rubygems.org"
-  task "release:rubygem_push" => ["bundler:release:setup", "man:check", "bundler:build_metadata", "check_release_preparations"]
+  task "release:rubygem_push" => ["man:check", "bundler:build_metadata"]
 
   desc "Generates the Bundler changelog for a specific target version"
   task :generate_changelog, [:version] => [:install_release_dependencies] do |_t, opts|
@@ -762,11 +762,6 @@ namespace :bundler do
   end
 
   namespace :release do
-    desc "Install gems needed for releasing"
-    task :setup do
-      Release.install_dependencies!
-    end
-
     task :check_ruby_version do
       raise "bundler:build need to released Ruby for using nokogiri" if RUBY_PATCHLEVEL.to_i < 0
     end

--- a/Rakefile
+++ b/Rakefile
@@ -290,7 +290,7 @@ desc "Upload the release to GitHub releases"
 task :upload_to_github do
   require_relative "tool/release"
 
-  Release.for_rubygems(v).create_for_github!
+  Release.new(v.to_s).create_for_github!
 end
 
 desc "Upload release to S3"
@@ -727,7 +727,13 @@ namespace :bundler do
   require_relative "spec/support/build_metadata"
   require_relative "tool/release"
 
-  Bundler::GemHelper.tag_prefix = "bundler-"
+  # The rubygems release task tags the release as v#{version} and creates the
+  # single GitHub release covering both RubyGems and Bundler, so bundler's
+  # release must not tag or create a GitHub release of its own. Drop the
+  # release:source_control_push prerequisite that would add a bundler-v tag.
+  Rake::Task["bundler:release"].clear
+  desc "Push bundler-#{Bundler::GemHelper.gemspec.version}.gem to rubygems.org"
+  task release: ["build", "release:guard_clean", "release:rubygem_push"]
 
   desc "Write build metadata file in preparation for release"
   task :build_metadata do
@@ -748,7 +754,7 @@ namespace :bundler do
   task "build" => ["bundler:release:check_ruby_version"]
 
   desc "Push to rubygems.org"
-  task "release:rubygem_push" => ["bundler:release:setup", "man:check", "bundler:build_metadata", "check_release_preparations", "bundler:release:github"]
+  task "release:rubygem_push" => ["bundler:release:setup", "man:check", "bundler:build_metadata", "check_release_preparations"]
 
   desc "Generates the Bundler changelog for a specific target version"
   task :generate_changelog, [:version] => [:install_release_dependencies] do |_t, opts|
@@ -759,13 +765,6 @@ namespace :bundler do
     desc "Install gems needed for releasing"
     task :setup do
       Release.install_dependencies!
-    end
-
-    desc "Push the release to GitHub releases"
-    task :github do
-      gemspec_version = Bundler::GemHelper.gemspec.version
-
-      Release.for_bundler(gemspec_version).create_for_github!
     end
 
     task :check_ruby_version do

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -114,12 +114,11 @@ We only release major breaking changes when incrementing the _major_ version of 
     * Run `rake check_deprecations` and package `rubygems-update` gem.
     * Tag the release like `v4.0.0.beta3` and push the tag to GitHub.
     * Push `rubygems-update-4.0.0.beta3` to RubyGems.org.
-    * Upload RubyGems tgz and zip files to s3 and create a GitHub release.
+    * Upload RubyGems tgz and zip files to s3 and create a single GitHub release covering both RubyGems and Bundler.
     * Update the guides website and blog posts of rubygems.org.
 *   Release `bundler` with `bin/rake bundler:release`.
     * Package `bundler` gem and run `rake man:check`.
-    * Tag the release like `v2.4.0.beta3` and push the tag to GitHub. And create a GitHub release.
-    * Push `bundler-2.4.0.beta3` to RubyGems.org.
+    * Push `bundler-4.0.0.beta3` to RubyGems.org. No separate tag or GitHub release is created for Bundler.
 
 #### Post-release
 

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -15,7 +15,7 @@ class Release
   module SubRelease
     include GithubAPI
 
-    attr_reader :version, :changelog, :version_files, :tag_prefix
+    attr_reader :version, :changelog, :version_files
 
     def cut_changelog_for!(pull_requests)
       set_relevant_pull_requests_from(pull_requests)
@@ -37,26 +37,17 @@ class Release
       end
     end
 
-    def create_for_github!
-      tag = "#{@tag_prefix}#{@version}"
-
-      options = {
-        name: tag,
-        body: @changelog.release_notes.join("\n").strip,
-        prerelease: @version.prerelease?,
-      }
-      options[:target_commitish] = @stable_branch unless @version.prerelease?
-
-      gh_client.create_release "ruby/rubygems", tag, **options
-    end
-
     def previous_version
-      @previous_version ||= remove_tag_prefix(latest_release.tag_name)
+      @previous_version ||= latest_release.tag_name.delete_prefix("v")
     end
 
+    # RubyGems and Bundler are versioned in lockstep and share a single
+    # unified `v`-prefixed release, so both sub-releases derive their previous
+    # version from it. The `bundler-v` tags from older releases don't match
+    # the `v` prefix and are ignored.
     def latest_release
-      @latest_release ||= gh_client.releases("ruby/rubygems").select {|release| release.tag_name.start_with?(@tag_prefix) }.max_by do |release|
-        Gem::Version.new(remove_tag_prefix(release.tag_name))
+      @latest_release ||= gh_client.releases("ruby/rubygems").select {|release| release.tag_name.start_with?("v") }.max_by do |release|
+        Gem::Version.new(release.tag_name.delete_prefix("v"))
       end
     end
 
@@ -65,20 +56,13 @@ class Release
     def set_relevant_pull_requests_from(pulls)
       @relevant_pull_requests = pulls.select {|pull| @changelog.relevant_label_for(pull) }
     end
-
-    private
-
-    def remove_tag_prefix(name)
-      name.gsub(/^#{@tag_prefix}/, "")
-    end
   end
 
   class Bundler
     include SubRelease
 
-    def initialize(version, stable_branch)
+    def initialize(version)
       @version = Gem::Version.new(version)
-      @stable_branch = stable_branch
       @changelog = Changelog.for_bundler(version)
       # Bundler's version file was flattened to lib/bundler/version.rb on
       # master, but stays at bundler/lib/bundler/version.rb on the 4.0 and
@@ -90,7 +74,6 @@ class Release
         File.expand_path("../lib/bundler/version.rb", __dir__),
         File.expand_path("../bundler/lib/bundler/version.rb", __dir__),
       ]
-      @tag_prefix = "bundler-v"
     end
 
     def version_files
@@ -105,12 +88,10 @@ class Release
   class Rubygems
     include SubRelease
 
-    def initialize(version, stable_branch)
+    def initialize(version)
       @version = Gem::Version.new(version)
-      @stable_branch = stable_branch
       @changelog = Changelog.for_rubygems(version)
       @version_files = [File.expand_path("../lib/rubygems.rb", __dir__)]
-      @tag_prefix = "v"
     end
 
     def extra_entry
@@ -172,10 +153,10 @@ class Release
     @last_release_tag = @level == :patch ? "v#{@stable_branch}.#{segments[2] - 1}" : @previous_release_tag
 
     rubygems_version = segments.join(".").gsub(/([a-z])\.(\d)/i, '\1\2')
-    @rubygems = Rubygems.new(rubygems_version, @stable_branch)
+    @rubygems = Rubygems.new(rubygems_version)
 
     bundler_version = segments.join(".").gsub(/([a-z])\.(\d)/i, '\1\2')
-    @bundler = Bundler.new(bundler_version, @stable_branch)
+    @bundler = Bundler.new(bundler_version)
 
     @release_branch = "release/#{version}"
   end
@@ -391,8 +372,29 @@ class Release
     @current_library.cut_changelog_for!(unreleased_pull_requests)
   end
 
+  # Creates the single GitHub release covering both RubyGems and Bundler,
+  # attached to the unified v#{version} tag.
   def create_for_github!
-    @current_library.create_for_github!
+    tag = "v#{@rubygems.version}"
+
+    body = <<~BODY.strip
+      ## RubyGems #{@rubygems.version}
+
+      #{@rubygems.changelog.release_notes.join("\n").strip}
+
+      ## Bundler #{@bundler.version}
+
+      #{@bundler.changelog.release_notes.join("\n").strip}
+    BODY
+
+    options = {
+      name: tag,
+      body: body,
+      prerelease: @prerelease,
+    }
+    options[:target_commitish] = @stable_branch unless @prerelease
+
+    gh_client.create_release "ruby/rubygems", tag, **options
   end
 
   private


### PR DESCRIPTION
Each release currently pushes two tags pointing at the same commit, `v4.0.17` and `bundler-v4.0.17`, and creates two GitHub releases with split notes, which shows up as duplicated entries on the releases page. Since RubyGems and Bundler are released in lockstep, `rake release` now creates a single GitHub release on the `v<version>` tag whose body contains both changelogs, like the blog announcement, and `bundler:release` no longer tags `bundler-v<version>` or creates a release of its own. With the GitHub release and the S3 upload gone from the bundler side, `bundler:release` also drops `check_release_preparations` and `bundler:release:setup`, leaving gem build, `guard_clean`, `man:check` and `gem push`.
