### PR TITLE
Fix gem uninstall --user-install crash when GEM_HOME does not exist

### DIFF
--- a/lib/rubygems/uninstaller.rb
+++ b/lib/rubygems/uninstaller.rb
@@ -64,7 +64,8 @@ class Gem::Uninstaller
     @gem                = gem
     @version            = options[:version] || Gem::Requirement.default
     @install_dir        = options[:install_dir]
-    @gem_home           = File.realpath(@install_dir || Gem.dir)
+    gem_home            = @install_dir || Gem.dir
+    @gem_home           = File.exist?(gem_home) ? File.realpath(gem_home) : gem_home
     @user_dir           = File.exist?(Gem.user_dir) ? File.realpath(Gem.user_dir) : Gem.user_dir
     @force_executables  = options[:executables]
     @force_all          = options[:all]

--- a/test/rubygems/test_gem_uninstaller.rb
+++ b/test/rubygems/test_gem_uninstaller.rb
@@ -451,6 +451,24 @@ create_makefile '#{@spec.name}'
     assert_same uninstaller, @post_uninstall_hook_arg
   end
 
+  def test_uninstall_user_install_with_missing_gem_home
+    FileUtils.rm_rf Gem.dir
+
+    Gem::Specification.dirs = [Gem.user_dir]
+
+    uninstaller = Gem::Uninstaller.new(@user_spec.name,
+                                       executables: true,
+                                       user_install: true)
+
+    gem_dir = @user_spec.gem_dir
+
+    assert_path_exist gem_dir
+
+    uninstaller.uninstall
+
+    assert_path_not_exist gem_dir
+  end
+
   def test_uninstall_user_install_with_symlinked_home
     pend "Symlinks not supported or not enabled" unless symlink_supported?
 


### PR DESCRIPTION
`gem uninstall GEM --user-install` crashes with `Errno::ENOENT` when `Gem.dir` does not exist, which happens when every gem on the machine was installed with `--user-install`. `Gem::Uninstaller#initialize` called `File.realpath` on `Gem.dir` unconditionally. Skip the realpath resolution when the directory is missing, as already done for `Gem.user_dir` on the next line.

Fixes #9149

Generated with [Claude Code](https://claude.com/claude-code)
