### PR TITLE
Use `delete_prefix` to strip the `subjectAltName` email tag

### DIFF
--- a/lib/rubygems/security/signer.rb
+++ b/lib/rubygems/security/signer.rb
@@ -109,9 +109,7 @@ class Gem::Security::Signer
     subject_alt_name = cert.extensions.find {|e| e.oid == "subjectAltName" }
 
     if subject_alt_name
-      /\Aemail:/ =~ subject_alt_name.value # rubocop:disable Performance/StartWith
-
-      $' || subject_alt_name.value
+      subject_alt_name.value.delete_prefix("email:")
     else
       cert.subject
     end


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

- Simplifying the code is good?

## What is your fix for the problem, implemented in this PR?

- `Gem::Security::Signer#extract_name` matched `/\Aemail:/` then read the non-matching part of the string out of `$'`.

- Prefer `delete_prefix("email:")` as it's understandable by mortals.

- Consequently get rid of a RuboCop disable for `Performance/StartWith`.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#tests) for features and bug fixes
  - There's a pre-existing test for this code that still passes with these changes.
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
