### PR TITLE
Summarize cooldown-skipped versions at the end of install, update, and lock

### DIFF
--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -20,6 +20,17 @@ module Bundler
       Bundler.ui.info msg
     end
 
+    def self.output_cooldown_skipped_summary(definition = Bundler.definition)
+      skipped = definition.cooldown_skipped
+      return if skipped.empty?
+
+      Bundler.ui.info "The following gem versions were skipped by the cooldown setting:"
+      skipped.each do |entry|
+        days = entry[:available_in_days]
+        Bundler.ui.info "  * #{entry[:name]} #{entry[:version]} (available in #{days} #{days == 1 ? "day" : "days"}), resolved #{entry[:resolved]} instead"
+      end
+    end
+
     def self.output_fund_metadata_summary
       return if Bundler.settings["ignore_funding_requests"]
       definition = Bundler.definition

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -64,6 +64,7 @@ module Bundler
       end
 
       Bundler::CLI::Common.output_post_install_messages installer.post_install_messages
+      Bundler::CLI::Common.output_cooldown_skipped_summary(definition)
 
       if CLI::Common.clean_after_install?
         require_relative "clean"

--- a/lib/bundler/cli/lock.rb
+++ b/lib/bundler/cli/lock.rb
@@ -77,6 +77,8 @@ module Bundler
           puts "Writing lockfile to #{file}"
           definition.write_lock(file, false)
         end
+
+        Bundler::CLI::Common.output_cooldown_skipped_summary(definition)
       end
 
       Bundler.ui.output_stream = previous_output_stream

--- a/lib/bundler/cli/update.rb
+++ b/lib/bundler/cli/update.rb
@@ -126,6 +126,7 @@ module Bundler
       Bundler.ui.confirm "Bundle updated!"
       Bundler::CLI::Common.output_without_groups_message(:update)
       Bundler::CLI::Common.output_post_install_messages installer.post_install_messages
+      Bundler::CLI::Common.output_cooldown_skipped_summary
 
       Bundler::CLI::Common.output_fund_metadata_summary
     end

--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -372,6 +372,12 @@ module Bundler
       sources.git_sources.filter_map {|s| File.realpath(s.path) if File.exist?(s.path) }
     end
 
+    # Versions excluded by cooldown during the last resolution, one entry per
+    # gem with the newest skipped version. Empty when no resolution ran.
+    def cooldown_skipped
+      @cooldown_skipped || []
+    end
+
     def groups
       dependencies.flat_map(&:groups).uniq
     end
@@ -782,6 +788,8 @@ module Bundler
       @platforms << Bundler.local_platform if local_platform_needed_for_resolvability
 
       result = SpecSet.new(resolver.start)
+
+      @cooldown_skipped = resolver.cooldown_skipped
 
       @resolved_bundler_version = result.find {|spec| spec.name == "bundler" }&.version
 

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -500,9 +500,9 @@ module Bundler
 
     # Reports, per gem, the newest version that cooldown kept out of a
     # successful resolution. A skipped version is only worth reporting when it
-    # is newer than the version actually resolved and satisfies every
-    # requirement the final resolution places on that gem, so we don't claim a
-    # version the resolver could never have picked anyway.
+    # is newer than the resolved version and satisfies every requirement the
+    # final resolution places on that gem, so we don't claim a version the
+    # resolver could never have picked anyway.
     def cooldown_skipped_summary(spec_set)
       return [] if @cooldown_skipped_specs.empty?
 

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -14,11 +14,15 @@ module Bundler
     require_relative "resolver/root"
     require_relative "resolver/strategy"
 
+    attr_reader :cooldown_skipped
+
     def initialize(base, gem_version_promoter, most_specific_locked_platform = nil)
       @source_requirements = base.source_requirements
       @base = base
       @gem_version_promoter = gem_version_promoter
       @most_specific_locked_platform = most_specific_locked_platform
+      @cooldown_skipped = []
+      @cooldown_skipped_specs = {}
     end
 
     def start
@@ -35,6 +39,8 @@ module Bundler
     def setup_solver
       root = Resolver::Root.new(name_for_explicit_dependency_source)
       root_version = Resolver::Candidate.new(0)
+
+      @cooldown_skipped_specs = {}
 
       @all_specs = Hash.new do |specs, name|
         source = source_for(name)
@@ -83,7 +89,9 @@ module Bundler
       result = solver.solve
       resolved_specs = result.flat_map {|package, version| version.to_specs(package, @most_specific_locked_platform) }
       Override.attach(resolved_specs, @base.overrides)
-      SpecSet.new(resolved_specs).specs_with_additional_variants_from(@base.locked_specs)
+      spec_set = SpecSet.new(resolved_specs).specs_with_additional_variants_from(@base.locked_specs)
+      @cooldown_skipped = cooldown_skipped_summary(spec_set)
+      spec_set
     rescue Gem::PubGrub::SolveFailure => e
       incompatibility = e.incompatibility
 
@@ -447,6 +455,7 @@ module Bundler
       specs.each do |spec|
         next unless cooldown_excluded?(spec)
         excluded[[spec.name, spec.version]] = true
+        (@cooldown_skipped_specs ||= {})[[spec.name, spec.version]] ||= spec
       end
       excluded
     end
@@ -487,6 +496,50 @@ module Bundler
 
     def cooldown_now
       @cooldown_now ||= Time.now
+    end
+
+    # Reports, per gem, the newest version that cooldown kept out of a
+    # successful resolution. A skipped version is only worth reporting when it
+    # is newer than the version actually resolved and satisfies every
+    # requirement the final resolution places on that gem, so we don't claim a
+    # version the resolver could never have picked anyway.
+    def cooldown_skipped_summary(spec_set)
+      return [] if @cooldown_skipped_specs.empty?
+
+      requirements = Hash.new {|h, name| h[name] = [] }
+      @requirements.each {|dep| requirements[dep.name] << dep.requirement }
+      spec_set.each do |spec|
+        spec.dependencies.each {|dep| requirements[dep.name] << dep.requirement }
+      end
+
+      resolved_versions = {}
+      spec_set.each do |spec|
+        version = resolved_versions[spec.name]
+        resolved_versions[spec.name] = spec.version if version.nil? || spec.version > version
+      end
+
+      newest_skipped = {}
+      @cooldown_skipped_specs.each do |(name, version), spec|
+        resolved = resolved_versions[name]
+        next unless resolved && version > resolved
+        next unless requirements[name].all? {|req| req.satisfied_by?(version) }
+        newest = newest_skipped[name]
+        newest_skipped[name] = spec if newest.nil? || version > newest.version
+      end
+
+      newest_skipped.values.sort_by(&:name).map do |spec|
+        {
+          name: spec.name,
+          version: spec.version,
+          resolved: resolved_versions[spec.name],
+          available_in_days: remaining_cooldown_days(spec),
+        }
+      end
+    end
+
+    def remaining_cooldown_days(spec)
+      remaining = (spec.remote.effective_cooldown * 86_400) - (cooldown_now - spec.created_at)
+      [(remaining / 86_400.0).ceil, 1].max
     end
 
     def filter_remote_specs(specs, package)

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -188,6 +188,84 @@ RSpec.describe "bundle install with the cooldown setting" do
       expect(the_bundle).to include_gems("ripe_gem 2.0.0")
     end
 
+    it "summarizes skipped versions at the end of bundle install" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem"
+      G
+
+      bundle "install --cooldown 7", artifice: "compact_index_cooldown"
+
+      expect(out).to include("The following gem versions were skipped by the cooldown setting:")
+      expect(out).to include("* ripe_gem 2.0.0 (available in 6 days), resolved 1.0.0 instead")
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0")
+    end
+
+    it "summarizes skipped versions at the end of bundle update" do
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            ripe_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          ripe_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "update ripe_gem", artifice: "compact_index_cooldown"
+
+      expect(out).to include("The following gem versions were skipped by the cooldown setting:")
+      expect(out).to include("* ripe_gem 2.0.0 (available in 6 days), resolved 1.0.0 instead")
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0")
+    end
+
+    it "does not print a skip summary when cooldown is disabled" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem"
+      G
+
+      bundle "install --cooldown 0", artifice: "compact_index_cooldown"
+
+      expect(out).not_to include("skipped by the cooldown setting")
+    end
+
+    it "does not print a skip summary for versions the Gemfile requirement rejects anyway" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem", "~> 1.0"
+      G
+
+      bundle "install --cooldown 7", artifice: "compact_index_cooldown"
+
+      expect(out).not_to include("skipped by the cooldown setting")
+      expect(the_bundle).to include_gems("ripe_gem 1.0.0")
+    end
+
+    it "does not print a skip summary when installing from an up-to-date lockfile" do
+      gemfile <<-G
+        source "https://gem.repo3", cooldown: 7
+        gem "ripe_gem"
+      G
+
+      bundle "install", artifice: "compact_index_cooldown"
+      expect(out).to include("skipped by the cooldown setting")
+
+      bundle "install", artifice: "compact_index_cooldown"
+      expect(out).not_to include("skipped by the cooldown setting")
+    end
+
     it "applies cooldown declared per-source in the Gemfile" do
       gemfile <<-G
         source "https://gem.repo3", cooldown: 7


### PR DESCRIPTION
When cooldown silently resolves an older version, there is no way to tell why an environment with a different cooldown setting picked a newer one. A user reported puzzling over CI installing `rbs` 4.1.2 while their local machine, with a cooldown configured, kept getting the older release.

This collects the versions the resolver excluded and prints the newest skipped version per gem after `bundle install`, `bundle update`, and `bundle lock` finish. Only versions satisfying every requirement of the final resolution are reported, so the summary never claims a version the resolver could not have picked anyway.

```
$ bundle install --cooldown 7
...
Bundle complete! 1 Gemfile dependency, 1 gem now installed.
The following gem versions were skipped by the cooldown setting:
  * rbs 4.1.2 (available in 6 days), resolved 4.1.0 instead
```

No message is printed when nothing was skipped or when install uses an up-to-date lockfile.
