### PR TITLE
Update blog repository URL to renamed rubygems/blog

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -385,7 +385,7 @@ end
 
 directory "tmp/blog.rubygems.org" do
   sh "git", "clone",
-    "https://github.com/rubygems/rubygems.github.io.git",
+    "https://github.com/rubygems/blog.git",
      "tmp/blog.rubygems.org"
 end
 


### PR DESCRIPTION
The blog repository was renamed from `rubygems/rubygems.github.io` to `rubygems/blog`, so the `blog:pull` release task would clone from a redirected URL. This updates the clone URL in the `Rakefile` to the new repository name.

Generated with [Claude Code](https://claude.com/claude-code)
