### PR TITLE
Fix two release Rakefile issues hit during the 4.0.18 release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -338,6 +338,7 @@ namespace "guides" do
     rubygems_dir = Dir.pwd
     env = {
       "BUNDLE_GEMFILE" => nil,
+      "BUNDLE_WITHOUT" => "site:jekyll_plugins",
       "RUBYOPT" => "--disable-gems -I#{File.join(rubygems_dir, "lib")}",
       "RUBYGEMS_DIR" => rubygems_dir,
     }

--- a/Rakefile
+++ b/Rakefile
@@ -405,8 +405,8 @@ namespace "blog" do
       if ENV["DRYRUN"]
         puts "DRYRUN mode: skipping checksum verification for #{file}"
       else
-        release_url = URI("https://rubygems.org/#{file.end_with?("gem") ? "gems" : "rubygems"}/#{basename}")
         require "net/http"
+        release_url = URI("https://rubygems.org/#{file.end_with?("gem") ? "gems" : "rubygems"}/#{basename}")
         response = Net::HTTP.get_response(release_url)
 
         if response.is_a?(Net::HTTPSuccess)


### PR DESCRIPTION
During the 4.0.18 release I hit two failures in the release Rakefile.

First, running `rake blog:publish` standalone aborts with `NoMethodError: undefined method 'URI' for main` because `blog:checksums` requires `net/http` after calling `URI()`. A full `rake release` masks this since octokit loads `net/http` earlier. Moving the require above the call fixes the standalone invocation.

Second, `guides:update` failed to `bundle install` on Ruby 4.0.6: the default-group `jekyll` pulls in `google-protobuf` via `sass-embedded`, whose precompiled variants cap `required_ruby_version` at `< 3.5.dev`, making the resolve fail. The generation tasks (`command_reference`, `spec_guide`) do not use jekyll, so this sets `BUNDLE_WITHOUT=site:jekyll_plugins`. It depends on the rubygems/guides PR moving jekyll into the `site` group, which must be merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)