### PR TITLE
Filter git command output against the configured URI

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -364,9 +364,10 @@ module Bundler
           git("rev-parse", "--verify", reference, dir: path).strip
         end
 
-        # Adds credentials to the URI
+        # Adds credentials to the URI. This is the URI given to git, so it's
+        # also the one command output must be filtered against.
         def configured_uri
-          if /https?:/.match?(uri)
+          @configured_uri ||= if /https?:/.match?(uri)
             remote = Gem::URI(uri)
             config_auth = Bundler.settings[remote.to_s] || Bundler.settings[remote.host]
             remote.userinfo ||= config_auth
@@ -409,7 +410,7 @@ module Bundler
           raise GitNotInstalledError.new unless Bundler.git_present?
 
           require "shellwords"
-          URICredentialsFilter.credential_filtered_string("git #{command.shelljoin}", uri)
+          URICredentialsFilter.credential_filtered_string("git #{command.shelljoin}", configured_uri)
         end
 
         def run_command(*command, dir: nil)
@@ -429,10 +430,10 @@ module Bundler
             require "open3"
             out, err, status = Open3.capture3(*capture3_args_for(cmd, dir))
 
-            filtered_out = URICredentialsFilter.credential_filtered_string(out, uri)
+            filtered_out = URICredentialsFilter.credential_filtered_string(out, configured_uri)
             return [filtered_out, status] if ignore_err
 
-            filtered_err = URICredentialsFilter.credential_filtered_string(err, uri)
+            filtered_err = URICredentialsFilter.credential_filtered_string(err, configured_uri)
             [filtered_out, filtered_err, status]
           end
         end

--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -98,6 +98,68 @@ RSpec.describe Bundler::Source::Git::GitProxy do
     end
   end
 
+  describe "filtering credentials out of command output" do
+    let(:secret) { "s3cr3tp4ss" }
+    let(:credentialed_uri) { "https://user:#{secret}@github.com/ruby/rubygems.git" }
+    let(:redacted_uri) { "https://user@github.com/ruby/rubygems.git" }
+
+    before do
+      allow(Open3).to receive(:capture3).and_return(["", "fatal: repository '#{credentialed_uri}' not found", fail_result])
+      allow(Open3).to receive(:capture3).with("git", "--version").and_return(["git version 2.14.0", "", clone_result])
+    end
+
+    it "redacts credentials configured for the host from failed commands" do
+      Bundler.settings.temporary("github.com" => "user:#{secret}") do
+        expect { git_proxy.checkout }.to raise_error(Bundler::Source::Git::GitCommandError) do |error|
+          expect(error.message).not_to include(secret)
+          expect(error.message).to include(redacted_uri)
+        end
+      end
+    end
+
+    it "redacts credentials configured for the full URI from failed commands" do
+      Bundler.settings.temporary(uri => "user:#{secret}") do
+        expect { git_proxy.checkout }.to raise_error(Bundler::Source::Git::GitCommandError) do |error|
+          expect(error.message).not_to include(secret)
+          expect(error.message).to include(redacted_uri)
+        end
+      end
+    end
+
+    it "redacts configured credentials from stdout and stderr" do
+      Bundler.settings.temporary("github.com" => "user:#{secret}") do
+        allow(Open3).to receive(:capture3).and_return(["cloning #{credentialed_uri}", "error: #{credentialed_uri}", fail_result])
+
+        out, err, = git_proxy.send(:capture, ["fetch"], nil)
+
+        expect(out).to eq("cloning #{redacted_uri}")
+        expect(err).to eq("error: #{redacted_uri}")
+      end
+    end
+
+    context "when the URI itself embeds credentials" do
+      let(:uri) { credentialed_uri }
+
+      it "redacts them from failed commands" do
+        expect { git_proxy.checkout }.to raise_error(Bundler::Source::Git::GitCommandError) do |error|
+          expect(error.message).not_to include(secret)
+          expect(error.message).to include(redacted_uri)
+        end
+      end
+    end
+
+    context "when no credentials are involved" do
+      it "leaves output untouched" do
+        allow(Open3).to receive(:capture3).and_return(["cloning #{uri}", "error: #{uri}", fail_result])
+
+        out, err, = git_proxy.send(:capture, ["fetch"], nil)
+
+        expect(out).to eq("cloning #{uri}")
+        expect(err).to eq("error: #{uri}")
+      end
+    end
+  end
+
   describe "#copy_to" do
     let(:revision) { "abc123" }
     let(:destination) { tmp("git-proxy-copy") }


### PR DESCRIPTION
Credentials configured through `bundle config` are injected into the remote URI only inside `configured_uri`, but `GitProxy` filtered command strings and git output against the original `uri`. `URICredentialsFilter.credential_filtered_string` replaces nothing when the reference URI carries no credentials, so the filter was a no-op on that path and the credentials stayed in `GitCommandError` messages and in the stdout and stderr Bundler prints when a clone or fetch fails. Credentials written directly into a Gemfile URL were unaffected because the original `uri` carries them.

Both filters now use `configured_uri`, which is the URI git receives, and `configured_uri` is memoized because it is consulted on every git invocation. Non-HTTP(S) remotes keep their current behavior since that branch returns `uri.to_s` unchanged.
