### PR TITLE
Document Bundler checksum behavior for default gems

### DIFF
--- a/lib/bundler/man/bundle-config.1
+++ b/lib/bundler/man/bundle-config.1
@@ -139,7 +139,7 @@ Cooldown filtering depends on the gem server providing a per\-version \fBcreated
 .IP "\(bu" 4
 \fBlockfile\fR (\fBBUNDLE_LOCKFILE\fR): The path to the lockfile that bundler should use\. By default, Bundler adds \fB\.lock\fR to the end of the \fBgemfile\fR entry\. Can be set to \fBfalse\fR in the Gemfile to disable lockfile creation entirely (see gemfile(5))\.
 .IP "\(bu" 4
-\fBlockfile_checksums\fR (\fBBUNDLE_LOCKFILE_CHECKSUMS\fR): Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources\. Defaults to true\.
+\fBlockfile_checksums\fR (\fBBUNDLE_LOCKFILE_CHECKSUMS\fR): Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources\. Defaults to true\. Bundler's own checksum is only included when its \fB\.gem\fR file is cached, which may not be the case when Bundler is installed as a default gem\.
 .IP "\(bu" 4
 \fBno_build_extension\fR (\fBBUNDLE_NO_BUILD_EXTENSION\fR): Whether Bundler should skip building native extensions during installation\. When set, gems are installed without compiling their C extensions\. To build extensions later, unset this setting and run \fBbundle pristine <gem>\fR\.
 .IP "\(bu" 4

--- a/lib/bundler/man/bundle-config.1.ronn
+++ b/lib/bundler/man/bundle-config.1.ronn
@@ -230,6 +230,8 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Gemfile to disable lockfile creation entirely (see gemfile(5)).
 * `lockfile_checksums` (`BUNDLE_LOCKFILE_CHECKSUMS`):
    Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources. Defaults to true.
+   Bundler's own checksum is only included when its `.gem` file is cached, which
+   may not be the case when Bundler is installed as a default gem.
 * `no_build_extension` (`BUNDLE_NO_BUILD_EXTENSION`):
    Whether Bundler should skip building native extensions during installation.
    When set, gems are installed without compiling their C extensions.


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

Bundler's own checksum is only included when the matching `.gem` file is cached. Bundler installed as a default gem may not have this file, but this behavior was not documented.

## What is your fix for the problem, implemented in this PR?

Document the limitation under `lockfile_checksums` and regenerate `bundle-config(1)`. This does not change runtime behavior.

@Edouard-chin, you mentioned in #9512 that you would be happy to review this, so here it is 😄

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#tests) for features and bug fixes (N/A, documentation only)
- [ ] Write code to solve the problem (N/A, documentation only)
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
