### PR TITLE
Fix release date extraction for the current changelog header format

### DIFF
--- a/spec/support/build_metadata.rb
+++ b/spec/support/build_metadata.rb
@@ -45,7 +45,7 @@ module Spec
 
     def release_date_for(version, dir:)
       changelog = File.expand_path("CHANGELOG-bundler.md", dir)
-      File.readlines(changelog)[2].scan(/^## #{Regexp.escape(version)} \((.*)\)/).first&.first if File.exist?(changelog)
+      File.readlines(changelog)[2].scan(/^## #{Regexp.escape(version)} \/ (.*)$/).first&.first if File.exist?(changelog)
     end
 
     extend self

--- a/spec/support/build_metadata.rb
+++ b/spec/support/build_metadata.rb
@@ -45,7 +45,7 @@ module Spec
 
     def release_date_for(version, dir:)
       changelog = File.expand_path("CHANGELOG-bundler.md", dir)
-      File.readlines(changelog)[2].scan(/^## #{Regexp.escape(version)} \/ (.*)$/).first&.first if File.exist?(changelog)
+      File.readlines(changelog)[2].scan(%r{^## #{Regexp.escape(version)} / (.*)$}).first&.first if File.exist?(changelog)
     end
 
     extend self

--- a/spec/support/path.rb
+++ b/spec/support/path.rb
@@ -307,7 +307,7 @@ module Spec
     def replace_changelog(version, dir:)
       changelog = File.expand_path("CHANGELOG-bundler.md", dir)
       contents = File.readlines(changelog)
-      contents = [contents[0], contents[1], "## #{version} (2100-01-01)\n", *contents[3..-1]].join
+      contents = [contents[0], contents[1], "## #{version} / 2100-01-01\n", *contents[3..-1]].join
       File.open(changelog, "w") {|f| f << contents }
     end
 

--- a/test/test_build_metadata_generator.rb
+++ b/test/test_build_metadata_generator.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "bundler"
+require_relative "../spec/support/build_metadata"
+require_relative "rubygems/helper"
+
+class BuildMetadataGeneratorTest < Test::Unit::TestCase
+  def test_release_date_for_extracts_the_date_from_the_current_changelog_header_format
+    Dir.mktmpdir do |dir|
+      write_changelog(dir, "## 9.9.9 / 2026-08-05")
+
+      assert_equal "2026-08-05", Spec::BuildMetadata.send(:release_date_for, "9.9.9", dir: dir)
+    end
+  end
+
+  def test_release_date_for_returns_nil_when_the_changelog_has_no_entry_for_the_version
+    Dir.mktmpdir do |dir|
+      write_changelog(dir, "## 1.0.0 / 2026-01-01")
+
+      assert_nil Spec::BuildMetadata.send(:release_date_for, "9.9.9", dir: dir)
+    end
+  end
+
+  private
+
+  def write_changelog(dir, header)
+    File.write(File.join(dir, "CHANGELOG-bundler.md"), <<~CHANGELOG)
+      # Changelog
+
+      #{header}
+
+      ### Enhancements:
+    CHANGELOG
+  end
+end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle version` should show the date when that Bundler version was released.
But it always shows today's date instead. This happens for every Bundler
version released after 4.0.9.

## What is your fix for the problem, implemented in this PR?

The release date comes from `CHANGELOG-bundler.md`. The old code expected
the header format `## VERSION (DATE)`. But the changelog has used
`## VERSION / DATE` since version 4.0.9. So the old regex never matched,
and the release date was always empty. As a fallback, Bundler used today's
date instead.

This PR fixes the regex to match the current header format. It also adds
a test for this case.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write tests for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the current code style and write meaningful commit messages without tags