### PR TITLE
Perform the install triggered by auto_install in a subprocess

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -187,7 +187,7 @@ module Bundler
       rescue GemNotFound, GitError
         ui.info "Automatically installing missing gems."
         reset!
-        CLI::Install.new({}).run
+        auto_install_missing_gems
         reset!
       end
     end
@@ -604,6 +604,44 @@ module Bundler
     end
 
     private
+
+    # When possible we do the install in a subprocess because to install gems
+    # we need to require some default gems like `openssl` (for HTTPS remotes)
+    # which may later conflict with the Gemfile requirements. `bundler/inline`
+    # re-resolves when that happens. We can't: the `Bundler.setup` that follows
+    # must activate what the lockfile says.
+    def auto_install_missing_gems
+      do_install = -> { CLI::Install.new({}).run }
+
+      if Process.respond_to?(:fork)
+        [$stdout, $stderr].each(&:flush) # don't let the fork inherit buffered output
+
+        _, status = Process.waitpid2(Process.fork do
+          exit_status = 1
+
+          begin
+            # Errors here never reach the parent's handler. Report them in the
+            # child, and let the parent exit with the status. Required inside the
+            # fork so the CLI's vendored Thor stays out of the parent.
+            require_relative "bundler/friendly_errors"
+
+            with_friendly_errors(&do_install)
+            exit_status = 0
+          rescue SystemExit => e
+            exit_status = e.status
+          ensure
+            # Skip `at_exit` handlers, they belong to the booting program.
+            # `exit!` doesn't flush, so flush by hand.
+            [$stdout, $stderr].each(&:flush)
+            exit!(exit_status)
+          end
+        end)
+
+        exit(status.exitstatus || status.to_i) unless status.success?
+      else
+        do_install.call
+      end
+    end
 
     def unbundle_env(env)
       if env.key?("BUNDLER_ORIG_MANPATH")

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -250,6 +250,36 @@ RSpec.describe Bundler do
     end
   end
 
+  describe "#auto_install" do
+    let(:install) { double("install") }
+
+    before do
+      skip "requires Process.fork" unless Process.respond_to?(:fork)
+
+      definition = double("definition")
+      allow(definition).to receive(:specs).and_raise(Bundler::GemNotFound)
+      allow(Bundler).to receive(:definition).and_return(definition)
+      allow(Bundler::CLI::Install).to receive(:new).with({}).and_return(install)
+    end
+
+    it "installs in a subprocess, so that gems activated to install don't conflict with the Gemfile" do
+      installer_pid = tmp("auto_install_pid")
+      allow(install).to receive(:run) { File.write(installer_pid, Process.pid) }
+
+      Bundler.settings.temporary(auto_install: true) { Bundler.auto_install }
+
+      expect(installer_pid.read.to_i).not_to eq(Process.pid)
+    end
+
+    it "exits with the status code of a failed install" do
+      allow(install).to receive(:run).and_raise(Bundler::InstallError)
+
+      expect do
+        Bundler.settings.temporary(auto_install: true) { Bundler.auto_install }
+      end.to raise_error(SystemExit) {|error| expect(error.status).to eq(5) }
+    end
+  end
+
   describe "#mkdir_p" do
     it "creates a folder at the given path" do
       install_gemfile <<-G

--- a/spec/runtime/setup_gems_spec.rb
+++ b/spec/runtime/setup_gems_spec.rb
@@ -792,6 +792,29 @@ RSpec.describe "Bundler.setup" do
     expect(out).to include("Installing myrack 1.0.0")
   end
 
+  it "performs an automatic bundle install of a default gem locked to another version" do
+    build_repo4 do
+      build_gem "psych", "999"
+      build_gem "myrack", "1.0.0"
+    end
+
+    gemfile <<-G
+      source "https://gem.repo4"
+      gem "psych"
+      gem "myrack"
+    G
+
+    bundle_config "auto_install 1"
+
+    ruby <<-RUBY, artifice: "compact_index"
+      require 'bundler/setup'
+      puts Gem.loaded_specs["psych"].version
+    RUBY
+    expect(err).to be_empty
+    expect(out).to include("Installing psych 999")
+    expect(out).to include("999")
+  end
+
   context "in a read-only filesystem" do
     before do
       gemfile <<-G


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

With `auto_install` enabled, the first `require "bundler/setup"` (or `bundle exec`) after gems go missing installs them and then fails:

```
Automatically installing missing gems.
...
Bundle complete! 2 Gemfile dependencies, 2 gems now installed.
/path/to/lib/bundler/runtime.rb:328:in 'Bundler::Runtime#check_for_activated_spec!': You have already activated openssl 3.2.0, but your Gemfile requires openssl 3.2.1. Since openssl is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports openssl as a default gem. (Gem::LoadError)
```

The install itself succeeded, so running the same command again works, which makes it look unreproducible. Both suggestions in the error message are dead ends: `openssl` is usually a transitive dependency that can't be dropped from the Gemfile, and the bundler in use is already current.

Reproduction, on a Ruby whose default `openssl` differs from the pinned version:

```bash
WORK="$(mktemp -d)"; cd "$WORK"; mkdir gems
export GEM_HOME="$WORK/gems" GEM_PATH="$WORK/gems"
unset BUNDLE_GEMFILE RUBYOPT

cat > Gemfile <<'EOF'
source "https://rubygems.org"
gem "openssl", "3.2.1"   # any released version != this Ruby's default openssl
gem "rake"               # any gem at all, it only has to be missing
EOF

bundle lock
BUNDLE_AUTO_INSTALL=true ruby -e 'require "bundler/setup"; puts "OK"'   # => Gem::LoadError
```

Only `auto_install` is affected, since it is what chains an install and a `Bundler.setup` in one process. `bundle exec <binstub>` reaches the same path; `bundle exec ruby ...` does not, because `ruby` is `Kernel.exec`ed and activation is reset.

## What is your fix for the problem, implemented in this PR?

Installing talks to the gem source over HTTPS, which requires `openssl`. `Bundler.setup` has not run at that point, so no Gemfile requirement is in effect and RubyGems activates the newest installed version, which is the default gem while the locked one is still missing. Activation is one version per process and can't be undone — `reset!` only drops Bundler's `Definition`, not RubyGems' activated specs — so the `Bundler.setup` that follows activates the lockfile's version and raises. Bundler normally avoids this class of conflict by vendoring what it needs, but `openssl` is a C extension and can't be vendored.

So run the install in a forked child, the way `bundler/inline` already does for the same reason, and keep installing in process on platforms without `fork`, also as in `bundler/inline`.

Unlike `bundler/inline`, this does not call `Gem.load_yaml` before forking: on Ruby 3.2 that requires `psych` unconditionally, activating the default `psych` in the parent, which is the very conflict this PR removes. `bundler/inline` can afford the pre-activation because it recovers by re-resolving with the activated version; here `Bundler.setup` must activate what the lockfile says. The `NameError` that call is meant to prevent did not occur, because `Bundler.setup` has already loaded the real `Psych` by the time YAML is loaded.

### Tests

`spec/bundler/bundler_spec.rb` covers the install running in a subprocess and a failed install exiting with the child's status code. `spec/runtime/setup_gems_spec.rb` covers an automatic install of a bundle that locks a default gem to another version; it uses a `psych 999` fixture rather than `openssl` because the suite stubs HTTPS, the same stand-in `spec/runtime/inline_spec.rb` already uses.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
