### PR TITLE
Honor NO_PROXY="*" in Gem::Request::ConnectionPools

### DIFF
--- a/lib/rubygems/request/connection_pools.rb
+++ b/lib/rubygems/request/connection_pools.rb
@@ -50,6 +50,9 @@ class Gem::Request::ConnectionPools # :nodoc:
   end
 
   def no_proxy?(host, env_no_proxy)
+    # A lone "*" entry bypasses the proxy for every host
+    return true if env_no_proxy.include?("*")
+
     host = host.downcase
 
     env_no_proxy.any? do |pattern|

--- a/test/rubygems/test_gem_request_connection_pools.rb
+++ b/test/rubygems/test_gem_request_connection_pools.rb
@@ -96,6 +96,14 @@ class TestGemRequestConnectionPool < Gem::TestCase
     refute no_proxy, "wildcard mismatch"
   end
 
+  def test_to_proxy_star
+    pools = Gem::Request::ConnectionPools.new nil, []
+
+    no_proxy = pools.send :no_proxy?, "rubygems.example", ["*"]
+
+    assert no_proxy, "asterisk matches every host"
+  end
+
   def test_net_http_args
     pools = Gem::Request::ConnectionPools.new nil, []
 
@@ -123,6 +131,19 @@ class TestGemRequestConnectionPool < Gem::TestCase
   def test_net_http_args_no_proxy
     orig_no_proxy = ENV["no_proxy"]
     ENV["no_proxy"] = "example"
+
+    pools = Gem::Request::ConnectionPools.new nil, []
+
+    net_http_args = pools.send :net_http_args, Gem::URI("http://example"), @proxy
+
+    assert_equal ["example", 80, nil, nil], net_http_args
+  ensure
+    ENV["no_proxy"] = orig_no_proxy
+  end
+
+  def test_net_http_args_no_proxy_star
+    orig_no_proxy = ENV["no_proxy"]
+    ENV["no_proxy"] = "*"
 
     pools = Gem::Request::ConnectionPools.new nil, []
 


### PR DESCRIPTION
Setting `NO_PROXY=*` conventionally bypasses the proxy for every host. curl and net-http-persistent both honor it, and Bundler's fetcher honors it as well, but `Gem::Request::ConnectionPools#no_proxy?` never matched a `*` entry, so `gem` commands kept sending requests through the configured proxy. This treats a `*` entry as matching every host, so connections are built without proxy arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
