### PR TITLE
Restrict UserDefined handling to explicit class set for Gem::SafeMashal.

### DIFF
--- a/lib/rubygems/safe_marshal/visitors/to_ruby.rb
+++ b/lib/rubygems/safe_marshal/visitors/to_ruby.rb
@@ -183,8 +183,15 @@ module Gem::SafeMarshal
         @symbols.fetch(o.offset)
       end
 
+      SAFE_USER_DEFINED_CLASSES = [::Time, ::Gem::Specification].freeze
+      private_constant :SAFE_USER_DEFINED_CLASSES
+
       def visit_Gem_SafeMarshal_Elements_UserDefined(o)
-        register_object(call_method(resolve_class(o.name), :_load, o.binary_string))
+        klass = resolve_class(o.name)
+        unless SAFE_USER_DEFINED_CLASSES.include?(klass)
+          raise UnsupportedError.new("Unsupported user-defined class #{klass} in marshal stream", stack: formatted_stack)
+        end
+        register_object(call_method(klass, :_load, o.binary_string))
       end
 
       def visit_Gem_SafeMarshal_Elements_UserMarshal(o)

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -461,6 +461,16 @@ class TestGemSafeMarshal < Gem::TestCase
     end
   end
 
+  def test_date_user_defined_rejected
+    # Provide string as the inner payload, Date._load passes it raw to rb_marshal_load.
+    inner = Marshal.dump("exploit")
+    payload = "\x04\bu:\tDate" + (inner.bytesize + 5).chr + inner
+    e = assert_raise(Gem::SafeMarshal::Visitors::ToRuby::UnsupportedError) do
+      Gem::SafeMarshal.safe_load(payload)
+    end
+    assert_equal "Unsupported user-defined class Date in marshal stream @ root", e.message
+  end
+
   def assert_safe_load_marshal(dumped, additional_methods: [], permitted_ivars: nil, equality: true, marshal_dump_equality: true,
     inspect: true, to_s: true)
     loaded = Marshal.load(dumped)


### PR DESCRIPTION
<!--
Thanks so much for the contribution!

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

A crafted payload using the UserDefined (u:) format for a permitted class such as Date, which normally serializes as UserMarshal (U:), can result in Date._load to invoke rb_marshal_load on attacker-controlled bytes, bypassing SafeMarshal's allowlists.

HackerOne report 3915697, triaged as hardening.

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

```
require 'rubygems/safe_marshal'
inner = Marshal.dump("exploit") # any inner payload — Date._load passes raw bytes to rb_marshal_load
payload = "\x04\bu:\tDate" + (inner.bytesize + 5).chr + inner #=> "\u0004\bu:\tDate\u0016\u0004\bI\"\fexploit\u0006:\u0006ET"
Gem::SafeMarshal.safe_load(payload)
/usr/share/rubygems/rubygems/safe_marshal/visitors/to_ruby.rb:358:in 'Date._load': expected an array (TypeError)

        receiver.__send__(method, *args)
                          ^^^^^^^^^^^^^
	from /usr/share/rubygems/rubygems/safe_marshal/visitors/to_ruby.rb:358:in 'Gem::SafeMarshal::Visitors::ToRuby#call_method'
	from /usr/share/rubygems/rubygems/safe_marshal/visitors/to_ruby.rb:187:in 'Gem::SafeMarshal::Visitors::ToRuby#visit_Gem_SafeMarshal_Elements_UserDefined'
	from /usr/share/rubygems/rubygems/safe_marshal/visitors/visitor.rb:6:in 'Gem::SafeMarshal::Visitors::Visitor#visit'
	from /usr/share/rubygems/rubygems/safe_marshal/visitors/to_ruby.rb:28:in 'Gem::SafeMarshal::Visitors::ToRuby#visit'
	from /usr/share/rubygems/rubygems/safe_marshal.rb:71:in 'Gem::SafeMarshal.load'
	from /usr/share/rubygems/rubygems/safe_marshal.rb:61:in 'Gem::SafeMarshal.safe_load'
	from (irb):5:in '<main>'
	from /usr/share/gems/gems/irb-1.16.0/exe/irb:9:in '<top (required)>'
	from /usr/share/rubygems/rubygems.rb:305:in 'Kernel#load'
	from /usr/share/rubygems/rubygems.rb:305:in 'Gem.activate_and_load_bin_path'
	from /usr/sbin/irb:25:in '<main>'
```
`TypeError` is raised , instead of a `Gem::SafeMarshal` exception, raw object was passed into `Date._load` method which can is hardened against in this PR.

With this PR, an `Gem::SafeMarshal::Visitors::ToRuby::UnsupportedError` is raised instead, explaining `Date` is not on the allowlist of classes that can use UserDefined `u` marshal tag:
```
irb(main):001> require 'rubygems/safe_marshal'
irb(main):002> inner = Marshal.dump("exploit") # any inner payload, Date._load passes raw bytes to rb_marshal_load
irb(main):003> payload = "\x04\bu:\tDate" + (inner.bytesize + 5).chr + inner
=> "\u0004\bu:\tDate\u0016\u0004\bI\"\fexploit\u0006:\u0006ET"
irb(main):004> Gem::SafeMarshal.safe_load(payload)
/usr/share/rubygems/rubygems/safe_marshal/visitors/to_ruby.rb:192:in 'Gem::SafeMarshal::Visitors::ToRuby#visit_Gem_SafeMarshal_Elements_UserDefined': Unsupported user-defined class Date in marshal stream @ root (Gem::SafeMarshal::Visitors::ToRuby::UnsupportedError)
	from /usr/share/rubygems/rubygems/safe_marshal/visitors/visitor.rb:6:in 'Gem::SafeMarshal::Visitors::Visitor#visit'
	from /usr/share/rubygems/rubygems/safe_marshal/visitors/to_ruby.rb:28:in 'Gem::SafeMarshal::Visitors::ToRuby#visit'
	from /usr/share/rubygems/rubygems/safe_marshal.rb:72:in 'Gem::SafeMarshal.load'
	from /usr/share/rubygems/rubygems/safe_marshal.rb:62:in 'Gem::SafeMarshal.safe_load'
	from (irb):5:in '<main>'
	from /usr/share/gems/gems/irb-1.16.0/exe/irb:9:in '<top (required)>'
	from /usr/share/rubygems/rubygems.rb:306:in 'Kernel#load'
	from /usr/share/rubygems/rubygems.rb:306:in 'Gem.activate_and_load_bin_path'
	from /usr/sbin/irb:25:in '<main>'
```

`Date` objects can still be correctly unmarshalled via the `U` tag

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
