### PR TITLE
Clarify :path expectations and cross-link platform docs in man pages

### DIFF
--- a/lib/bundler/man/bundle-platform.1
+++ b/lib/bundler/man/bundle-platform.1
@@ -38,6 +38,8 @@ Your current platform satisfies the Ruby version requirement\.
 .IP "" 0
 .P
 \fBplatform\fR lists all the platforms in your \fBGemfile\.lock\fR as well as the \fBruby\fR directive if applicable from your Gemfile(5)\. It also lets you know if the \fBruby\fR directive requirement has been met\. If \fBruby\fR directive doesn't match the running Ruby VM, it tells you what part does not\.
+.P
+For a detailed explanation of how bundler handles platforms, see the \fBPLATFORMS\fR section in Gemfile(5)\.
 .SH "OPTIONS"
 .TP
 \fB\-\-ruby\fR
@@ -45,5 +47,7 @@ It will display the ruby directive information, so you don't have to parse it fr
 .SH "SEE ALSO"
 .IP "\(bu" 4
 bundle\-lock(1) \fIbundle\-lock\.1\.html\fR
+.IP "\(bu" 4
+Gemfile(5) \fIgemfile\.5\.html\fR
 .IP "" 0
 

--- a/lib/bundler/man/bundle-platform.1.ronn
+++ b/lib/bundler/man/bundle-platform.1.ronn
@@ -38,6 +38,9 @@ If you run `bundle platform` on Ruby 3.1.2, it displays the following output:
 if the `ruby` directive requirement has been met. If `ruby` directive doesn't
 match the running Ruby VM, it tells you what part does not.
 
+For a detailed explanation of how bundler handles platforms, see the
+`PLATFORMS` section in Gemfile(5).
+
 ## OPTIONS
 
 * `--ruby`:
@@ -47,3 +50,4 @@ match the running Ruby VM, it tells you what part does not.
 ## SEE ALSO
 
 * [bundle-lock(1)](bundle-lock.1.html)
+* [Gemfile(5)](gemfile.5.html)

--- a/lib/bundler/man/gemfile.5
+++ b/lib/bundler/man/gemfile.5
@@ -392,7 +392,7 @@ gem "rails", git: "https://rails@bitbucket\.org/rails/rails\.git"
 .P
 Since the \fBbitbucket\fR method is a specialization of \fBgit_source\fR, it accepts a \fB:branch\fR named argument\.
 .SS "PATH"
-You can specify that a gem is located in a particular location on the file system\. Relative paths are resolved relative to the directory containing the \fBGemfile\fR\.
+You can specify that a gem is located in a particular location on the file system\. Relative paths are resolved relative to the directory containing the \fBGemfile\fR\. The path must point to a directory containing the gem's unpacked source code, not to a packaged \fB\.gem\fR file\.
 .P
 Similar to the semantics of the \fB:git\fR option, the \fB:path\fR option requires that the directory in question either contains a \fB\.gemspec\fR for the gem, or that you specify an explicit version that bundler should use\.
 .P

--- a/lib/bundler/man/gemfile.5.ronn
+++ b/lib/bundler/man/gemfile.5.ronn
@@ -451,7 +451,9 @@ Since the `bitbucket` method is a specialization of `git_source`, it accepts a `
 
 You can specify that a gem is located in a particular location
 on the file system. Relative paths are resolved relative to the
-directory containing the `Gemfile`.
+directory containing the `Gemfile`. The path must point to a
+directory containing the gem's unpacked source code, not to a
+packaged `.gem` file.
 
 Similar to the semantics of the `:git` option, the `:path`
 option requires that the directory in question either contains


### PR DESCRIPTION
Two documentation issues reported against bundler-site are actually gaps in the man pages maintained here.

`gemfile(5)` never says what a `:path` directory is supposed to contain, so a reader assumed it could unpack and install a packaged `.gem` file. I added a sentence to the PATH section stating that the path must point to a directory with the gem's unpacked source code. The existing note that an explicit version can substitute for a `.gemspec` is accurate and stays as is.

`bundle-platform(1)` describes its output but never points to the detailed platform documentation in `gemfile(5)`, leaving readers without a next step. I added a pointer to the PLATFORMS section in the DESCRIPTION and a `Gemfile(5)` entry under SEE ALSO.

Fixes rubygems/bundler-site#546
Fixes rubygems/bundler-site#594
