### PR TITLE
Fix auto-clean default version in bundle config docs

### DIFF
--- a/lib/bundler/man/bundle-config.1
+++ b/lib/bundler/man/bundle-config.1
@@ -82,7 +82,7 @@ The following is a list of all configuration keys and their purpose\. You can le
 .IP "\(bu" 4
 \fBcache_path\fR (\fBBUNDLE_CACHE_PATH\fR): The directory that bundler will place cached gems in when running \fBbundle package\fR, and that bundler will look in when installing gems\. Defaults to \fBvendor/cache\fR\.
 .IP "\(bu" 4
-\fBclean\fR (\fBBUNDLE_CLEAN\fR): Whether Bundler should run \fBbundle clean\fR automatically after \fBbundle install\fR\. Defaults to \fBtrue\fR in Bundler 4, as long as \fBpath\fR is not explicitly configured\.
+\fBclean\fR (\fBBUNDLE_CLEAN\fR): Whether Bundler should run \fBbundle clean\fR automatically after \fBbundle install\fR\. Defaults to \fBtrue\fR in Bundler 5, as long as \fBpath\fR is not explicitly configured\.
 .IP "\(bu" 4
 \fBconsole\fR (\fBBUNDLE_CONSOLE\fR): The console that \fBbundle console\fR starts\. Defaults to \fBirb\fR\.
 .IP "\(bu" 4

--- a/lib/bundler/man/bundle-config.1.ronn
+++ b/lib/bundler/man/bundle-config.1.ronn
@@ -133,7 +133,7 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Defaults to `vendor/cache`.
 * `clean` (`BUNDLE_CLEAN`):
    Whether Bundler should run `bundle clean` automatically after
-   `bundle install`. Defaults to `true` in Bundler 4, as long as `path` is not
+   `bundle install`. Defaults to `true` in Bundler 5, as long as `path` is not
    explicitly configured.
 * `console` (`BUNDLE_CONSOLE`):
    The console that `bundle console` starts. Defaults to `irb`.


### PR DESCRIPTION
The `clean` (`BUNDLE_CLEAN`) entry in `bundle-config.1.ronn` says auto-clean defaults to `true` in Bundler 4, but that default was deferred to Bundler 5 in c314d7b25156657c47e7aace95772c2c56ea189e and `clean_after_install?` checks `bundler_5_mode?`. This updates the man page to say Bundler 5.
