### PR TITLE
[Content Addressable] Support Content Addressable Gems in Remote Install Process

### DIFF
--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -140,16 +140,33 @@ class Gem::BasicSpecification
   end
 
   ##
-  # Returns the full name (name-version) of this Gem.  Platform information
-  # is included (name-version-platform) if it is specified and not the
+  # Returns the full name (name-version) of this Gem.
+  # Content address is included (name-version-content_address) if it is specified.
+  # Platform information is included (name-version-platform) if it is specified and not the
   # default Ruby platform.
 
   def full_name
-    if platform == Gem::Platform::RUBY || platform.nil?
+    if content_addressable?
+      "#{name}-#{version}-#{content_address}"
+    elsif platform == Gem::Platform::RUBY || platform.nil?
       "#{name}-#{version}"
     else
       "#{name}-#{version}-#{platform}"
     end
+  end
+
+  def content_address # :nodoc:
+    raise NotImplementedError
+  end
+
+  def content_addressable? # :nodoc:
+    Gem::BasicSpecification.content_address?(content_address)
+  end
+
+  CONTENT_ADDRESS = /\A[0-9a-f]{8,64}\z/ # :nodoc:
+
+  def self.content_address?(value) # :nodoc:
+    value.is_a?(String) && CONTENT_ADDRESS.match?(value)
   end
 
   ##

--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -114,6 +114,9 @@ class Gem::Installer
 
     def copy_to(path)
     end
+
+    def gem
+    end
   end
 
   ##
@@ -266,6 +269,7 @@ class Gem::Installer
   #     specifications/<gem-version>.gemspec #=> the Gem::Specification
 
   def install
+    assign_content_address
     pre_install_checks
 
     run_pre_install_hooks
@@ -965,6 +969,26 @@ class Gem::Installer
   end
 
   private
+
+  def assign_content_address
+    path = @package.gem&.path
+    address = derive_content_address_from_filename(path)
+    @gem_dir = nil if address != spec.content_address
+    spec.content_address = address
+  end
+
+  def derive_content_address_from_filename(path)
+    return unless path
+
+    filename = File.basename(path, ".gem")
+    token = filename.split("-").last
+    return nil unless Gem::BasicSpecification.content_address?(token)
+
+    require "digest"
+    digest = Digest::SHA256.file(path).hexdigest
+    raise Gem::InstallError, "content address mismatch for #{File.basename(path)}" unless digest.start_with?(token)
+    token
+  end
 
   def user_install_dir
     # never install to user home in --build-root mode

--- a/lib/rubygems/resolver.rb
+++ b/lib/rubygems/resolver.rb
@@ -396,10 +396,11 @@ class Gem::Resolver
       next installed.first if installed.length == 1
       candidates = installed if installed.any?
 
-      # Among remaining candidates, prefer the most specific platform, then the
-      # earlier-supplied source.
+      # Among remaining candidates, prefer the most specific platform, then a
+      # content-addressed candidate, then the earlier-supplied source.
       candidates.min_by do |s|
         [Gem::Platform.platform_specificity_match(s.platform, Gem::Platform.local),
+         s.content_addressable? ? 0 : 1,
          source_rank[s.source]]
       end
     end

--- a/lib/rubygems/resolver/api_set.rb
+++ b/lib/rubygems/resolver/api_set.rb
@@ -108,12 +108,12 @@ class Gem::Resolver::APISet < Gem::Resolver::Set
       []
     end
 
-    infos.each do |_, number, platform, dependencies, requirements|
-      platform ||= "ruby"
+    infos.each do |_, number, suffix, dependencies, requirements|
+      suffix ||= "ruby"
       dependencies = dependencies.map {|dep_name, reqs| [dep_name, reqs.join(", ")] }
       requirements = requirements.map {|req_name, reqs| [req_name.to_sym, reqs] }.to_h
 
-      @data[name] << { name: name, number: number, platform: platform, dependencies: dependencies, requirements: requirements }
+      @data[name] << { name: name, number: number, suffix: suffix, dependencies: dependencies, requirements: requirements }
     end
 
     @data[name]

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -31,8 +31,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
     @set = set
     @name = api_data[:name]
     @version = Gem::Version.new(api_data[:number]).freeze
-    @platform = Gem::Platform.new(api_data[:platform]).freeze
-    @original_platform = api_data[:platform].freeze
+    assign_platform(api_data)
     @dependencies = api_data[:dependencies].map do |name, ver|
       Gem::Dependency.new(name, ver.split(/\s*,\s*/)).freeze
     end.freeze
@@ -46,15 +45,17 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
       @set          == other.set &&
       @name         == other.name &&
       @version      == other.version &&
-      @platform     == other.platform
+      @platform     == other.platform &&
+      @content_address == other.content_address
   end
 
   def hash
-    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash
+    @set.hash ^ @name.hash ^ @version.hash ^ @platform.hash ^ @content_address.hash
   end
 
   def fetch_development_dependencies # :nodoc:
-    spec = source.fetch_spec Gem::NameTuple.new @name, @version, @platform
+    suffix = @content_address || @platform
+    spec = source.fetch_spec Gem::NameTuple.new @name, @version, suffix
 
     @dependencies = spec.dependencies
   end
@@ -99,6 +100,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
       s.original_platform = @original_platform
       s.required_ruby_version = @required_ruby_version
       s.required_rubygems_version = @required_rubygems_version
+      s.content_address = @content_address
 
       @dependencies.each do |dependency|
         s.add_runtime_dependency dependency.name, *dependency.requirement.as_list
@@ -111,6 +113,29 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
   end
 
   private
+
+  def assign_platform(api_data)
+    suffix = api_data[:suffix]
+    required_platform = required_platform_from(api_data.dig(:requirements, :platform))
+
+    if Gem::BasicSpecification.content_address?(suffix) && required_platform
+      @content_address = suffix.freeze
+      @platform = required_platform.freeze
+      @original_platform = required_platform.to_s.freeze
+    else
+      @content_address = nil
+      @platform = Gem::Platform.new(suffix).freeze
+      @original_platform = suffix.freeze
+    end
+  end
+
+  def required_platform_from(requirement)
+    req = Array(requirement).last.to_s
+    op, platform = req.split(" ")
+    return unless op == "=" && platform
+
+    Gem::Platform.new(platform)
+  end
 
   def parse_created_at(value)
     value = value.first if value.is_a?(Array)

--- a/lib/rubygems/resolver/spec_specification.rb
+++ b/lib/rubygems/resolver/spec_specification.rb
@@ -23,6 +23,10 @@ class Gem::Resolver::SpecSpecification < Gem::Resolver::Specification
     spec.dependencies
   end
 
+  def content_address # :nodoc:
+    spec.content_address
+  end
+
   ##
   # The required_ruby_version constraint for this specification
 

--- a/lib/rubygems/resolver/specification.rb
+++ b/lib/rubygems/resolver/specification.rb
@@ -73,6 +73,7 @@ class Gem::Resolver::Specification
     @version      = nil
     @required_ruby_version = Gem::Requirement.default
     @required_rubygems_version = Gem::Requirement.default
+    @content_address = nil
   end
 
   ##
@@ -80,6 +81,12 @@ class Gem::Resolver::Specification
   # default (see APISpecification).
 
   def fetch_development_dependencies # :nodoc:
+  end
+
+  attr_reader :content_address # :nodoc:
+
+  def content_addressable? # :nodoc:
+    Gem::BasicSpecification.content_address?(content_address)
   end
 
   ##

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -407,6 +407,8 @@ class Gem::Specification < Gem::BasicSpecification
 
   attr_accessor :metadata
 
+  attr_accessor :content_address # :nodoc:
+
   ######################################################################
   # :section: Optional gemspec attributes
 
@@ -1342,7 +1344,8 @@ class Gem::Specification < Gem::BasicSpecification
     self.class === other &&
       name == other.name &&
       version == other.version &&
-      platform == other.platform
+      platform == other.platform &&
+      content_address == other.content_address
   end
 
   ##
@@ -1913,7 +1916,7 @@ class Gem::Specification < Gem::BasicSpecification
   # :startdoc:
 
   def hash # :nodoc:
-    name.hash ^ version.hash
+    [name, version, platform, content_address].hash
   end
 
   def init_with(coder) # :nodoc:
@@ -1949,6 +1952,7 @@ class Gem::Specification < Gem::BasicSpecification
     @loaded_from = nil
     @original_platform = nil
     @installed_by_version = nil
+    @content_address = nil
 
     set_nil_attributes_to_nil
     set_not_nil_attributes_to_default_values
@@ -2269,7 +2273,8 @@ class Gem::Specification < Gem::BasicSpecification
   # True if this gem has the same attributes as +other+.
 
   def same_attributes?(spec)
-    @@attributes.all? {|name, _default| send(name) == spec.send(name) }
+    @@attributes.all? {|name, _default| send(name) == spec.send(name) } &&
+      content_address == spec.content_address
   end
 
   private :same_attributes?
@@ -2368,9 +2373,11 @@ class Gem::Specification < Gem::BasicSpecification
   # still have their default values are omitted.
 
   def to_ruby
+    gem_suffix = content_addressable? ? content_address : platform
     result = []
     result << "# -*- encoding: utf-8 -*-"
-    result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{platform} #{raw_require_paths.join("\0")}"
+    result << "#{Gem::StubSpecification::PREFIX}#{name} #{version} #{gem_suffix} #{raw_require_paths.join("\0")}"
+    result << "#{Gem::StubSpecification::TARGET_PREFIX}platform=#{platform}" if content_addressable?
     result << "#{Gem::StubSpecification::PREFIX}#{extensions.join "\0"}" unless
       extensions.empty?
     result << nil
@@ -2381,6 +2388,7 @@ class Gem::Specification < Gem::BasicSpecification
     unless platform.nil? || platform == Gem::Platform::RUBY
       result << "  s.platform = #{ruby_code original_platform}"
     end
+    result << "  s.content_address = #{ruby_code content_address}" if content_addressable?
     result << ""
     result << "  s.required_rubygems_version = #{ruby_code required_rubygems_version} if s.respond_to? :required_rubygems_version="
 

--- a/lib/rubygems/stub_specification.rb
+++ b/lib/rubygems/stub_specification.rb
@@ -10,11 +10,14 @@ class Gem::StubSpecification < Gem::BasicSpecification
   PREFIX = "# stub: "
 
   # :nodoc:
+  TARGET_PREFIX = "# stub-target: "
+
+  # :nodoc:
   OPEN_MODE = "r:UTF-8:-"
 
   class StubLine # :nodoc: all
     attr_reader :name, :version, :platform, :require_paths, :extensions,
-                :full_name
+                :full_name, :content_address
 
     NO_EXTENSIONS = [].freeze
 
@@ -33,7 +36,7 @@ class Gem::StubSpecification < Gem::BasicSpecification
       "lib" => ["lib"].freeze,
     }.freeze
 
-    def initialize(data, extensions)
+    def initialize(data, extensions, target = nil)
       parts          = data[PREFIX.length..-1].split(" ", 4)
       @name          = -parts[0]
       @version       = if Gem::Version.correct?(parts[1])
@@ -42,12 +45,17 @@ class Gem::StubSpecification < Gem::BasicSpecification
         Gem::Version.new(0)
       end
 
-      @platform      = Gem::Platform.new parts[2]
+      suffix = parts[2]
+      target_platform = target && target["platform"]
+      @platform = Gem::Platform.new(target_platform || suffix)
+      @content_address = suffix if Gem::BasicSpecification.content_address?(suffix)
       @extensions    = extensions
-      @full_name     = if platform == Gem::Platform::RUBY
+      @full_name     = if @content_address
+        "#{name}-#{version}-#{content_address}"
+      elsif platform == Gem::Platform::RUBY
         "#{name}-#{version}"
       else
-        "#{name}-#{version}-#{platform}"
+        "#{name}-#{version}-#{suffix}"
       end
 
       path_list = parts.last
@@ -110,18 +118,28 @@ class Gem::StubSpecification < Gem::BasicSpecification
           file.readline # discard encoding line
           stubline = file.readline
           if stubline.start_with?(PREFIX)
-            extline = file.readline
+            line = file.readline
+
+            if line.delete_prefix!(TARGET_PREFIX)
+              line.chomp!
+              target = {}
+              line.split(",").each do |pair|
+                key, value = pair.split("=", 2)
+                target[key] = value
+              end
+              line = file.readline
+            end
 
             extensions =
-              if extline.delete_prefix!(PREFIX)
-                extline.chomp!
-                extline.split "\0"
+              if line.delete_prefix!(PREFIX)
+                line.chomp!
+                line.split "\0"
               else
                 StubLine::NO_EXTENSIONS
               end
 
             stubline.chomp! # readline(chomp: true) allocates 3x as much as .readline.chomp!
-            @data = StubLine.new stubline, extensions
+            @data = StubLine.new stubline, extensions, target
           end
         rescue EOFError
         end
@@ -160,6 +178,10 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
   def platform
     data.platform
+  end
+
+  def content_address # :nodoc:
+    data.content_address
   end
 
   ##
@@ -208,13 +230,14 @@ class Gem::StubSpecification < Gem::BasicSpecification
     self.class === other &&
       name == other.name &&
       version == other.version &&
-      platform == other.platform
+      platform == other.platform &&
+      content_address == other.content_address
   end
 
   alias_method :eql?, :== # :nodoc:
 
   def hash # :nodoc:
-    name.hash ^ version.hash ^ platform.hash
+    [name, version, platform, content_address].hash
   end
 
   def <=>(other) # :nodoc:

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "installer_test_case"
+require "digest"
 
 class TestGemInstaller < Gem::InstallerTestCase
   def setup
@@ -1028,6 +1029,92 @@ class TestGemInstaller < Gem::InstallerTestCase
 
     assert_path_exist File.join(gemhome2, "gems", @spec.full_name)
     assert_path_not_exist File.join(Gem.user_dir, "gems", @spec.full_name)
+  end
+
+  def test_install_assigns_content_address_from_filename
+    _, a_gem = util_gem "a", 2
+
+    digest = Digest::SHA256.file(a_gem).hexdigest
+    address = digest[0, 8]
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-#{address}.gem")
+    FileUtils.cp a_gem, filename
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    # deliberately memoize the directory before installation, to prove the installation recalculates
+    installer.gem_dir
+    spec = installer.install
+
+    assert_equal address, spec.content_address
+    assert_equal "a-2-#{address}", spec.full_name
+    assert_path_exist File.join(@gemhome, "gems", "a-2-#{address}")
+    assert_path_exist File.join(@gemhome, "specifications", "a-2-#{address}.gemspec")
+  end
+
+  def test_install_raises_for_mismatched_content_address
+    _, a_gem = util_gem "a", 2
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-deadbeef.gem")
+    FileUtils.cp a_gem, filename
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+
+    e = assert_raise Gem::InstallError do
+      installer.install
+    end
+
+    assert_match(/content address mismatch/, e.message)
+  end
+
+  def test_non_content_addressed_gems_install_as_expected
+    _, a_gem = util_gem "a", 2
+    installer = Gem::Installer.at a_gem, install_dir: @gemhome, force: true
+    spec = installer.install
+
+    assert_nil spec.content_address
+    assert_equal "a-2", spec.full_name
+    assert_path_exist File.join(@gemhome, "gems", "a-2")
+    assert_path_exist File.join(@gemhome, "specifications", "a-2.gemspec")
+  end
+
+  def test_require_works_after_content_addressed_install
+    source_spec, a_gem = util_gem "a", 2 do |spec|
+      spec.files = ["lib/ca_activation_test.rb"]
+    end
+    FileUtils.rm_rf source_spec.gem_dir
+
+    digest = Digest::SHA256.file(a_gem).hexdigest
+    address = digest[0, 8]
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-#{address}.gem")
+    FileUtils.cp a_gem, filename
+
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    installer.install
+
+    Gem::Specification.reset
+
+    assert require "ca_activation_test"
+  end
+
+  def test_reinstalling_content_addressed_gem_is_idempotent
+    source_spec, a_gem = util_gem "a", 2
+    FileUtils.rm_rf source_spec.gem_dir
+
+    digest = Digest::SHA256.file(a_gem).hexdigest
+    address = digest[0, 8]
+    dir = File.dirname(a_gem)
+    filename = File.join(dir, "a-2-#{address}.gem")
+    FileUtils.cp a_gem, filename
+    installer = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    installer.install
+
+    installer2 = Gem::Installer.at filename, install_dir: @gemhome, force: true
+    spec2 = installer2.install
+
+    assert_equal "a-2-#{address}", spec2.full_name
+    assert_path_exist File.join(@gemhome, "gems", "a-2-#{address}")
+    assert_path_exist File.join(@gemhome, "specifications", "a-2-#{address}.gemspec")
+    assert_equal 1, Dir[File.join(@gemhome, "gems", "a-2*")].size
+    assert_equal 1, Dir[File.join(@gemhome, "specifications", "a-2*.gemspec")].size
   end
 
   def test_install

--- a/test/rubygems/test_gem_remote_fetcher.rb
+++ b/test/rubygems/test_gem_remote_fetcher.rb
@@ -125,6 +125,24 @@ class TestGemRemoteFetcher < Gem::TestCase
     assert File.exist?(a1_cache_gem)
   end
 
+  def test_download_and_install_content_addressed_gem
+    require "digest"
+
+    address = Digest::SHA256.file(@a1_gem).hexdigest[0, 10]
+    @a1.content_address = address
+    gem_data = File.binread @a1_gem
+    gem_url = "http://gems.example.com/gems/a-1-#{address}.gem"
+    fetcher = fake_fetcher(gem_url, gem_data)
+
+    gem_path = fetcher.download(@a1, "http://gems.example.com")
+    installed_spec = Gem::Installer.at(gem_path, install_dir: @gemhome, force: true).install
+
+    assert_equal gem_url, fetcher.paths.last
+    assert_equal address, installed_spec.content_address
+    assert_equal "a-1-#{address}", installed_spec.full_name
+    assert_path_exist installed_spec.full_gem_path
+  end
+
   def test_download_with_auth
     a1_data = File.open @a1_gem, "rb", &:read
     a1_url = "http://user:password@gems.example.com/gems/a-1.gem"

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -322,6 +322,67 @@ class TestGemResolver < Gem::TestCase
     assert_resolves_to [a2_p1.spec], res
   end
 
+  def test_prefers_content_addressed_gem_for_same_platform
+    ca_spec = util_spec "a", "1"
+    spec = util_spec "a", "1"
+
+    ca_spec.platform = Gem::Platform.local
+    ca_spec.content_address = "abc1234567"
+    spec.platform = Gem::Platform.local
+
+    s = set(spec, ca_spec)
+    dependency = make_dep "a"
+    resolver = Gem::Resolver.new([dependency], s)
+    assert_resolves_to [ca_spec], resolver
+  end
+
+  def test_falls_back_to_fat_when_content_addressed_gem_requires_other_rubygems_version
+    ca_spec = util_spec "a", "1"
+    fat_spec = util_spec "a", "1"
+
+    ca_spec.platform = Gem::Platform.local
+    ca_spec.content_address = "abc1234567"
+    ca_spec.required_rubygems_version = ">= 999"
+    fat_spec.platform = Gem::Platform.local
+
+    s = set(fat_spec, ca_spec)
+    dependency = make_dep "a"
+    resolver = Gem::Resolver.new([dependency], s)
+    assert_resolves_to [fat_spec], resolver
+  end
+
+  def test_falls_back_to_source_when_content_addressed_gem_requires_other_ruby
+    ca_spec = util_spec "a", "1"
+    source_spec = util_spec "a", "1"
+
+    ca_spec.platform = Gem::Platform.local
+    ca_spec.content_address = "abc1234567"
+    ca_spec.required_ruby_version = ">= 999"
+    source_spec.platform = Gem::Platform::RUBY
+
+    s = set(source_spec, ca_spec)
+    dependency = make_dep "a"
+    resolver = Gem::Resolver.new([dependency], s)
+    assert_resolves_to [source_spec], resolver
+  end
+
+  def test_falls_back_to_fat_before_source_when_content_addressed_gem_requires_other_ruby
+    ca_spec = util_spec "a", "1"
+    fat_spec = util_spec "a", "1"
+    source_spec = util_spec "a", "1"
+
+    ca_spec.platform = Gem::Platform.local
+    ca_spec.content_address = "abc1234567"
+    ca_spec.required_ruby_version = ">= 999"
+    fat_spec.platform = Gem::Platform.local
+    source_spec.platform = Gem::Platform::RUBY
+
+    s = set(source_spec, fat_spec, ca_spec)
+    dependency = make_dep "a"
+    resolver = Gem::Resolver.new([dependency], s)
+    assert_resolves_to [fat_spec], resolver
+  end
+
   def test_does_not_pick_musl_variants_on_non_musl_linux
     util_set_arch "aarch64-linux" do
       is = Gem::Resolver::IndexSpecification

--- a/test/rubygems/test_gem_resolver_api_set.rb
+++ b/test/rubygems/test_gem_resolver_api_set.rb
@@ -38,7 +38,7 @@ class TestGemResolverAPISet < Gem::TestCase
     data = [
       { name: "a",
         number: "1",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
     ]
 
@@ -55,17 +55,31 @@ class TestGemResolverAPISet < Gem::TestCase
     assert_equal expected, set.find_all(a_dep)
   end
 
+  def test_find_all_content_addressed
+    spec_fetcher
+
+    @fetcher.data["#{@dep_uri}a"] = util_compact_index_response("---\n1-ab12345678 |platform:= #{Gem::Platform.local}\n")
+
+    set = Gem::Resolver::APISet.new @dep_uri
+    a_dep = Gem::Resolver::DependencyRequest.new dep("a"), nil
+    spec = set.find_all(a_dep).first
+
+    assert_equal "ab12345678", spec.content_address
+    assert_equal Gem::Platform.local, spec.platform
+    assert_predicate spec, :content_addressable?
+  end
+
   def test_find_all_prereleases
     spec_fetcher
 
     data = [
       { name: "a",
         number: "1",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
       { name: "a",
         number: "2.a",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
     ]
 
@@ -90,7 +104,7 @@ class TestGemResolverAPISet < Gem::TestCase
     data = [
       { name: "a",
         number: "1",
-        platform: "ruby",
+        suffix: "ruby",
         dependencies: [] },
     ]
 

--- a/test/rubygems/test_gem_resolver_api_specification.rb
+++ b/test/rubygems/test_gem_resolver_api_specification.rb
@@ -8,7 +8,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: Gem::Platform.local.to_s,
+      suffix: Gem::Platform.local.to_s,
       dependencies: [
         ["bundler",  "~> 1.0"],
         ["railties", "= 3.0.3"],
@@ -30,12 +30,64 @@ class TestGemResolverAPISpecification < Gem::TestCase
     assert_nil spec.created_at
   end
 
+  def test_initialize_content_address
+    set = Gem::Resolver::APISet.new
+    data = {
+      name: "rails",
+      number: "3.0.3",
+      suffix: "abc1234567",
+      dependencies: [],
+      requirements: { platform: ["= #{Gem::Platform.local}"] },
+    }
+
+    spec = Gem::Resolver::APISpecification.new set, data
+
+    assert_equal "abc1234567", spec.content_address
+    assert_equal Gem::Platform.local, spec.platform
+    assert_predicate spec, :content_addressable?
+    assert_equal "abc1234567", spec.spec.content_address
+  end
+
+  def test_initialize_does_not_treat_non_content_address_suffix_as_content_addressed
+    set = Gem::Resolver::APISet.new
+    data = {
+      name: "rails",
+      number: "3.0.3",
+      suffix: Gem::Platform.local.to_s,
+      dependencies: [],
+      requirements: { platform: ["= #{Gem::Platform.local}"] },
+    }
+
+    spec = Gem::Resolver::APISpecification.new set, data
+
+    assert_nil spec.content_address
+    refute_predicate spec, :content_addressable?
+    assert_equal Gem::Platform.local, spec.platform
+  end
+
+  def test_content_addressed_specs_with_different_addresses_are_distinct
+    set = Gem::Resolver::APISet.new
+    data = {
+      name: "rails",
+      number: "3.0.3",
+      suffix: "abc1234567",
+      dependencies: [],
+      requirements: { platform: ["= #{Gem::Platform.local}"] },
+    }
+
+    first = Gem::Resolver::APISpecification.new set, data
+    second = Gem::Resolver::APISpecification.new set, data.merge(suffix: "def1234567")
+
+    refute_equal first, second
+    refute_equal first.hash, second.hash
+  end
+
   def test_initialize_created_at
     set = Gem::Resolver::APISet.new
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
       requirements: { created_at: ["2026-06-05T10:30:45Z"] },
     }
@@ -50,7 +102,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
       requirements: { created_at: ["not a timestamp"] },
     }
@@ -65,7 +117,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
       requirements: { created_at: ["2026"] },
     }
@@ -93,7 +145,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "rails",
       number: "3.0.3",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [
         ["bundler",  "~> 1.0"],
         ["railties", "= 3.0.3"],
@@ -115,12 +167,42 @@ class TestGemResolverAPISpecification < Gem::TestCase
     assert_equal expected, spec.dependencies
   end
 
+  def test_fetch_development_dependencies_for_content_addressed_spec
+    fetched_tuple = nil
+    fetched_spec = util_spec "rails", "3.0.3" do |s|
+      s.add_development_dependency "a", "= 1"
+    end
+
+    source = Object.new
+    source.define_singleton_method(:fetch_spec) do |tuple|
+      fetched_tuple = tuple
+      fetched_spec
+    end
+
+    set = Gem::Resolver::APISet.new
+    set.instance_variable_set :@source, source
+    data = {
+      name: "rails",
+      number: "3.0.3",
+      suffix: "abc1234567",
+      dependencies: [],
+      requirements: { platform: ["= #{Gem::Platform.local}"] },
+    }
+
+    spec = Gem::Resolver::APISpecification.new set, data
+
+    spec.fetch_development_dependencies
+
+    assert_equal "rails-3.0.3-abc1234567.gemspec", fetched_tuple.spec_name
+    assert_equal [Gem::Dependency.new("a", "= 1", :development)], spec.dependencies
+  end
+
   def test_installable_platform_eh
     set = Gem::Resolver::APISet.new
     data = {
       name: "a",
       number: "1",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
     }
 
@@ -131,7 +213,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "b",
       number: "1",
-      platform: "cpu-other_platform-1",
+      suffix: "cpu-other_platform-1",
       dependencies: [],
     }
 
@@ -142,7 +224,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "c",
       number: "1",
-      platform: Gem::Platform.local.to_s,
+      suffix: Gem::Platform.local.to_s,
       dependencies: [],
     }
 
@@ -156,7 +238,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "a",
       number: "1",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
     }
 
@@ -175,7 +257,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "a",
       number: "1",
-      platform: "ruby",
+      suffix: "ruby",
       dependencies: [],
     }
 
@@ -199,7 +281,7 @@ class TestGemResolverAPISpecification < Gem::TestCase
     data = {
       name: "j",
       number: "1",
-      platform: "jruby",
+      suffix: "jruby",
       dependencies: [],
     }
 

--- a/test/rubygems/test_gem_specification.rb
+++ b/test/rubygems/test_gem_specification.rb
@@ -1925,6 +1925,21 @@ dependencies: []
     assert_equal "a-1-x86-darwin-8", @a1.full_name
   end
 
+  def test_content_addressable_full_name
+    @a1 = Gem::Specification.new "a", 1
+    @a1.platform = "x86_64-linux"
+    @a1.content_address = "abcdef12"
+    assert_equal "a-1-abcdef12", @a1.full_name
+    assert_equal "x86_64-linux", @a1.platform.to_s
+  end
+
+  def test_content_address_predicate
+    assert Gem::BasicSpecification.content_address?("abcdef12")
+    refute Gem::BasicSpecification.content_address?("x86_64-linux")
+    refute Gem::BasicSpecification.content_address?(nil)
+    refute Gem::BasicSpecification.content_address?("abc")
+  end
+
   def test_full_name_windows
     test_cases = {
       "i386-mswin32" => "a-1-x86-mswin32-60",
@@ -1949,6 +1964,19 @@ dependencies: []
     assert_equal @a1.hash, @a1.hash
     assert_equal @a1.hash, @a1.dup.hash
     refute_equal @a1.hash, @a2.hash
+  end
+
+  def test_content_addressable_specs_are_distinct
+    first = Gem::Specification.new "a", 1
+    first.platform = "arm64-darwin"
+    first.content_address = "abcdef12"
+
+    second = Gem::Specification.new "a", 1
+    second.platform = "arm64-darwin"
+    second.content_address = "12345678"
+
+    refute_equal first, second
+    assert_equal 2, [first, second].uniq.size
   end
 
   def test_installed_by_version
@@ -2342,6 +2370,29 @@ end
     same_spec = eval ruby_code
 
     assert_equal @a2, same_spec
+  end
+
+  def test_to_ruby_content_addressable
+    spec = Gem::Specification.new "a", 1
+    spec.platform = "x86_64-linux"
+    spec.content_address = "abcdef12"
+    spec.extensions = ["ext/a/extconf.rb"]
+
+    ruby_code = spec.to_ruby
+
+    expected_stub = <<~STUB.chomp
+      # stub: a 1 abcdef12 lib
+      # stub-target: platform=x86_64-linux
+      # stub: ext/a/extconf.rb
+    STUB
+
+    assert_includes ruby_code, expected_stub
+
+    same_spec = eval ruby_code
+
+    assert_equal "abcdef12", same_spec.content_address
+    assert_equal "x86_64-linux", same_spec.platform.to_s
+    assert_equal "a-1-abcdef12", same_spec.full_name
   end
 
   def test_to_ruby_with_rsa_key

--- a/test/rubygems/test_gem_stub_specification.rb
+++ b/test/rubygems/test_gem_stub_specification.rb
@@ -23,6 +23,26 @@ class TestStubSpecification < Gem::TestCase
     assert @foo.stubbed?
   end
 
+  def test_initialize_with_target
+    stub = stub_with_target
+
+    assert_equal "stub_with_target", stub.name
+    assert_equal v(2), stub.version
+    assert_equal Gem::Platform.new("x86_64-linux"), stub.platform
+    assert_equal [stub.extension_dir, "lib"], stub.require_paths
+    assert_equal %w[ext/stub_with_target/extconf.rb], stub.extensions
+    assert_equal "ab12345678", stub.content_address
+    assert_equal "stub_with_target-2-ab12345678", stub.full_name
+  end
+
+  def test_content_addressable_stubs_are_distinct
+    first = stub_with_target "ab12345678"
+    second = stub_with_target "cd12345678"
+
+    refute_equal first, second
+    assert_equal 2, [first, second].uniq.size
+  end
+
   def test_initialize_extension
     stub = stub_with_extension
 
@@ -253,6 +273,31 @@ class TestStubSpecification < Gem::TestCase
         Gem::Specification.new do |s|
           s.name = 'stub_v'
           s.version = ""
+        end
+      STUB
+
+      io.flush
+
+      stub = Gem::StubSpecification.gemspec_stub io.path, @gemhome, File.join(@gemhome, "gems")
+
+      yield stub if block_given?
+
+      return stub
+    end
+  end
+
+  def stub_with_target(content_address = "ab12345678")
+    spec = File.join @gemhome, "specifications", "stub_with_target-#{content_address}.gemspec"
+    File.open spec, "w" do |io|
+      io.write <<~STUB
+        # -*- encoding: utf-8 -*-
+        # stub: stub_with_target 2 #{content_address} lib
+        # stub-target: platform=x86_64-linux
+        # stub: ext/stub_with_target/extconf.rb
+
+        Gem::Specification.new do |s|
+          s.name = 'stub_with_target'
+          s.version = Gem::Version.new '2'
         end
       STUB
 


### PR DESCRIPTION
## TL;DR

  Adds support for resolving, downloading, and installing content-addressed (“skinny”) gems from a remote source.

  ## Description

  Compact-index entries for skinny gems use the content address as the version suffix and provide the real platform through the `platform:` requirement.

  This change:

  - Separates the content address from the gem’s real platform.
  - Carries the content address through the resolver into the full specification.
  - Prefers a compatible skinny gem over fat and source variants.
  - Falls back to fat or source gems when the skinny gem is incompatible.
  - Downloads gems and development gemspecs using their content-addressed filenames.
  - Preserves distinct resolver candidates when their content addresses differ.

  This PR builds on the local content-addressed installation work.

  ## Testing

```
  ruby --disable-gems -Ilib:test \
    test/rubygems/test_gem_resolver_api_set.rb \
    test/rubygems/test_gem_resolver_api_specification.rb \
    test/rubygems/test_gem_resolver.rb \
    test/rubygems/test_gem_remote_fetcher.rb
```

  The tests cover:

  - Parsing content-addressed compact-index entries.
  - Selecting compatible skinny gems.
  - Falling back to fat or source gems.
  - Respecting Ruby and RubyGems requirements.
  - Downloading SHA-named gem archives.
  - Fetching SHA-named gemspecs for development dependencies.

  ## Top hatting

  1. Configure a gem server containing compatible skinny, fat, and source variants.
  2. Install the gem using this RubyGems checkout:

```
     ruby --disable-gems -Ilib exe/gem install GEM_NAME \
       --source SERVER_URL \
       --install-dir "$(mktemp -d)"
```

  3. Confirm the compatible SHA-named gem was downloaded and installed.
  4. Confirm the installed specification reports the real platform.
  5. Confirm the gem can be required.
  6. Repeat with no compatible skinny variant and confirm installation falls back to the fat or source gem.