### PR TITLE
Validate the platform field in Gem::Installer#verify_spec

### DIFF
--- a/lib/rubygems/installer.rb
+++ b/lib/rubygems/installer.rb
@@ -697,7 +697,7 @@ class Gem::Installer
       raise Gem::InstallError, "#{spec} has an invalid extensions"
     end
 
-    if /\R/.match?(spec.platform.to_s)
+    unless /\A[\w.-]+\z/.match?(spec.platform.to_s)
       raise Gem::InstallError, "#{spec.platform} is an invalid platform"
     end
 

--- a/test/rubygems/test_gem_installer.rb
+++ b/test/rubygems/test_gem_installer.rb
@@ -2057,6 +2057,62 @@ class TestGemInstaller < Gem::InstallerTestCase
     end
   end
 
+  # Psych assigns @cpu/@os/@version directly, so a platform coming from gem
+  # metadata never goes through Gem::Platform#initialize.
+  def test_pre_install_checks_traversal_platform_from_array
+    spec = util_spec "a", "1"
+    def spec.validate(*args); end
+    spec.platform = Gem::Platform.new([nil, "../../../../tmp/X", nil])
+
+    installer = Gem::Installer.for_spec spec
+    installer.gem_home = @gemhome
+
+    use_ui @ui do
+      e = assert_raise Gem::InstallError do
+        installer.pre_install_checks
+      end
+      assert_equal "../../../../tmp/X is an invalid platform", e.message
+    end
+  end
+
+  # Gem::Platform#initialize normalizes the os but keeps the cpu verbatim.
+  def test_pre_install_checks_traversal_platform_from_string
+    spec = util_spec "a", "1"
+    def spec.validate(*args); end
+    spec.platform = Gem::Platform.new("../../../../tmp/X-linux")
+
+    installer = Gem::Installer.for_spec spec
+    installer.gem_home = @gemhome
+
+    use_ui @ui do
+      e = assert_raise Gem::InstallError do
+        installer.pre_install_checks
+      end
+      assert_equal "../../../../tmp/X-linux is an invalid platform", e.message
+    end
+  end
+
+  def test_pre_install_checks_accepts_real_platforms
+    %w[x86_64-linux arm64-darwin-23 x64-mingw-ucrt java ruby].each do |platform|
+      spec = util_spec "a", "1" do |s|
+        s.platform = platform
+      end
+
+      util_build_gem spec
+
+      installer = Gem::Installer.at spec.cache_file,
+                                    install_dir: @gemhome,
+                                    user_install: false,
+                                    force: true
+
+      use_ui @ui do
+        assert_equal spec, installer.install, platform
+      end
+
+      assert_path_exist File.join(@gemhome, "gems", spec.full_name), platform
+    end
+  end
+
   def test_shebang
     load_relative "no" do
       installer = setup_base_installer


### PR DESCRIPTION
`Gem::Specification#full_name` interpolates `spec.platform.to_s` directly, and `Gem::Installer` builds `gem_dir` and `extension_dir` from that name before passing both to `FileUtils.rm_rf` and extracting into them. A platform carrying path separators resolves outside the gems directory.

Nothing upstream of `verify_spec` normalizes it. `Gem::Platform` is in `PERMITTED_CLASSES` without `init_with` or `yaml_initialize`, so Psych assigns `@cpu`, `@os`, and `@version` straight from gem metadata without ever running `Gem::Platform#initialize`. The `String` branch of that initializer is no backstop either, because it normalizes the os against a fixed vocabulary but keeps the cpu verbatim.

So this replaces the newline-only check with the allowed-character pattern `verify_spec` already applies to the gem name. Every platform string in `test/rubygems/test_gem_platform.rb` passes it.
