### PR TITLE
Make repeated bundle lock options accumulate

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -627,15 +627,15 @@ module Bundler
     end
 
     desc "lock", "Creates a lockfile without installing"
-    method_option "update", type: :array, lazy_default: true, banner: "ignore the existing lockfile, update all gems by default, or update list of given gems"
+    method_option "update", type: :array, lazy_default: true, repeatable: true, banner: "ignore the existing lockfile, update all gems by default, or update list of given gems"
     method_option "local", type: :boolean, default: false, banner: "do not attempt to fetch remote gemspecs and use the local gem cache only"
     method_option "print", type: :boolean, default: false, banner: "print the lockfile to STDOUT instead of writing to the file system"
     method_option "gemfile", type: :string, banner: "Use the specified gemfile instead of Gemfile"
     method_option "lockfile", type: :string, default: nil, banner: "the path the lockfile should be written to"
     method_option "full-index", type: :boolean, default: false, banner: "Fall back to using the single-file index of all gems"
     method_option "add-checksums", type: :boolean, default: false, banner: "Adds checksums to the lockfile"
-    method_option "add-platform", type: :array, default: [], banner: "Add a new platform to the lockfile"
-    method_option "remove-platform", type: :array, default: [], banner: "Remove a platform from the lockfile"
+    method_option "add-platform", type: :array, default: [], repeatable: true, banner: "Add a new platform to the lockfile"
+    method_option "remove-platform", type: :array, default: [], repeatable: true, banner: "Remove a platform from the lockfile"
     method_option "normalize-platforms", type: :boolean, default: false, banner: "Normalize lockfile platforms"
     method_option "patch", type: :boolean, banner: "If updating, prefer updating only to next patch version"
     method_option "minor", type: :boolean, banner: "If updating, prefer updating only to next minor version"

--- a/lib/bundler/cli/lock.rb
+++ b/lib/bundler/cli/lock.rb
@@ -26,6 +26,9 @@ module Bundler
       Bundler::Fetcher.disable_endpoint = options["full-index"]
 
       update = options[:update]
+      # --update is repeatable, so it parses as an array with one entry per
+      # occurrence, where a bare `--update` produces a `true` entry
+      update = update.include?(true) ? true : update.flatten if update.is_a?(Array)
       conservative = options[:conservative]
       bundler = options[:bundler]
 
@@ -44,12 +47,12 @@ module Bundler
 
         Bundler::CLI::Common.configure_gem_version_promoter(definition, options) if options[:update]
 
-        options["remove-platform"].each do |platform_string|
+        options["remove-platform"].flatten.each do |platform_string|
           platform = Gem::Platform.new(platform_string)
           definition.remove_platform(platform)
         end
 
-        options["add-platform"].each do |platform_string|
+        options["add-platform"].flatten.each do |platform_string|
           platform = Gem::Platform.new(platform_string)
           if platform.to_s == "unknown"
             Bundler.ui.error "The platform `#{platform_string}` is unknown to RubyGems and can't be added to the lockfile."

--- a/spec/commands/lock_spec.rb
+++ b/spec/commands/lock_spec.rb
@@ -463,6 +463,49 @@ RSpec.describe "bundle lock" do
     expect(read_lockfile).to eq(expected_lockfile)
   end
 
+  it "updates gems given through repeated --update options" do
+    build_repo4 do
+      build_gem "foo", "1.0"
+      build_gem "foo", "2.0"
+      build_gem "bar", "1.0"
+      build_gem "bar", "2.0"
+      build_gem "baz", "1.0"
+      build_gem "baz", "2.0"
+    end
+
+    gemfile <<-G
+      source "https://gem.repo4"
+
+      gem "foo"
+      gem "bar"
+      gem "baz"
+    G
+
+    lockfile <<~L
+      GEM
+        remote: https://gem.repo4/
+        specs:
+          bar (1.0)
+          baz (1.0)
+          foo (1.0)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        bar
+        baz
+        foo
+
+      BUNDLED WITH
+        #{Bundler::VERSION}
+    L
+
+    bundle "lock --update foo --update bar"
+
+    expect(lockfile).to include("foo (2.0)", "bar (2.0)", "baz (1.0)")
+  end
+
   it "updates specific gems using --update, even if that requires unlocking other top level gems" do
     build_repo4 do
       build_gem "prism", "0.15.1"
@@ -853,6 +896,15 @@ RSpec.describe "bundle lock" do
     expect(the_bundle.locked_platforms).to match_array(default_platform_list("java", "x86-mingw32"))
   end
 
+  it "supports adding platforms through repeated --add-platform options" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
+    bundle "lock --add-platform java --add-platform x86-mingw32"
+
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+    expect(the_bundle.locked_platforms).to match_array(default_platform_list("java", "x86-mingw32"))
+  end
+
   it "supports adding new platforms when a previous lockfile exists" do
     gemfile_with_rails_weakling_and_foo_from_repo4
 
@@ -973,6 +1025,19 @@ RSpec.describe "bundle lock" do
     bundle "lock --remove-platform java"
 
     expect(the_bundle.locked_platforms).to match_array(default_platform_list("x86-mingw32"))
+  end
+
+  it "supports removing platforms through repeated --remove-platform options" do
+    gemfile_with_rails_weakling_and_foo_from_repo4
+
+    bundle "lock --add-platform java x86-mingw32"
+
+    allow(Bundler::SharedHelpers).to receive(:find_gemfile).and_return(bundled_app_gemfile)
+    expect(the_bundle.locked_platforms).to match_array(default_platform_list("java", "x86-mingw32"))
+
+    bundle "lock --remove-platform java --remove-platform x86-mingw32"
+
+    expect(the_bundle.locked_platforms).to match_array(default_platform_list)
   end
 
   it "also cleans up redundant platform gems when removing platforms" do


### PR DESCRIPTION
`bundle lock --add-platform x86_64-linux --add-platform ruby` silently applied only the last `--add-platform` because Thor array options are last-wins. This marks `--add-platform`, `--remove-platform` and `--update` as repeatable so every occurrence takes effect. Thor collects repeatable array options as one array per occurrence, so `CLI::Lock` flattens the parsed values, and a bare `--update` mixed with gem names is treated as a full update.

Fixes #5357.
