### PR TITLE
Preserve native extensions during implicit clean

### DIFF
--- a/lib/bundler/stub_specification.rb
+++ b/lib/bundler/stub_specification.rb
@@ -126,7 +126,9 @@ module Bundler
     def _remote_specification
       @_remote_specification ||= begin
         rs = stub.to_spec
-        if rs.equal?(self) # happens when to_spec gets the spec from Gem.loaded_specs
+        # Gem::StubSpecification#to_spec may return an activated specification
+        # with the same name and version from a different gem installation.
+        if rs.equal?(self) || rs.loaded_from != loaded_from
           rs = Gem::Specification.load(loaded_from)
           Bundler.rubygems.stub_set_spec(stub, rs)
         end

--- a/spec/commands/install_spec.rb
+++ b/spec/commands/install_spec.rb
@@ -2062,6 +2062,37 @@ RSpec.describe "bundle install with gem sources" do
     expect(Dir.glob(vendored_gems("bin/*"))).to eq(expected_executables)
   end
 
+  it "preserves bundled native extensions when BUNDLE_CLEAN removes another gem" do
+    build_repo4 do
+      build_gem "native_child", "1.0", &:add_c_extension
+      build_gem "native_parent", "1.0" do |s|
+        s.add_dependency "native_child", "1.0"
+      end
+      build_gem "cleanup_target", "1.0"
+      build_gem "cleanup_target", "2.0"
+    end
+
+    system_gems %w[native_child-1.0 native_parent-1.0 cleanup_target-1.0], gem_repo: gem_repo4
+
+    install_gemfile <<~G, env: { "BUNDLE_CLEAN" => "false", "BUNDLE_PATH" => "vendor/bundle" }
+      source "https://gem.repo4"
+      gem "native_parent"
+      gem "cleanup_target", "1.0"
+    G
+
+    extension_dir = Pathname.glob("#{vendored_gems}/extensions/*/*/native_child-1.0").first
+    expect(extension_dir).to exist
+
+    install_gemfile <<~G, env: { "BUNDLE_CLEAN" => "true", "BUNDLE_PATH" => "vendor/bundle", "RUBYOPT" => "-rnative_child" }
+      source "https://gem.repo4"
+      gem "native_parent"
+      gem "cleanup_target", "2.0"
+    G
+
+    expect(out).to include("Removing cleanup_target (1.0)")
+    expect(extension_dir).to exist
+  end
+
   it "preserves lockfile versions conservatively" do
     build_repo4 do
       build_gem "mypsych", "4.0.6" do |s|


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Fixes #9795.

When a native gem is already activated from the system gem path, an implicit
clean after `bundle install` can use that system installation's extension path
for the project-local stub. It then treats the still-required extension under
`BUNDLE_PATH` as stale and removes it silently.

## What is your fix for the problem, implemented in this PR?

Reload a stub's own gemspec when `Gem::StubSpecification#to_spec` returns an
activated specification from a different installation. This keeps the local
specification and extension paths together when implicit clean computes its
stale directories.

The regression test activates the system copy of a native gem, installs the
same version into `BUNDLE_PATH`, and changes an unrelated locked gem while
`BUNDLE_CLEAN=true`. It verifies that cleanup removes the obsolete gem but
preserves the required local native extension.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)

## Testing

- `bin/rspec spec/commands/install_spec.rb:2065`
- `bin/rspec spec/bundler/stub_specification_spec.rb spec/commands/install_spec.rb`
- `bin/rake rubocop`
- `PATH="/tmp/oss-rspec-bin:$PATH" bin/rake spec:all` (3 existing non-TTY color expectation failures; the same examples fail on the recorded upstream commit)