### PR TITLE
Don't mask install errors when no Gemfile can be located

### DIFF
--- a/lib/bundler/installer/parallel_installer.rb
+++ b/lib/bundler/installer/parallel_installer.rb
@@ -255,7 +255,15 @@ module Bundler
 
     def require_tree_for_spec(spec)
       tree = @spec_set.what_required(spec)
-      t = String.new("In #{File.basename(SharedHelpers.default_gemfile)}:\n")
+      gemfile_name = begin
+        File.basename(SharedHelpers.default_gemfile)
+      rescue GemfileNotFound
+        # This runs while reporting an install error. When no Gemfile can be
+        # located (e.g. Bundler used as a library), raising here would mask
+        # the original error, so fall back to a generic header instead.
+        "Gemfile"
+      end
+      t = String.new("In #{gemfile_name}:\n")
       tree.each_with_index do |s, depth|
         t << "  " * depth.succ << s.name
         unless tree.last == s

--- a/spec/bundler/installer/parallel_installer_spec.rb
+++ b/spec/bundler/installer/parallel_installer_spec.rb
@@ -227,6 +227,26 @@ RSpec.describe Bundler::ParallelInstaller do
     end
   end
 
+  describe "require tree in error reports" do
+    # require_tree_for_spec runs while reporting an install error. When no
+    # Gemfile can be located, default_gemfile raises GemfileNotFound, which
+    # would mask the original install error entirely.
+    it "falls back to a generic header when no Gemfile can be located" do
+      parallel_installer = Bundler::ParallelInstaller.new(nil, [], 1, false, false)
+
+      spec = double("spec", name: "mygem", version: Gem::Version.new("1.0"))
+      spec_set = double("spec_set", what_required: [spec])
+      parallel_installer.instance_variable_set(:@spec_set, spec_set)
+
+      allow(Bundler::SharedHelpers).to receive(:default_gemfile).
+        and_raise(Bundler::GemfileNotFound, "Could not locate Gemfile")
+
+      tree = parallel_installer.send(:require_tree_for_spec, spec)
+      expect(tree).to start_with("In Gemfile:\n")
+      expect(tree).to include("mygem")
+    end
+  end
+
   describe "make jobserver with nmake" do
     # nmake reads MAKEFLAGS from the environment and treats its contents as
     # bare option letters, so a GNU make `--jobserver-auth` aborts the build


### PR DESCRIPTION
`ParallelInstaller#require_tree_for_spec` calls `SharedHelpers.default_gemfile` to build the `In Gemfile:` header of the install error report. When `BUNDLE_GEMFILE` is unset and no Gemfile is findable from the current directory, for example when Bundler is used as a library, this raises `GemfileNotFound` from inside the error-reporting path and the original install errors get replaced by "Could not locate Gemfile". Fall back to a generic header so the real errors always surface.
