### PR TITLE
Report permission errors from bundle clean

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -304,7 +304,9 @@ module Bundler
         Bundler.ui.info "Would have removed #{output}"
       else
         Bundler.ui.info "Removing #{output}"
-        FileUtils.rm_rf(dir)
+        SharedHelpers.filesystem_access(dir) do |path|
+          FileUtils.rm_r(path)
+        end
       end
 
       output

--- a/spec/commands/clean_spec.rb
+++ b/spec/commands/clean_spec.rb
@@ -46,6 +46,38 @@ RSpec.describe "bundle clean" do
     expect(vendored_gems("bin/myrackup")).to exist
   end
 
+  it "reports an error when an unused gem directory cannot be removed", :permissions do
+    gemfile <<-G
+      source "https://gem.repo1"
+
+      gem "foo"
+      gem "myrack"
+    G
+
+    bundle_config "path vendor/bundle"
+    bundle_config "clean false"
+    bundle "install"
+
+    gemfile <<-G
+      source "https://gem.repo1"
+
+      gem "myrack"
+    G
+    bundle "install"
+
+    stale_gem_path = vendored_gems("gems/foo-1.0")
+    FileUtils.chmod(0o500, stale_gem_path)
+
+    bundle :clean, raise_on_error: false
+
+    expect(exitstatus).to eq(23)
+    expect(err).to include(stale_gem_path.to_s)
+    expect(err).to include("grant write permissions")
+    expect(stale_gem_path).to exist
+  ensure
+    FileUtils.chmod(0o755, stale_gem_path) if stale_gem_path&.exist?
+  end
+
   it "removes unused gems when the bundle path contains glob metacharacters" do
     gemfile <<-G
       source "https://gem.repo1"


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

`bundle clean` reports that it removed an unused gem and exits successfully even when filesystem permissions prevent the directory from being deleted. `FileUtils.rm_rf` deliberately suppresses those removal errors, leaving users with stale files and no indication that cleanup failed.

Fixes #9396.

## What is your fix for the problem, implemented in this PR?

Use the existing `SharedHelpers.filesystem_access` error translation around `FileUtils.rm_r`. The raising removal preserves recursive cleanup on success, while Bundler now reports permission failures with the affected path and exits with its permission-error status instead of silently succeeding.

The integration regression makes an unused installed gem directory non-writable, runs `bundle clean`, and verifies exit status 23, the actionable permission message/path, and that the directory remains. The same example exits 0 against the old implementation and passes with this change.

## Verification

- `bin/rspec spec/commands/clean_spec.rb:49` — 1 example, 0 failures (and confirmed red against the old implementation)
- `bin/rspec spec/commands/clean_spec.rb` — 36 examples, 0 failures, 1 existing pending example
- `bin/rubocop lib/bundler/runtime.rb spec/commands/clean_spec.rb` — no offenses
- `git diff --check` — passed

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write tests for the bug fix
- [x] Write code to solve the problem
- [x] Follow the current code style and use a meaningful commit message without tags

AI disclosure: I used an AI coding assistant to help inspect the removal/error-handling path, implement the focused fix and regression test, and run the checks above. I reviewed the final diff and red/green evidence before submitting.
