### PR TITLE
Check the resolved parent directory before extracting old format gems

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -453,10 +453,7 @@ EOM
           directories << mkdir
         end
 
-        real_mkdir = File.realpath(mkdir)
-        unless real_mkdir == destination_dir || normalize_path(real_mkdir).start_with?(normalize_path(destination_dir + "/"))
-          raise Gem::Package::PathError.new(real_mkdir, destination_dir)
-        end
+        verify_extraction_dir mkdir, destination_dir
 
         if entry.file?
           File.open(destination, "wb") do |out|
@@ -660,6 +657,20 @@ EOM
       normalize_path(destination).start_with? normalize_path(destination_dir + "/")
 
     destination
+  end
+
+  ##
+  # Raises an exception unless +dir+, with symlinks resolved, is
+  # +destination_dir+ or a directory inside it.  +destination_dir+ must
+  # already be resolved with File.realpath by the caller.
+
+  def verify_extraction_dir(dir, destination_dir) # :nodoc:
+    real_dir = File.realpath(dir)
+
+    return if real_dir == destination_dir ||
+              normalize_path(real_dir).start_with?(normalize_path(destination_dir + "/"))
+
+    raise Gem::Package::PathError.new(real_dir, destination_dir)
   end
 
   ##

--- a/lib/rubygems/package/old.rb
+++ b/lib/rubygems/package/old.rb
@@ -79,9 +79,11 @@ class Gem::Package::Old < Gem::Package
         raise Gem::Package::FormatError, "#{full_name} in #{@gem} is corrupt" if
           file_data.length != entry["size"].to_i
 
-        FileUtils.rm_rf destination
-
         FileUtils.mkdir_p File.dirname(destination), mode: dir_mode && 0o755
+
+        verify_extraction_dir File.dirname(destination), destination_dir
+
+        FileUtils.rm_rf destination
 
         File.open destination, "wb", file_mode(entry["mode"]) do |out|
           out.write file_data

--- a/test/rubygems/test_gem_package_old.rb
+++ b/test/rubygems/test_gem_package_old.rb
@@ -44,6 +44,22 @@ unless Gem.java_platform? # jruby can't require the simple_gem file
       assert_equal mask, File.stat(extracted).mode unless Gem.win_platform?
     end
 
+    def test_extract_files_rejects_preexisting_symlink_escape
+      omit "Symlinks not supported or not enabled" unless symlink_supported?
+
+      escape_dir = File.join @tempdir, "escape"
+      FileUtils.mkdir_p escape_dir
+
+      File.symlink escape_dir, File.join(@destination, "lib")
+
+      assert_raise Gem::Package::PathError do
+        @package.extract_files @destination
+      end
+
+      assert_path_not_exist File.join(escape_dir, "foo.rb"),
+                            "must not write outside extraction root via symlink"
+    end
+
     def test_extract_files_security_policy
       pend "openssl is missing" unless Gem::HAVE_OPENSSL
 


### PR DESCRIPTION
`Gem::Package::Old#extract_files` validated entry paths only by expanding them against the destination directory, so a symlinked subdirectory that already exists under the extraction root redirected writes outside of it. `Gem::Package#extract_tar_gz` already re-resolves the parent directory with `File.realpath`, so this makes the legacy reader consistent with the modern one rather than fixing a vulnerability. Planting that symlink already requires write access to the extraction directory.

The shared check now lives in `verify_extraction_dir` and both readers call it. In the old format reader the `FileUtils.rm_rf` of the destination runs after the check, so a rejected entry cannot delete a file outside the root on its way out.
