### PR TITLE
Point bundler.io URLs at guides.rubygems.org

### DIFF
--- a/doc/DOCUMENTATION.md
+++ b/doc/DOCUMENTATION.md
@@ -7,7 +7,7 @@ Code needs explanation, and sometimes those who know the code well have trouble 
 Documentation for RubyGems and Bundler is managed in two places:
 
 - **Guides and tutorials**: [RubyGems Guides](https://guides.rubygems.org/) — hosted in the [rubygems/guides](https://github.com/rubygems/guides) repository
-- **Bundler CLI man pages**: Built from `.ronn` files in `lib/bundler/man/` in this repository and published to [bundler.io](https://bundler.io)
+- **Bundler CLI man pages**: Built from `.ronn` files in `lib/bundler/man/` in this repository and published as the [Bundler command reference](https://guides.rubygems.org/command-reference/bundle/) on RubyGems Guides
 
 All documentation other than Bundler command man pages — including guides, tutorials, and reference material for both RubyGems and Bundler — should be contributed to the [rubygems/guides](https://github.com/rubygems/guides) repository.
 
@@ -98,7 +98,7 @@ $ man ./lib/bundler/man/bundle-cookies.1
 
 If you make more changes to `bundle-cookies.1.ronn`, you'll need to run the `bin/rake man:build` again before previewing.
 
-The [Bundler documentation site](https://bundler.io) is automatically generated from these `.ronn` files.
+The [Bundler command reference](https://guides.rubygems.org/command-reference/bundle/) on RubyGems Guides is generated from these `.ronn` files by the `bundler_reference` task in the [rubygems/guides](https://github.com/rubygems/guides) repository, and republished when RubyGems is released.
 
 ### Testing
 

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -25,10 +25,10 @@ Please open a ticket with [Heroku](https://www.heroku.com) if you're having trou
 
 ## Other problems
 
-First, figure out exactly what it is that you're trying to do (see [XY Problem](http://xyproblem.info/)). Then, go to the [Bundler documentation website](https://bundler.io) and see if we have instructions on how to do that.
+First, figure out exactly what it is that you're trying to do (see [XY Problem](http://xyproblem.info/)). Then, go to the [RubyGems guides](https://guides.rubygems.org/) and see if we have instructions on how to do that.
 
 Second, check [the compatibility
-list](https://bundler.io/compatibility.html), and make sure that the version of Bundler that you are using works with the versions of Ruby and RubyGems that you are using. To see your versions:
+list](https://guides.rubygems.org/bundler-compatibility/), and make sure that the version of Bundler that you are using works with the versions of Ruby and RubyGems that you are using. To see your versions:
 
     # Bundler version
     bundle -v

--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -26,7 +26,7 @@ require_relative "bundler/build_metadata"
 # or Bundler.setup to setup environment where only specified gems and their
 # specified versions could be used.
 #
-# See {Bundler website}[https://bundler.io/docs.html] for extensive documentation
+# See {Bundler documentation}[https://guides.rubygems.org/command-reference/bundle/] for extensive documentation
 # on gemfiles creation and Bundler usage.
 #
 # As a standard library inside project, Bundler could be used for introspection

--- a/lib/bundler/cli/issue.rb
+++ b/lib/bundler/cli/issue.rb
@@ -13,10 +13,10 @@ module Bundler
         https://github.com/ruby/rubygems/blob/master/doc/bundler/TROUBLESHOOTING.md
 
         2. Instructions for common Bundler uses can be found on the documentation
-        site: https://bundler.io/
+        site: https://guides.rubygems.org/
 
         3. Information about each Bundler command can be found in the Bundler
-        man pages: https://bundler.io/man/bundle.1.html
+        man pages: https://guides.rubygems.org/command-reference/bundle/
 
         Hopefully the troubleshooting steps above resolved your problem!  If things
         still aren't working the way you expect them to, please let us know so

--- a/lib/bundler/man/bundle-add.1
+++ b/lib/bundler/man/bundle-add.1
@@ -79,4 +79,4 @@ You can assign the gem to more than one group\.
 \fBbundle add rails \-\-group "development, test"\fR
 .IP "" 0
 .SH "SEE ALSO"
-Gemfile(5) \fIhttps://bundler\.io/man/gemfile\.5\.html\fR, bundle\-remove(1) \fIbundle\-remove\.1\.html\fR
+Gemfile(5) \fIhttps://guides\.rubygems\.org/gemfile/\fR, bundle\-remove(1) \fIbundle\-remove\.1\.html\fR

--- a/lib/bundler/man/bundle-add.1.ronn
+++ b/lib/bundler/man/bundle-add.1.ronn
@@ -91,5 +91,5 @@ Adds the named gem to the [`Gemfile(5)`][Gemfile(5)] and run `bundle install`.
 
 ## SEE ALSO
 
-[Gemfile(5)](https://bundler.io/man/gemfile.5.html),
+[Gemfile(5)](https://guides.rubygems.org/gemfile/),
 [bundle-remove(1)](bundle-remove.1.html)

--- a/lib/bundler/man/bundle-console.1
+++ b/lib/bundler/man/bundle-console.1
@@ -8,7 +8,7 @@
 .SH "DESCRIPTION"
 Starts an interactive Ruby console session in the context of the current bundle\.
 .P
-If no \fBGROUP\fR is specified, all gems in the \fBdefault\fR group in the Gemfile(5) \fIhttps://bundler\.io/man/gemfile\.5\.html\fR are preliminarily loaded\.
+If no \fBGROUP\fR is specified, all gems in the \fBdefault\fR group in the Gemfile(5) \fIhttps://guides\.rubygems\.org/gemfile/\fR are preliminarily loaded\.
 .P
 If \fBGROUP\fR is specified, all gems in the given group in the Gemfile in addition to the gems in \fBdefault\fR group are loaded\. Even if the given group does not exist in the Gemfile, IRB console starts without any warning or error\.
 .P
@@ -30,4 +30,4 @@ Resolving dependencies\|\.\|\.\|\.
 [1] pry(main)>
 .fi
 .SH "SEE ALSO"
-Gemfile(5) \fIhttps://bundler\.io/man/gemfile\.5\.html\fR
+Gemfile(5) \fIhttps://guides\.rubygems\.org/gemfile/\fR

--- a/lib/bundler/man/bundle-console.1.ronn
+++ b/lib/bundler/man/bundle-console.1.ronn
@@ -9,7 +9,7 @@ bundle-console(1) -- Open an IRB session with the bundle pre-loaded
 
 Starts an interactive Ruby console session in the context of the current bundle.
 
-If no `GROUP` is specified, all gems in the `default` group in the [Gemfile(5)](https://bundler.io/man/gemfile.5.html) are
+If no `GROUP` is specified, all gems in the `default` group in the [Gemfile(5)](https://guides.rubygems.org/gemfile/) are
 preliminarily loaded.
 
 If `GROUP` is specified, all gems in the given group in the Gemfile in addition
@@ -36,4 +36,4 @@ the shell from the following:
 
 ## SEE ALSO
 
-[Gemfile(5)](https://bundler.io/man/gemfile.5.html)
+[Gemfile(5)](https://guides.rubygems.org/gemfile/)

--- a/lib/bundler/man/bundle-init.1
+++ b/lib/bundler/man/bundle-init.1
@@ -17,4 +17,4 @@ Use the specified name for the gemfile instead of \fBGemfile\fR
 .SH "FILES"
 Included in the default [\fBGemfile(5)\fR][Gemfile(5)] generated is the line \fB# frozen_string_literal: true\fR\. This is a magic comment supported for the first time in Ruby 2\.3\. The presence of this line results in all string literals in the file being implicitly frozen\.
 .SH "SEE ALSO"
-Gemfile(5) \fIhttps://bundler\.io/man/gemfile\.5\.html\fR
+Gemfile(5) \fIhttps://guides\.rubygems\.org/gemfile/\fR

--- a/lib/bundler/man/bundle-init.1.ronn
+++ b/lib/bundler/man/bundle-init.1.ronn
@@ -29,4 +29,4 @@ results in all string literals in the file being implicitly frozen.
 
 ## SEE ALSO
 
-[Gemfile(5)](https://bundler.io/man/gemfile.5.html)
+[Gemfile(5)](https://guides.rubygems.org/gemfile/)

--- a/lib/bundler/man/bundle-plugin.1
+++ b/lib/bundler/man/bundle-plugin.1
@@ -71,6 +71,6 @@ Describe subcommands or one specific subcommand\.
 No options\.
 .SH "SEE ALSO"
 .IP "\(bu" 4
-How to write a Bundler plugin \fIhttps://bundler\.io/guides/bundler_plugins\.html\fR
+How to write a Bundler plugin \fIhttps://guides\.rubygems\.org/bundler_plugins/\fR
 .IP "" 0
 

--- a/lib/bundler/man/bundle-plugin.1.ronn
+++ b/lib/bundler/man/bundle-plugin.1.ronn
@@ -81,4 +81,4 @@ No options.
 
 ## SEE ALSO
 
-* [How to write a Bundler plugin](https://bundler.io/guides/bundler_plugins.html)
+* [How to write a Bundler plugin](https://guides.rubygems.org/bundler_plugins/)

--- a/lib/bundler/man/bundle.1
+++ b/lib/bundler/man/bundle.1
@@ -8,7 +8,7 @@
 .SH "DESCRIPTION"
 Bundler manages an \fBapplication's dependencies\fR through its entire life across many machines systematically and repeatably\.
 .P
-See the bundler website \fIhttps://bundler\.io\fR for information on getting started, and Gemfile(5) for more information on the \fBGemfile\fR format\.
+See the RubyGems guides \fIhttps://guides\.rubygems\.org/\fR for information on getting started, and Gemfile(5) for more information on the \fBGemfile\fR format\.
 .SH "OPTIONS"
 .TP
 \fB\-\-no\-color\fR

--- a/lib/bundler/man/bundle.1.ronn
+++ b/lib/bundler/man/bundle.1.ronn
@@ -10,7 +10,7 @@ bundle(1) -- Ruby Dependency Management
 Bundler manages an `application's dependencies` through its entire life
 across many machines systematically and repeatably.
 
-See [the bundler website](https://bundler.io) for information on getting
+See [the RubyGems guides](https://guides.rubygems.org/) for information on getting
 started, and Gemfile(5) for more information on the `Gemfile` format.
 
 ## OPTIONS

--- a/lib/bundler/man/gemfile.5
+++ b/lib/bundler/man/gemfile.5
@@ -166,7 +166,7 @@ bundle config set \-\-local without development test
 .P
 Also, calling \fBBundler\.setup\fR with no parameters, or calling \fBrequire "bundler/setup"\fR will setup all groups except for the ones you excluded via \fB\-\-without\fR (since they are not available)\.
 .P
-Note that on \fBbundle install\fR, bundler downloads and evaluates all gems, in order to create a single canonical list of all of the required gems and their dependencies\. This means that you cannot list different versions of the same gems in different groups\. For more details, see Understanding Bundler \fIhttps://bundler\.io/rationale\.html\fR\.
+Note that on \fBbundle install\fR, bundler downloads and evaluates all gems, in order to create a single canonical list of all of the required gems and their dependencies\. This means that you cannot list different versions of the same gems in different groups\. For more details, see Dependency management \fIhttps://guides\.rubygems\.org/dependency_management/\fR\.
 .SS "PLATFORMS"
 If a gem should only be used in a particular platform or set of platforms, you can specify them\. Platforms are essentially identical to groups, except that you do not need to use the \fB\-\-without\fR install\-time flag to exclude groups of gems for other platforms\.
 .P

--- a/lib/bundler/man/gemfile.5.ronn
+++ b/lib/bundler/man/gemfile.5.ronn
@@ -200,7 +200,7 @@ are not available).
 Note that on `bundle install`, bundler downloads and evaluates all gems, in order to
 create a single canonical list of all of the required gems and their dependencies.
 This means that you cannot list different versions of the same gems in different
-groups. For more details, see [Understanding Bundler](https://bundler.io/rationale.html).
+groups. For more details, see [Dependency management](https://guides.rubygems.org/dependency_management/).
 
 ### PLATFORMS
 

--- a/lib/rubygems/commands/help_command.rb
+++ b/lib/rubygems/commands/help_command.rb
@@ -59,7 +59,7 @@ multiple environments.  The RubyGems implementation is designed to be
 compatible with Bundler's Gemfile format.  You can see additional
 documentation on the format at:
 
-  https://bundler.io
+  https://guides.rubygems.org/
 
 RubyGems automatically looks for these gem dependencies files:
 
@@ -174,7 +174,7 @@ and #platforms methods:
 See the bundler Gemfile manual page for a list of platforms supported in a gem
 dependencies file.:
 
-  https://bundler.io/v2.5/man/gemfile.5.html
+  https://guides.rubygems.org/gemfile/
 
 Ruby Version and Engine Dependency
 ==================================


### PR DESCRIPTION
bundler.io has been wound down and its content now lives on RubyGems Guides. The man pages moved to `/command-reference/`, the Gemfile reference to `/gemfile/`, the plugin guide to `/bundler_plugins/`, the rationale page to `/dependency_management/`, and the compatibility list to `/bundler-compatibility/`. Redirects still cover the old URLs, but the links shipped in RubyGems and Bundler should name the real pages. `gem help gem_dependencies` also stops pointing at a version-pinned `v2.5` man page.

`doc/DOCUMENTATION.md` needed more than a URL swap because it described bundler.io as where the man pages get published. It now names the `bundler_reference` task in `rubygems/guides` that builds the command reference from these `.ronn` files.

Two references stay on bundler.io. The homepage in `lib/bundler/source/metadata.rb` has to match the published bundler gemspec, and the team pages linked from `doc/POLICIES.md` have no replacement yet.

Every new URL returns 200, and `rake man:check` reports the regenerated man pages in sync.
