### PR TITLE
Address remaining cooldown review follow-ups

### DIFF
--- a/lib/bundler/cli/common.rb
+++ b/lib/bundler/cli/common.rb
@@ -3,9 +3,25 @@
 module Bundler
   module CLI::Common
     def self.validate_cooldown!(value)
-      return if value.nil?
+      # Without the flag the config file and BUNDLE_COOLDOWN decide, and those
+      # only warn, so a typo left in a config file keeps the command usable.
+      return warn_invalid_cooldown_setting if value.nil?
       return if value.is_a?(Integer) && value >= 0
       raise InvalidOption, "Expected `--cooldown` to be a non-negative integer, got #{value.inspect}"
+    end
+
+    # A cooldown value that cannot be read as a non-negative integer disables
+    # the cooldown for every source, overriding any per-source `cooldown:` in
+    # the Gemfile, so say so rather than letting the protection lapse quietly.
+    def self.warn_invalid_cooldown_setting
+      value = Bundler.settings.locations(:cooldown).values.first
+      return if value.nil?
+
+      days = Integer(value.to_s, exception: false)
+      return if days && !days.negative?
+
+      Bundler.ui.warn "Invalid cooldown value #{value.inspect}, so the cooldown is disabled for all sources. " \
+                      "Expected a non-negative integer number of days."
     end
 
     def self.output_post_install_messages(messages)

--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -155,10 +155,11 @@ module Bundler
     end
 
     def parse_metadata(data)
+      @created_at = nil
+
       unless data
         @required_ruby_version = nil
         @required_rubygems_version = nil
-        @created_at = nil
         return
       end
 
@@ -181,18 +182,29 @@ module Bundler
         when "ruby"
           @required_ruby_version = Gem::Requirement.new(v)
         when "created_at"
-          value = v.is_a?(Array) ? v.last : v
-          if value.is_a?(String)
-            @created_at = begin
-              Time.new(value)
-            rescue ArgumentError
-              nil
-            end
-          end
+          @created_at = parse_created_at(v.is_a?(Array) ? v.last : v)&.freeze
         end
       end
     rescue StandardError => e
       raise GemspecError, "There was an error parsing the metadata for the gem #{name} (#{version}): #{e.class}\n#{e}\nThe metadata was #{data.inspect}"
+    end
+
+    # Matches an ISO 8601 time zone designator at the end of a timestamp.
+    TIME_ZONE_SUFFIX = /(?:Z|z|[+-]\d{2}(?::?\d{2})?)\z/
+    private_constant :TIME_ZONE_SUFFIX
+
+    # A timestamp without a time zone offset is read as UTC, because reading
+    # it as local time would shift the cooldown window by the environment's
+    # offset. Unparsable values become nil so the cooldown fails open.
+    def parse_created_at(value)
+      return unless value.is_a?(String)
+
+      require "time"
+      begin
+        Time.iso8601(value.match?(TIME_ZONE_SUFFIX) ? value : "#{value}Z")
+      rescue ArgumentError
+        nil
+      end
     end
 
     def build_dependency(name, requirements)

--- a/lib/bundler/man/bundle-config.1
+++ b/lib/bundler/man/bundle-config.1
@@ -99,6 +99,8 @@ The per\-source \fBcooldown:\fR keyword in the Gemfile, such as \fBsource "https
 .IP
 The CLI flag and this setting apply uniformly to every source, including ones declared with their own \fBcooldown:\fR value\. To keep a private registry permanently exempt while still cooling down public gems, declare \fBsource "https://internal", cooldown: 0\fR in the Gemfile; remember that \fB\-\-cooldown N\fR on the command line will still override it for that single run\.
 .IP
+The value must be a non\-negative integer\. \fB\-\-cooldown\fR rejects anything else outright, while a value coming from this setting or from \fBBUNDLE_COOLDOWN\fR only warns, because a typo left in a config file should not make every command fail\. Such a value disables the cooldown for every source, including sources that declare their own \fBcooldown:\fR in the Gemfile\.
+.IP
 Cooldown filtering depends on the gem server providing a per\-version \fBcreated_at\fR timestamp in the v2 compact\-index format\. Versions without that metadata \- older gem servers, historical entries that predate the v2 cutover on \fBrubygems\.org\fR, or private registries that still emit the v1 format \- are treated as outside the cooldown window and remain resolvable\. If you rely on cooldown for supply\-chain protection, confirm that the gem server emits \fBcreated_at\fR in its \fB/info/<gem>\fR responses\.
 .IP "\(bu" 4
 \fBdefault_cli_command\fR (\fBBUNDLE_DEFAULT_CLI_COMMAND\fR): The command that running \fBbundle\fR without arguments should run\. Defaults to \fBcli_help\fR since Bundler 4, but can also be \fBinstall\fR which was the previous default\.

--- a/lib/bundler/man/bundle-config.1
+++ b/lib/bundler/man/bundle-config.1
@@ -102,6 +102,8 @@ The CLI flag and this setting apply uniformly to every source, including ones de
 The value must be a non\-negative integer\. \fB\-\-cooldown\fR rejects anything else outright, while a value coming from this setting or from \fBBUNDLE_COOLDOWN\fR only warns, because a typo left in a config file should not make every command fail\. Such a value disables the cooldown for every source, including sources that declare their own \fBcooldown:\fR in the Gemfile\.
 .IP
 Cooldown filtering depends on the gem server providing a per\-version \fBcreated_at\fR timestamp in the v2 compact\-index format\. Versions without that metadata \- older gem servers, historical entries that predate the v2 cutover on \fBrubygems\.org\fR, or private registries that still emit the v1 format \- are treated as outside the cooldown window and remain resolvable\. If you rely on cooldown for supply\-chain protection, confirm that the gem server emits \fBcreated_at\fR in its \fB/info/<gem>\fR responses\.
+.IP
+A \fBcreated_at\fR timestamp is read as UTC when it carries no time zone offset\. \fBrubygems\.org\fR always sends one, but a third\-party server that omits it would otherwise shift the cooldown window by the offset of whatever machine runs bundler\.
 .IP "\(bu" 4
 \fBdefault_cli_command\fR (\fBBUNDLE_DEFAULT_CLI_COMMAND\fR): The command that running \fBbundle\fR without arguments should run\. Defaults to \fBcli_help\fR since Bundler 4, but can also be \fBinstall\fR which was the previous default\.
 .IP "\(bu" 4

--- a/lib/bundler/man/bundle-config.1.ronn
+++ b/lib/bundler/man/bundle-config.1.ronn
@@ -174,6 +174,11 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    window and remain resolvable. If you rely on cooldown for
    supply-chain protection, confirm that the gem server emits
    `created_at` in its `/info/<gem>` responses.
+
+   A `created_at` timestamp is read as UTC when it carries no time zone
+   offset. `rubygems.org` always sends one, but a third-party server
+   that omits it would otherwise shift the cooldown window by the
+   offset of whatever machine runs bundler.
 * `default_cli_command` (`BUNDLE_DEFAULT_CLI_COMMAND`):
    The command that running `bundle` without arguments should run. Defaults to
    `cli_help` since Bundler 4, but can also be `install` which was the previous

--- a/lib/bundler/man/bundle-config.1.ronn
+++ b/lib/bundler/man/bundle-config.1.ronn
@@ -159,6 +159,13 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    Gemfile; remember that `--cooldown N` on the command line will
    still override it for that single run.
 
+   The value must be a non-negative integer. `--cooldown` rejects
+   anything else outright, while a value coming from this setting or
+   from `BUNDLE_COOLDOWN` only warns, because a typo left in a config
+   file should not make every command fail. Such a value disables the
+   cooldown for every source, including sources that declare their own
+   `cooldown:` in the Gemfile.
+
    Cooldown filtering depends on the gem server providing a per-version
    `created_at` timestamp in the v2 compact-index format. Versions
    without that metadata - older gem servers, historical entries that

--- a/lib/bundler/resolver.rb
+++ b/lib/bundler/resolver.rb
@@ -469,9 +469,9 @@ module Bundler
     def cooldown_excluded?(spec)
       return false unless spec.respond_to?(:created_at) && spec.created_at
       return false unless spec.respond_to?(:remote) && spec.remote
-      return false if locked_by_lockfile?(spec)
       days = spec.remote.effective_cooldown
       return false if days.nil? || days <= 0
+      return false if locked_by_lockfile?(spec)
       (cooldown_now - spec.created_at) < (days * 86_400)
     end
 

--- a/lib/bundler/source/rubygems/remote.rb
+++ b/lib/bundler/source/rubygems/remote.rb
@@ -20,10 +20,15 @@ module Bundler
         # Returns the cooldown days that apply to this remote, resolving the
         # precedence CLI > config > Gemfile per-source. Returns nil if no
         # cooldown applies.
+        #
+        # The resolver asks once per candidate spec, so the settings lookup is
+        # memoized. That snapshots the value: a Remote created before a
+        # settings change keeps the old one. Nothing in Bundler changes the
+        # cooldown setting after the sources are built (the CLI flag is applied
+        # before the Definition exists), so build a new Remote if you need to.
         def effective_cooldown
-          override = Bundler.settings[:cooldown]
-          return override if override
-          @cooldown
+          return @effective_cooldown if defined?(@effective_cooldown)
+          @effective_cooldown = Bundler.settings[:cooldown] || @cooldown
         end
 
         MAX_CACHE_SLUG_HOST_SIZE = 255 - 1 - 32 # 255 minus dot minus MD5 length

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -121,7 +121,9 @@ class Gem::ConfigFile
   ##
   # Number of days a newly published gem version must wait before it is
   # considered for installation or update (the cooldown period).  0
-  # disables the cooldown.
+  # disables the cooldown.  A value that cannot be read as a non-negative
+  # integer warns and leaves the cooldown disabled, so a typo in the gemrc
+  # file does not make every command fail.
 
   attr_accessor :cooldown
 

--- a/lib/rubygems/cooldown.rb
+++ b/lib/rubygems/cooldown.rb
@@ -28,8 +28,15 @@ class Gem::Cooldown
   end
 
   def initialize(days, now: Time.now)
-    @days = days.to_i
+    # A gemrc value is arbitrary YAML, so it can be any type at all. Anything
+    # that cannot be read as a non-negative integer leaves the cooldown
+    # disabled rather than raising out of an unrelated command.
+    valid = valid_days?(days)
+
+    @days = valid ? days.to_i : 0
     @now = now
+
+    Gem::Cooldown.warn_invalid_days(days) unless valid || days.nil?
   end
 
   ##
@@ -97,5 +104,31 @@ class Gem::Cooldown
 
   def self.reset_warned_missing_created_at # :nodoc:
     @warned = nil
+  end
+
+  # Warns once per process that a configured cooldown value cannot be read
+  # as a non-negative integer, which leaves the cooldown disabled.  The
+  # --cooldown option is validated by the option parser; this catches the
+  # gemrc path.
+
+  def self.warn_invalid_days(value) # :nodoc:
+    return if @warned_invalid_days
+    @warned_invalid_days = true
+
+    Gem::DefaultUserInteraction.ui.alert_warning \
+      "Invalid cooldown value #{value.inspect}, so the cooldown is disabled. " \
+      "Expected a non-negative integer number of days."
+  end
+
+  def self.reset_warned_invalid_days # :nodoc:
+    @warned_invalid_days = nil
+  end
+
+  private
+
+  def valid_days?(value)
+    days = Integer(value.to_s, exception: false)
+
+    !days.nil? && !days.negative?
   end
 end

--- a/lib/rubygems/cooldown.rb
+++ b/lib/rubygems/cooldown.rb
@@ -90,6 +90,27 @@ class Gem::Cooldown
     end
   end
 
+  # Matches an ISO 8601 time zone designator at the end of a timestamp.
+  TIME_ZONE_SUFFIX = /(?:Z|z|[+-]\d{2}(?::?\d{2})?)\z/ # :nodoc:
+  private_constant :TIME_ZONE_SUFFIX
+
+  ##
+  # Parses a +created_at+ timestamp from the compact index.  A timestamp
+  # without a time zone offset is read as UTC, because reading it as local
+  # time would shift the cooldown window by the environment's offset.
+  # Returns nil for anything unparsable, so the cooldown fails open.
+
+  def self.parse_created_at(value)
+    return unless value.is_a?(String)
+
+    require "time"
+    begin
+      Time.iso8601(value.match?(TIME_ZONE_SUFFIX) ? value : "#{value}Z")
+    rescue ArgumentError
+      nil
+    end
+  end
+
   ##
   # Warns once per process that +source+ did not provide publish times, so
   # the cooldown cannot be applied to gems from it.

--- a/lib/rubygems/cooldown_option.rb
+++ b/lib/rubygems/cooldown_option.rb
@@ -15,6 +15,11 @@ module Gem::CooldownOption
             "the last DAYS days (0 disables the cooldown)"].compact
 
     add_option(*args) do |value, options|
+      if value.negative?
+        raise Gem::OptionParser::InvalidArgument,
+              "#{value} (expected a non-negative integer number of days; use 0 to disable the cooldown)"
+      end
+
       options[:cooldown] = value
     end
   end

--- a/lib/rubygems/resolver/api_specification.rb
+++ b/lib/rubygems/resolver/api_specification.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../cooldown"
+
 ##
 # Represents a specification retrieved via the Compact Index API.
 #
@@ -114,13 +116,7 @@ class Gem::Resolver::APISpecification < Gem::Resolver::Specification
 
   def parse_created_at(value)
     value = value.first if value.is_a?(Array)
-    return unless value.is_a?(String)
 
-    require "time"
-    begin
-      Time.iso8601(value)
-    rescue ArgumentError
-      nil
-    end
+    Gem::Cooldown.parse_created_at(value)
   end
 end

--- a/lib/rubygems/source.rb
+++ b/lib/rubygems/source.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "text"
+require_relative "cooldown"
 ##
 # A Source knows how to list and fetch gems from a RubyGems marshal index.
 #
@@ -210,14 +211,8 @@ class Gem::Source
     return unless row
 
     value = row[Gem::CompactIndexClient::INFO_REQS].assoc("created_at")&.last&.first
-    return unless value.is_a?(String)
 
-    require "time"
-    begin
-      Time.iso8601(value)
-    rescue ArgumentError
-      nil
-    end
+    Gem::Cooldown.parse_created_at(value)
   end
 
   ##

--- a/spec/bundler/cli_common_spec.rb
+++ b/spec/bundler/cli_common_spec.rb
@@ -19,4 +19,53 @@ RSpec.describe Bundler::CLI::Common do
       expect(message).to match(/Did you mean 'method(|s)' or 'method(|s)'?/)
     end
   end
+
+  describe "validate_cooldown!" do
+    def warning(inspected)
+      "Invalid cooldown value #{inspected}, so the cooldown is disabled for all sources. " \
+        "Expected a non-negative integer number of days."
+    end
+
+    it "rejects a negative flag value" do
+      expect { subject.validate_cooldown!(-1) }.to raise_error(
+        Bundler::InvalidOption, "Expected `--cooldown` to be a non-negative integer, got -1"
+      )
+    end
+
+    it "accepts a non-negative flag value without reading the settings" do
+      expect(Bundler.ui).not_to receive(:warn)
+      expect { subject.validate_cooldown!(0) }.not_to raise_error
+      expect { subject.validate_cooldown!(7) }.not_to raise_error
+    end
+
+    context "when no flag is given" do
+      it "warns when the configured value is not a number" do
+        Bundler.settings.temporary(cooldown: "abc") do
+          expect(Bundler.ui).to receive(:warn).with(warning('"abc"')).once
+          subject.validate_cooldown!(nil)
+        end
+      end
+
+      it "warns when the configured value is negative" do
+        Bundler.settings.temporary(cooldown: "-5") do
+          expect(Bundler.ui).to receive(:warn).with(warning('"-5"')).once
+          subject.validate_cooldown!(nil)
+        end
+      end
+
+      it "warns when the configured value is only partly a number" do
+        Bundler.settings.temporary(cooldown: "7days") do
+          expect(Bundler.ui).to receive(:warn).with(warning('"7days"')).once
+          subject.validate_cooldown!(nil)
+        end
+      end
+
+      it "stays quiet for a valid value, an explicit 0, and an unset value" do
+        expect(Bundler.ui).not_to receive(:warn)
+        Bundler.settings.temporary(cooldown: "7") { subject.validate_cooldown!(nil) }
+        Bundler.settings.temporary(cooldown: "0") { subject.validate_cooldown!(nil) }
+        subject.validate_cooldown!(nil)
+      end
+    end
+  end
 end

--- a/spec/bundler/endpoint_specification_spec.rb
+++ b/spec/bundler/endpoint_specification_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe Bundler::EndpointSpecification do
 
   subject(:spec) { described_class.new(name, version, platform, spec_fetcher, dependencies, metadata) }
 
+  def with_tz(tz)
+    orig_tz = ENV["TZ"]
+    ENV["TZ"] = tz
+    yield
+  ensure
+    ENV["TZ"] = orig_tz
+  end
+
   describe "#build_dependency" do
     let(:name)           { "foo" }
     let(:requirement1)   { "~> 1.1" }
@@ -60,6 +68,24 @@ RSpec.describe Bundler::EndpointSpecification do
 
       it "still parses created_at" do
         expect(subject.created_at).to eq(Time.utc(2026, 5, 12, 10, 0, 0))
+      end
+    end
+
+    context "when created_at has no time zone offset" do
+      let(:metadata) { { "created_at" => "2026-05-12T10:00:00" } }
+
+      it "is interpreted as UTC regardless of the local time zone" do
+        with_tz("Asia/Tokyo") do
+          expect(subject.created_at).to eq(Time.utc(2026, 5, 12, 10, 0, 0))
+        end
+      end
+    end
+
+    context "when created_at has an explicit offset" do
+      let(:metadata) { { "created_at" => "2026-05-12T10:00:00+02:00" } }
+
+      it "keeps the offset" do
+        expect(subject.created_at).to eq(Time.utc(2026, 5, 12, 8, 0, 0))
       end
     end
 

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -124,6 +124,14 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
         settings.set_local :cooldown, "7"
         expect(settings[:cooldown]).to be 7
       end
+
+      it "coerces an unparsable cooldown to 0 without warning here" do
+        # The warning lives in CLI::Common so it fires once per command,
+        # outside any Bundler.ui.silence block. See cli_common_spec.rb.
+        expect(Bundler.ui).not_to receive(:warn)
+        settings.set_local :cooldown, "abc"
+        expect(settings[:cooldown]).to be 0
+      end
     end
 
     context "when it's not possible to create the settings directory" do

--- a/spec/bundler/source/rubygems/remote_spec.rb
+++ b/spec/bundler/source/rubygems/remote_spec.rb
@@ -203,5 +203,21 @@ RSpec.describe Bundler::Source::Rubygems::Remote do
         expect(remote(uri_no_auth).effective_cooldown).to eq(14)
       end
     end
+
+    it "reads the settings only once, however many candidates ask" do
+      r = Bundler::Source::Rubygems::Remote.new(uri_no_auth, cooldown: 7)
+      expect(Bundler.settings).to receive(:[]).with(:cooldown).once.and_return(14)
+
+      expect(r.effective_cooldown).to eq(14)
+      expect(r.effective_cooldown).to eq(14)
+    end
+
+    it "memoizes an absent override without re-reading the settings" do
+      r = Bundler::Source::Rubygems::Remote.new(uri_no_auth, cooldown: 7)
+      expect(Bundler.settings).to receive(:[]).with(:cooldown).once.and_return(nil)
+
+      expect(r.effective_cooldown).to eq(7)
+      expect(r.effective_cooldown).to eq(7)
+    end
   end
 end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -545,6 +545,7 @@ class Gem::TestCase < Test::Unit::TestCase
 
     if defined? Gem::Cooldown
       Gem::Cooldown.reset_warned_missing_created_at
+      Gem::Cooldown.reset_warned_invalid_days
     end
 
     Dir.chdir @current_dir

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -855,6 +855,14 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_equal 7, @cmd.options[:cooldown]
   end
 
+  def test_cooldown_option_negative
+    e = assert_raise Gem::OptionParser::InvalidArgument do
+      @cmd.handle_options %w[--cooldown -7 a]
+    end
+
+    assert_match "--cooldown", e.message
+  end
+
   def test_execute_with_invalid_gem_file
     FileUtils.touch("a.gem")
 

--- a/test/rubygems/test_gem_cooldown.rb
+++ b/test/rubygems/test_gem_cooldown.rb
@@ -42,6 +42,85 @@ class TestGemCooldown < Gem::TestCase
     Gem.configuration.cooldown = orig_cooldown
   end
 
+  def test_invalid_days_warns_once_and_fails_open
+    use_ui @ui do
+      refute Gem::Cooldown.new("abc").active?
+      refute Gem::Cooldown.new("abc").active?
+    end
+
+    assert_equal 1, @ui.error.scan("Invalid cooldown value").size
+    assert_match 'Invalid cooldown value "abc", so the cooldown is disabled.', @ui.error
+    assert_match "Expected a non-negative integer number of days.", @ui.error
+  end
+
+  def test_negative_days_warns_and_fails_open
+    use_ui @ui do
+      refute Gem::Cooldown.new(-5).active?
+    end
+
+    assert_match "Invalid cooldown value -5", @ui.error
+  end
+
+  def test_partly_numeric_days_warns_and_fails_open
+    use_ui @ui do
+      refute Gem::Cooldown.new("7days").active?
+    end
+
+    assert_match 'Invalid cooldown value "7days"', @ui.error
+  end
+
+  def test_non_numeric_type_warns_instead_of_raising
+    use_ui @ui do
+      [true, [7], :sym].each do |value|
+        refute Gem::Cooldown.new(value).active?
+      end
+    end
+
+    assert_match "Invalid cooldown value true", @ui.error
+  end
+
+  def test_valid_days_do_not_warn
+    use_ui @ui do
+      Gem::Cooldown.new 7
+      Gem::Cooldown.new 0
+      Gem::Cooldown.new "3"
+      Gem::Cooldown.new nil
+    end
+
+    assert_empty @ui.error
+  end
+
+  def test_parse_created_at_without_offset_is_utc
+    with_tz "Asia/Tokyo" do
+      assert_equal Time.utc(2026, 6, 5, 10, 30, 45),
+                   Gem::Cooldown.parse_created_at("2026-06-05T10:30:45")
+    end
+  end
+
+  def test_parse_created_at_keeps_explicit_offset
+    assert_equal Time.utc(2026, 6, 5, 8, 30, 45),
+                 Gem::Cooldown.parse_created_at("2026-06-05T10:30:45+02:00")
+
+    assert_equal Time.utc(2026, 6, 5, 10, 30, 45),
+                 Gem::Cooldown.parse_created_at("2026-06-05T10:30:45Z")
+  end
+
+  def test_parse_created_at_invalid
+    assert_nil Gem::Cooldown.parse_created_at("not a timestamp")
+    assert_nil Gem::Cooldown.parse_created_at("2026")
+    assert_nil Gem::Cooldown.parse_created_at("2026-06-05T10")
+    assert_nil Gem::Cooldown.parse_created_at(nil)
+    assert_nil Gem::Cooldown.parse_created_at(7)
+  end
+
+  def with_tz(tz)
+    orig_tz = ENV["TZ"]
+    ENV["TZ"] = tz
+    yield
+  ensure
+    ENV["TZ"] = orig_tz
+  end
+
   def test_warn_missing_created_at_warns_once
     source = Gem::Source.new @gem_repo
 

--- a/test/rubygems/test_gem_resolver_api_specification.rb
+++ b/test/rubygems/test_gem_resolver_api_specification.rb
@@ -75,6 +75,46 @@ class TestGemResolverAPISpecification < Gem::TestCase
     assert_nil spec.created_at
   end
 
+  def test_initialize_created_at_without_offset_is_utc
+    set = Gem::Resolver::APISet.new
+    data = {
+      name: "rails",
+      number: "3.0.3",
+      platform: "ruby",
+      dependencies: [],
+      requirements: { created_at: ["2026-06-05T10:30:45"] },
+    }
+
+    with_tz("Asia/Tokyo") do
+      spec = Gem::Resolver::APISpecification.new set, data
+
+      assert_equal Time.utc(2026, 6, 5, 10, 30, 45), spec.created_at
+    end
+  end
+
+  def test_initialize_created_at_keeps_explicit_offset
+    set = Gem::Resolver::APISet.new
+    data = {
+      name: "rails",
+      number: "3.0.3",
+      platform: "ruby",
+      dependencies: [],
+      requirements: { created_at: ["2026-06-05T10:30:45+02:00"] },
+    }
+
+    spec = Gem::Resolver::APISpecification.new set, data
+
+    assert_equal Time.utc(2026, 6, 5, 8, 30, 45), spec.created_at
+  end
+
+  def with_tz(tz)
+    orig_tz = ENV["TZ"]
+    ENV["TZ"] = tz
+    yield
+  ensure
+    ENV["TZ"] = orig_tz
+  end
+
   def test_fetch_development_dependencies
     specs = spec_fetcher do |fetcher|
       fetcher.spec "rails", "3.0.3" do |s|


### PR DESCRIPTION
Implements three remaining review findings from #9576.

`effective_cooldown` now memoizes the `Bundler.settings` lookup that the resolver makes once per candidate spec, and `cooldown_excluded?` checks the day count before touching the locked specs. The lookup being memoized means the value is a snapshot, which is fine because nothing changes the cooldown setting after the sources are built.

An invalid cooldown coming from a config file or from `BUNDLE_COOLDOWN` used to disable the cooldown silently. It now warns, and says the cooldown ends up disabled for every source, because such a value also overrides any per-source `cooldown:` in the Gemfile. The check runs at the CLI entry point rather than while reading the setting, so `bundle config` does not warn merely for listing settings and `bundle outdated` does not swallow the warning inside its `Bundler.ui.silence` block. `gem` warns the same way for gemrc values, and rejects a negative `--cooldown` outright.

A `created_at` timestamp without a time zone offset was read as local time, which shifted the cooldown window by whatever offset the machine happened to have. Both halves now complete the missing offset and parse it as UTC. `gem outdated` and `gem update` read timestamps through a second parser in `Gem::Source` that the first pass missed, so both paths share one helper now.
