### PR TITLE
Prevent test git commands from mutating the checkout's own git config

### DIFF
--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -8,6 +8,11 @@ require "bundler"
 RSpec.describe Bundler::ParallelInstaller do
   describe "priority queue" do
     before do
+      # Anchor the vendored Persistent classes on the real Gem::Net::HTTP
+      # before Artifice replaces it, see Artifice.activate_with. Requiring
+      # support/artifice/compact_index already activates Artifice, so this
+      # must come first.
+      require "bundler/vendored_persistent"
       require "support/artifice/compact_index"
       Artifice.activate_with(CompactIndexAPI)
 
@@ -98,6 +103,11 @@ RSpec.describe Bundler::ParallelInstaller do
         skip "This example does not work under a parent make jobserver"
       end
 
+      # Anchor the vendored Persistent classes on the real Gem::Net::HTTP
+      # before Artifice replaces it, see Artifice.activate_with. Requiring
+      # support/artifice/compact_index already activates Artifice, so this
+      # must come first.
+      require "bundler/vendored_persistent"
       require "support/artifice/compact_index"
       Artifice.activate_with(CompactIndexAPI)
 

--- a/spec/commands/show_spec.rb
+++ b/spec/commands/show_spec.rb
@@ -164,7 +164,13 @@ RSpec.describe "bundle show" do
     before :each do
       build_git "foo", path: lib_path("foo")
       File.open(lib_path("foo/Gemfile"), "w") {|f| f.puts "gemspec" }
-      sys_exec "rm -rf .git && git init", dir: lib_path("foo")
+      # sys_exec does not go through a shell, so this cannot be a single
+      # `rm -rf .git && git init` command: `&&` would be passed to `rm` as a
+      # literal argument, silently skipping the `git init` part and leaving a
+      # non-repository directory from which git would discover the rubygems
+      # checkout itself.
+      FileUtils.rm_rf lib_path("foo/.git")
+      git "init", lib_path("foo")
     end
 
     it "does not output git errors" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -147,6 +147,14 @@ RSpec.configure do |config|
       ENV["GIT_CONFIG_NOSYSTEM"] = "1"
     end
 
+    # Prevent git commands spawned by specs (directly or through Bundler)
+    # from discovering the rubygems checkout itself when run in a directory
+    # that is not a fixture repository, e.g. a fixture whose .git has been
+    # deleted by a concurrent cleanup. Without this, repository discovery
+    # walks up into the checkout and a stray `git config` writes the fixture
+    # identity to the checkout's own (possibly worktree-shared) .git/config.
+    ENV["GIT_CEILING_DIRECTORIES"] = [Spec::Path.tmp_root.to_s, Spec::Path.source_root.to_s].uniq.join(File::PATH_SEPARATOR)
+
     # Disable git background maintenance. Since Git 2.46, commands like
     # `git commit` spawn a detached `git maintenance run --auto` process,
     # which briefly creates `.git/objects/maintenance.lock`. That races with

--- a/spec/support/artifice/helpers/artifice.rb
+++ b/spec/support/artifice/helpers/artifice.rb
@@ -9,6 +9,14 @@ module Artifice
   # Rack endpoint.
   #
   # @param [#call] endpoint A valid Rack endpoint
+  # In-process users that also deactivate must load bundler/vendored_persistent
+  # before activating. If it gets lazily required while Artifice is active, the
+  # vendored Persistent classes are defined under the Artifice replacement of
+  # Gem::Net::HTTP instead of the real one, and after deactivation
+  # Gem::Net::HTTP::Persistent becomes unresolvable, blowing up the
+  # connection_pool fork hook on any later Process.fork. Spawned bundler
+  # processes are unaffected: they never deactivate, and requiring it here
+  # would double-load bundler files in them through mismatched load paths.
   def self.activate_with(endpoint)
     require_relative "rack_request"
 

--- a/spec/support/subprocess.rb
+++ b/spec/support/subprocess.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "command_execution"
-require_relative "path"
 
 module Spec
   module Subprocess
@@ -47,6 +46,10 @@ module Spec
       return if args.any? {|a| ["--global", "--system", "-f", "--file"].include?(a) || a.start_with?("--file=") }
       return if args.any? {|a| ["--get", "--get-all", "--get-regexp", "--get-urlmatch", "--list", "-l"].include?(a) }
 
+      # Required lazily because this file is loaded in every spawned ruby
+      # before RubygemsVersionManager switches RubyGems, where loading extra
+      # default gems (pathname, through support/path) breaks the setup.
+      require_relative "path"
       dir = File.expand_path(path.to_s)
       tmp_root = Spec::Path.tmp_root.to_s
       return if dir == tmp_root || dir.start_with?(tmp_root + File::SEPARATOR)

--- a/spec/support/subprocess.rb
+++ b/spec/support/subprocess.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "command_execution"
+require_relative "path"
 
 module Spec
   module Subprocess
@@ -31,7 +32,27 @@ module Spec
     end
 
     def git(cmd, path = Dir.pwd, options = {})
+      reject_git_config_pollution!(cmd, path)
       sh("git #{cmd}", options.merge(dir: path))
+    end
+
+    # A local `git config` write in a directory without a `.git` makes git
+    # discover an enclosing repository, which can be the rubygems checkout
+    # itself, polluting its (possibly worktree-shared) `.git/config` with
+    # fixture identities. Only allow local config writes inside tmp/.
+    def reject_git_config_pollution!(cmd, path)
+      require "shellwords"
+      args = cmd.to_s.shellsplit
+      return unless args.first == "config"
+      return if args.any? {|a| ["--global", "--system", "-f", "--file"].include?(a) || a.start_with?("--file=") }
+      return if args.any? {|a| ["--get", "--get-all", "--get-regexp", "--get-urlmatch", "--list", "-l"].include?(a) }
+
+      dir = File.expand_path(path.to_s)
+      tmp_root = Spec::Path.tmp_root.to_s
+      return if dir == tmp_root || dir.start_with?(tmp_root + File::SEPARATOR)
+
+      raise "Refusing to run `git #{cmd}` in #{dir}: " \
+            "a local git config write outside tmp/ could end up in the checkout's own .git/config"
     end
 
     def sh(cmd, options = {})

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -373,6 +373,12 @@ class Gem::TestCase < Test::Unit::TestCase
 
     @tempdir = Dir.mktmpdir("test_rubygems_", @tmp)
 
+    # @tmp lives inside the checkout by default, so stop git repository
+    # discovery from walking up into the checkout itself. Otherwise a git
+    # command run in a non-repository directory under @tempdir could mutate
+    # the checkout's own (possibly worktree-shared) .git/config.
+    ENV["GIT_CEILING_DIRECTORIES"] = File.realpath(top_srcdir)
+
     ENV["GEM_VENDOR"] = nil
     ENV["GEMRC"] = nil
     ENV["XDG_CACHE_HOME"] = nil
@@ -661,9 +667,9 @@ class Gem::TestCase < Test::Unit::TestCase
 
     Dir.chdir directory do
       unless File.exist? ".git"
-        system @git, "init", "--quiet"
-        system @git, "config", "user.name",  "RubyGems Tests"
-        system @git, "config", "user.email", "rubygems@example"
+        system @git, "init", "--quiet", exception: true
+        system @git, "config", "user.name",  "RubyGems Tests", exception: true
+        system @git, "config", "user.email", "rubygems@example", exception: true
       end
 
       system @git, "add", gemspec


### PR DESCRIPTION
When a fixture directory under `tmp/` has no `.git`, git repository discovery walks up into the checkout itself, and the fixture `git config user.email lol@wut.com` ends up in the checkout's shared `.git/config`, silently changing the author identity of subsequent commits in every worktree. This actually happened when a concurrent cleanup removed a fixture's `.git` between `git init` and `git config`. A setup line in `spec/commands/show_spec.rb` had the same dangerous shape, since `sys_exec "rm -rf .git && git init"` does not go through a shell, so `&&` was passed to `rm` as a literal argument and `git init` never ran.

Set `GIT_CEILING_DIRECTORIES` so discovery can never escape `tmp/`, make the spec `git` helper refuse local config writes outside `tmp/`, fix the `show_spec` setup, and apply the same ceiling in `test/rubygems/helper.rb`, whose default tmp also lives inside the checkout, along with `exception: true` on the `git_gem` setup commands.

Generated with [Claude Code](https://claude.com/claude-code)
