### PR TITLE
Document why rubygems.rb requires BUNDLER_SETUP at the end

### DIFF
--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1471,4 +1471,9 @@ else
 end
 eval File.read(path), nil, file
 
+# bundler/setup has to run before error_highlight, did_you_mean and
+# syntax_suggest are loaded, so that the Gemfile controls their versions
+# ([Bug #19089]). Ruby 4.1 autoloads them ([Feature #21951]) and deletes this
+# variable while loading RubyGems, so this can go once 4.1 is the oldest
+# supported version.
 require ENV["BUNDLER_SETUP"] if ENV["BUNDLER_SETUP"] && !defined?(Bundler)


### PR DESCRIPTION
The `require ENV["BUNDLER_SETUP"]` at the bottom of `lib/rubygems.rb` carries no explanation, so it looks removable. It makes `bundler/setup` run before `error_highlight`, `did_you_mean` and `syntax_suggest` load, which is what lets the Gemfile pin their versions ([Bug #19089]).

Ruby 4.1 autoloads those three ([Feature #21951]) and unsets `BUNDLER_SETUP` while loading RubyGems, so the line is dead there. It is still live on 3.2 through 4.0, which `required_ruby_version` still supports. Dropping it on 3.4 reproduces `You have already activated error_highlight 0.7.2, but your Gemfile requires 0.7.0`. The comment records the condition for removing it later.

Comment only, no behavior change.
