### PR TITLE
Fix wrong $LOAD_PATH for gems installed in the same process

### DIFF
--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -50,6 +50,19 @@ module Bundler
       end
     end
 
+    # `require_paths` is overridden above, but `full_require_paths` (and so
+    # `load_paths`) is computed from `raw_require_paths`, which would otherwise
+    # report the default `lib` for every gem
+    def raw_require_paths
+      if @remote_specification
+        @remote_specification.raw_require_paths
+      elsif _local_specification
+        _local_specification.raw_require_paths
+      else
+        super
+      end
+    end
+
     # needed for inline
     def load_paths
       # remote specs aren't installed, and can't have load_paths

--- a/lib/bundler/installer.rb
+++ b/lib/bundler/installer.rb
@@ -83,6 +83,12 @@ module Bundler
         install(options)
 
         Gem::Specification.reset # invalidate gem specification cache so that installed gems are immediately available
+        # Drop the source caches too, since releasing resolution memory dropped
+        # the source indexes. A resolution happening after this point would
+        # otherwise rebuild them around a snapshot of installed gems taken
+        # before the install, and materialize against remote specs that don't
+        # know where the gems they stand for ended up.
+        @definition.sources.clear_cache
 
         lock
         Standalone.new(options[:standalone], @definition).generate if options[:standalone]

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -706,6 +706,38 @@ RSpec.describe "bundler/inline#gemfile" do
     expect(err).to be_empty
   end
 
+  it "sets up custom require paths for gems installed in the same process" do
+    build_repo4 do
+      build_gem "securerandom", "999"
+
+      build_gem "unusual_paths", "1.0.0", no_default: true do |s|
+        s.require_paths = ["lib/unusual_paths"]
+        s.write "lib/unusual_paths/unusual_paths.rb", "UNUSUAL_PATHS = '1.0.0'"
+      end
+    end
+
+    script <<-RUBY, env: { "BUNDLER_SPEC_GEM_REPO" => gem_repo4.to_s }
+      # Simulate a platform where installing in a subprocess is not possible, so
+      # that the conflicting default gem forces a re-resolution in this process,
+      # after the gems have been installed.
+      class << Process
+        undef_method :fork
+      end
+
+      gemfile(true) do
+        source "https://gem.repo4"
+        gem "securerandom"
+        gem "unusual_paths"
+      end
+
+      puts UNUSUAL_PATHS
+    RUBY
+
+    expect(out).to include("Installing unusual_paths 1.0.0")
+    expect(out).to include("1.0.0")
+    expect(err).to be_empty
+  end
+
   it "installs a conflicting default gem alongside git sources" do
     build_repo4 do
       build_gem "securerandom", "999"

--- a/spec/runtime/inline_spec.rb
+++ b/spec/runtime/inline_spec.rb
@@ -712,7 +712,7 @@ RSpec.describe "bundler/inline#gemfile" do
 
       build_gem "unusual_paths", "1.0.0", no_default: true do |s|
         s.require_paths = ["lib/unusual_paths"]
-        s.write "lib/unusual_paths/unusual_paths.rb", "UNUSUAL_PATHS = '1.0.0'"
+        s.write "lib/unusual_paths/unusual_paths.rb", "UNUSUAL_PATHS = 'loaded'"
       end
     end
 
@@ -734,7 +734,7 @@ RSpec.describe "bundler/inline#gemfile" do
     RUBY
 
     expect(out).to include("Installing unusual_paths 1.0.0")
-    expect(out).to include("1.0.0")
+    expect(out).to include("loaded")
     expect(err).to be_empty
   end
 


### PR DESCRIPTION
`bundler/inline` builds a wrong `$LOAD_PATH` for gems it installs in the same process, so any gem whose `require_paths` is not the default `lib`, like `concurrent-ruby`, becomes unloadable. First run of a script fails while the second run succeeds, which hits hardest in CI where the gem home starts empty.

Two defects combine to cause this. `EndpointSpecification` overrides `require_paths` but not `raw_require_paths`, and `load_paths` reads the latter through `full_require_paths`, so it reported `<gem>/lib` for every gem. And since the source indexes are released before installing, a resolution after the install rebuilds them around a pre-install snapshot of installed gems and materializes against pristine remote specs that don't know where the gems ended up. Each fix alone is not sufficient. The new spec fails with either one reverted.

Fixes #9781.
