### PR TITLE
Show the newest out-of-cooldown version in bundle outdated

### DIFF
--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -254,7 +254,7 @@ module Bundler
       remaining = cooldown_days_remaining(active_spec)
       if remaining
         adoptable = newest_out_of_cooldown(active_spec, current_spec)
-        spec_version += " (cooldown #{remaining}d#{", #{adoptable.version} available" if adoptable})"
+        spec_version += " (cooldown #{remaining}d#{", #{adoptable.version} out of cooldown" if adoptable})"
       end
       dependency = dependency.requirement if dependency
 

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -164,11 +164,26 @@ module Bundler
 
       return active_spec if strict
 
+      matching_specs(active_spec, current_spec).last
+    end
+
+    def matching_specs(active_spec, current_spec)
       active_specs = active_spec.source.specs.search(current_spec.name).select {|spec| spec.installable_on_platform?(current_spec.platform) }.sort_by(&:version)
       if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
         active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
       end
-      active_specs.last
+      active_specs
+    end
+
+    # The newest version the cooldown setting would let bundler adopt right
+    # now, when the newest overall version is still inside the window. Only a
+    # version strictly between the installed one and the newest one is an
+    # adoptable update worth showing.
+    def newest_out_of_cooldown(active_spec, current_spec)
+      newest = matching_specs(active_spec, current_spec).reverse_each.find {|spec| cooldown_days_remaining(spec).nil? }
+      return unless newest
+      return if newest.version >= active_spec.version || newest.version <= current_spec.version
+      newest
     end
 
     def print_gems(gems_list)
@@ -214,7 +229,11 @@ module Bundler
       spec_outdated_info += ", released #{release_date}" unless release_date.empty?
 
       remaining = cooldown_days_remaining(active_spec)
-      spec_outdated_info += ", in cooldown for #{remaining} more day#{"s" if remaining > 1}" if remaining
+      if remaining
+        spec_outdated_info += ", in cooldown for #{remaining} more day#{"s" if remaining > 1}"
+        adoptable = newest_out_of_cooldown(active_spec, current_spec)
+        spec_outdated_info += ", newest out of cooldown #{adoptable.version}" if adoptable
+      end
 
       spec_outdated_info += ")"
 
@@ -233,7 +252,10 @@ module Bundler
       current_version = "#{current_spec.version}#{current_spec.git_version}"
       spec_version = "#{active_spec.version}#{active_spec.git_version}"
       remaining = cooldown_days_remaining(active_spec)
-      spec_version += " (cooldown #{remaining}d)" if remaining
+      if remaining
+        adoptable = newest_out_of_cooldown(active_spec, current_spec)
+        spec_version += " (cooldown #{remaining}d#{", #{adoptable.version} available" if adoptable})"
+      end
       dependency = dependency.requirement if dependency
 
       ret_val = [active_spec.name, current_version, spec_version, dependency.to_s, groups.to_s]

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -257,7 +257,8 @@ module Bundler
       remaining = cooldown_days_remaining(active_spec)
       if remaining
         adoptable = newest_out_of_cooldown(active_spec, current_spec)
-        spec_version += " (cooldown #{remaining}d#{", #{adoptable.version} out of cooldown" if adoptable})"
+        adoptable_note = adoptable ? ", #{adoptable.version} out of cooldown" : ""
+        spec_version += " (cooldown #{remaining}d#{adoptable_note})"
       end
       dependency = dependency.requirement if dependency
 

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -169,7 +169,7 @@ module Bundler
 
     def matching_specs(active_spec, current_spec)
       @matching_specs ||= {}
-      @matching_specs[[current_spec.name, current_spec.platform]] ||= begin
+      @matching_specs[[active_spec.source, current_spec.name, current_spec.platform]] ||= begin
         active_specs = active_spec.source.specs.search(current_spec.name).select {|spec| spec.installable_on_platform?(current_spec.platform) }.sort_by(&:version)
         if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
           active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -168,11 +168,14 @@ module Bundler
     end
 
     def matching_specs(active_spec, current_spec)
-      active_specs = active_spec.source.specs.search(current_spec.name).select {|spec| spec.installable_on_platform?(current_spec.platform) }.sort_by(&:version)
-      if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
-        active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
+      @matching_specs ||= {}
+      @matching_specs[[current_spec.name, current_spec.platform]] ||= begin
+        active_specs = active_spec.source.specs.search(current_spec.name).select {|spec| spec.installable_on_platform?(current_spec.platform) }.sort_by(&:version)
+        if !current_spec.version.prerelease? && !options[:pre] && active_specs.size > 1
+          active_specs.delete_if {|b| b.respond_to?(:version) && b.version.prerelease? }
+        end
+        active_specs
       end
-      active_specs
     end
 
     # The newest version the cooldown setting would let bundler adopt right

--- a/lib/bundler/cli/outdated.rb
+++ b/lib/bundler/cli/outdated.rb
@@ -268,13 +268,17 @@ module Bundler
       ret_val
     end
 
-    def cooldown_days_remaining(spec, now = Time.now)
+    def cooldown_days_remaining(spec, now = cooldown_now)
       return nil unless spec.respond_to?(:created_at) && spec.created_at
       return nil unless spec.respond_to?(:remote) && spec.remote
       days = spec.remote.effective_cooldown
       return nil if days.nil? || days <= 0
       remaining = days - ((now - spec.created_at) / 86_400.0)
       remaining > 0 ? remaining.ceil : nil
+    end
+
+    def cooldown_now
+      @cooldown_now ||= Time.now
     end
 
     def check_for_deployment_mode!

--- a/lib/bundler/man/bundle-outdated.1
+++ b/lib/bundler/man/bundle-outdated.1
@@ -55,7 +55,7 @@ Only list patch newer versions\.
 Only list gems specified in your Gemfile, not their dependencies\.
 .TP
 \fB\-\-cooldown=<number>\fR
-Annotate (rather than hide) versions that are still inside the cooldown window of \fInumber\fR days\. The prose output appends "in cooldown for Nd more days" and the table form adds "(cooldown Nd)" to the Latest column\. See \fBcooldown\fR in bundle\-config(1)\.
+Annotate (rather than hide) versions that are still inside the cooldown window of \fInumber\fR days\. The prose output appends "in cooldown for Nd more days" and the table form adds "(cooldown Nd)" to the Latest column\. When a version outside the window is newer than the installed one, the prose output also appends "newest out of cooldown X" and the table form becomes "(cooldown Nd, X out of cooldown)"\. See \fBcooldown\fR in bundle\-config(1)\.
 .SH "PATCH LEVEL OPTIONS"
 See bundle update(1) \fIbundle\-update\.1\.html\fR for details\.
 .SH "FILTERING OUTPUT"

--- a/lib/bundler/man/bundle-outdated.1
+++ b/lib/bundler/man/bundle-outdated.1
@@ -55,7 +55,7 @@ Only list patch newer versions\.
 Only list gems specified in your Gemfile, not their dependencies\.
 .TP
 \fB\-\-cooldown=<number>\fR
-Annotate (rather than hide) versions that are still inside the cooldown window of \fInumber\fR days\. The prose output appends "in cooldown for Nd more days" and the table form adds "(cooldown Nd)" to the Latest column\. When a version outside the window is newer than the installed one, the prose output also appends "newest out of cooldown X" and the table form becomes "(cooldown Nd, X out of cooldown)"\. With \fB\-\-filter\-strict\fR, "newest" is already the cooldown\-filtered resolved version, so none of these annotations appear\. See \fBcooldown\fR in bundle\-config(1)\.
+Annotate (rather than hide) versions that are still inside the cooldown window of \fInumber\fR days\. The prose output appends "in cooldown for Nd more days" and the table form adds "(cooldown Nd)" to the Latest column\. When a version outside the window is newer than the installed one, the prose output also appends "newest out of cooldown X" and the table form becomes "(cooldown Nd, X out of cooldown)"\. With \fB\-\-filter\-strict\fR (or \fB\-\-patch\fR, \fB\-\-minor\fR, \fB\-\-major\fR, which imply it), "newest" is already the cooldown\-filtered resolved version, so none of these annotations appear\. See \fBcooldown\fR in bundle\-config(1)\.
 .SH "PATCH LEVEL OPTIONS"
 See bundle update(1) \fIbundle\-update\.1\.html\fR for details\.
 .SH "FILTERING OUTPUT"

--- a/lib/bundler/man/bundle-outdated.1
+++ b/lib/bundler/man/bundle-outdated.1
@@ -55,7 +55,7 @@ Only list patch newer versions\.
 Only list gems specified in your Gemfile, not their dependencies\.
 .TP
 \fB\-\-cooldown=<number>\fR
-Annotate (rather than hide) versions that are still inside the cooldown window of \fInumber\fR days\. The prose output appends "in cooldown for Nd more days" and the table form adds "(cooldown Nd)" to the Latest column\. When a version outside the window is newer than the installed one, the prose output also appends "newest out of cooldown X" and the table form becomes "(cooldown Nd, X out of cooldown)"\. See \fBcooldown\fR in bundle\-config(1)\.
+Annotate (rather than hide) versions that are still inside the cooldown window of \fInumber\fR days\. The prose output appends "in cooldown for Nd more days" and the table form adds "(cooldown Nd)" to the Latest column\. When a version outside the window is newer than the installed one, the prose output also appends "newest out of cooldown X" and the table form becomes "(cooldown Nd, X out of cooldown)"\. With \fB\-\-filter\-strict\fR, "newest" is already the cooldown\-filtered resolved version, so none of these annotations appear\. See \fBcooldown\fR in bundle\-config(1)\.
 .SH "PATCH LEVEL OPTIONS"
 See bundle update(1) \fIbundle\-update\.1\.html\fR for details\.
 .SH "FILTERING OUTPUT"

--- a/lib/bundler/man/bundle-outdated.1.ronn
+++ b/lib/bundler/man/bundle-outdated.1.ronn
@@ -79,9 +79,10 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
   the Latest column. When a version outside the window is newer than the
   installed one, the prose output also appends "newest out of cooldown
   X" and the table form becomes "(cooldown Nd, X out of cooldown)".
-  With `--filter-strict`, "newest" is already the cooldown-filtered
-  resolved version, so none of these annotations appear. See `cooldown`
-  in bundle-config(1).
+  With `--filter-strict` (or `--patch`, `--minor`, `--major`, which
+  imply it), "newest" is already the cooldown-filtered resolved version,
+  so none of these annotations appear. See `cooldown` in
+  bundle-config(1).
 
 ## PATCH LEVEL OPTIONS
 

--- a/lib/bundler/man/bundle-outdated.1.ronn
+++ b/lib/bundler/man/bundle-outdated.1.ronn
@@ -78,8 +78,10 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
   cooldown for Nd more days" and the table form adds "(cooldown Nd)" to
   the Latest column. When a version outside the window is newer than the
   installed one, the prose output also appends "newest out of cooldown
-  X" and the table form becomes "(cooldown Nd, X out of cooldown)". See
-  `cooldown` in bundle-config(1).
+  X" and the table form becomes "(cooldown Nd, X out of cooldown)".
+  With `--filter-strict`, "newest" is already the cooldown-filtered
+  resolved version, so none of these annotations appear. See `cooldown`
+  in bundle-config(1).
 
 ## PATCH LEVEL OPTIONS
 

--- a/lib/bundler/man/bundle-outdated.1.ronn
+++ b/lib/bundler/man/bundle-outdated.1.ronn
@@ -76,7 +76,10 @@ are up to date, Bundler will exit with a status of 0. Otherwise, it will exit 1.
   Annotate (rather than hide) versions that are still inside the
   cooldown window of <number> days. The prose output appends "in
   cooldown for Nd more days" and the table form adds "(cooldown Nd)" to
-  the Latest column. See `cooldown` in bundle-config(1).
+  the Latest column. When a version outside the window is newer than the
+  installed one, the prose output also appends "newest out of cooldown
+  X" and the table form becomes "(cooldown Nd, X out of cooldown)". See
+  `cooldown` in bundle-config(1).
 
 ## PATCH LEVEL OPTIONS
 

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -509,6 +509,36 @@ RSpec.describe "bundle install with the cooldown setting" do
       expect(out).to match(/mid_gem.*2\.0\.0 \(cooldown \d+d, 1\.5\.0 out of cooldown\)/)
     end
 
+    it "shows the resolved version without cooldown notes in strict mode" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "mid_gem"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            mid_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          mid_gem
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "outdated --strict --cooldown 7 --parseable", artifice: "compact_index_cooldown", raise_on_error: false
+
+      # in strict mode "newest" is the resolved (cooldown-filtered) version
+      # itself, so the annotations have nothing to add
+      expect(out).to match(/mid_gem \(newest 1\.5\.0, installed 1\.0\.0/)
+      expect(out).not_to include("cooldown")
+    end
+
     it "shows no out-of-cooldown note when every version is inside the window" do
       gemfile <<-G
         source "https://gem.repo3"

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -506,7 +506,7 @@ RSpec.describe "bundle install with the cooldown setting" do
 
       bundle "outdated --cooldown 7", artifice: "compact_index_cooldown", raise_on_error: false
 
-      expect(out).to match(/mid_gem.*2\.0\.0 \(cooldown \d+d, 1\.5\.0 available\)/)
+      expect(out).to match(/mid_gem.*2\.0\.0 \(cooldown \d+d, 1\.5\.0 out of cooldown\)/)
     end
 
     it "shows no out-of-cooldown note when every version is inside the window" do

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -567,6 +567,34 @@ RSpec.describe "bundle install with the cooldown setting" do
       expect(out).not_to include("out of cooldown")
     end
 
+    it "uses the singular form when one cooldown day remains" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "mid_gem", "1.0.0"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            mid_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          mid_gem (= 1.0.0)
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      # mid_gem 2.0.0 is one day old, so a two-day window leaves one day
+      bundle "outdated --cooldown 2 --parseable", artifice: "compact_index_cooldown", raise_on_error: false
+
+      expect(out).to match(/mid_gem \(newest 2\.0\.0, installed 1\.0\.0.*in cooldown for 1 more day, newest out of cooldown 1\.5\.0\)/)
+    end
+
     it "leaves bundle outdated output untouched when cooldown is not enabled" do
       gemfile <<-G
         source "https://gem.repo3"

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -108,6 +108,18 @@ RSpec.describe "bundle install with the cooldown setting" do
           s.date = now - (30 * 86_400)
         end
 
+        # an adoptable version sits between the installed one and the
+        # in-cooldown newest one
+        build_gem "mid_gem", "1.0.0" do |s|
+          s.date = now - (30 * 86_400)
+        end
+        build_gem "mid_gem", "1.5.0" do |s|
+          s.date = now - (30 * 86_400)
+        end
+        build_gem "mid_gem", "2.0.0" do |s|
+          s.date = now - (1 * 86_400)
+        end
+
         # every published version is inside the cooldown window
         build_gem "fresh_gem", "0.3.1" do |s|
           s.date = now - (1 * 86_400)
@@ -464,6 +476,93 @@ RSpec.describe "bundle install with the cooldown setting" do
       bundle "outdated --cooldown 7 --parseable", artifice: "compact_index_cooldown", raise_on_error: false
 
       expect(out).to match(/ripe_gem.*in cooldown for \d+ more day/)
+    end
+
+    it "shows the newest out-of-cooldown version next to the in-cooldown newest one" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "mid_gem", "1.0.0"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            mid_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          mid_gem (= 1.0.0)
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "outdated --cooldown 7 --parseable", artifice: "compact_index_cooldown", raise_on_error: false
+
+      expect(out).to match(/mid_gem \(newest 2\.0\.0, installed 1\.0\.0.*in cooldown for \d+ more days, newest out of cooldown 1\.5\.0\)/)
+
+      bundle "outdated --cooldown 7", artifice: "compact_index_cooldown", raise_on_error: false
+
+      expect(out).to match(/mid_gem.*2\.0\.0 \(cooldown \d+d, 1\.5\.0 available\)/)
+    end
+
+    it "shows no out-of-cooldown note when every version is inside the window" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "fresh_gem", "0.3.1"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            fresh_gem (0.3.1)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          fresh_gem (= 0.3.1)
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "outdated --cooldown 7 --parseable", artifice: "compact_index_cooldown", raise_on_error: false
+
+      expect(out).to match(/fresh_gem.*in cooldown for \d+ more day/)
+      expect(out).not_to include("out of cooldown")
+    end
+
+    it "leaves bundle outdated output untouched when cooldown is not enabled" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "mid_gem", "1.0.0"
+      G
+
+      lockfile <<-L
+        GEM
+          remote: https://gem.repo3/
+          specs:
+            mid_gem (1.0.0)
+
+        PLATFORMS
+          #{lockfile_platforms}
+
+        DEPENDENCIES
+          mid_gem (= 1.0.0)
+
+        BUNDLED WITH
+           #{Bundler::VERSION}
+      L
+
+      bundle "outdated --parseable", artifice: "compact_index_cooldown", raise_on_error: false
+
+      expect(out).to match(/mid_gem \(newest 2\.0\.0, installed 1\.0\.0/)
+      expect(out).not_to include("cooldown")
     end
 
     it "excludes a locally-installed version that is still within the cooldown window" do


### PR DESCRIPTION
With cooldown enabled, `bundle outdated` reports the newest published version even when it is still inside the cooldown window, and the newest version bundler would actually adopt right now is not shown anywhere. Tools like libyear-bundler parse this output and currently have to look the adoptable version up elsewhere. This appends it to the outdated line when it sits strictly between the installed version and the in-cooldown newest one, in both the parseable output and the table. Existing tokens are untouched so parsers keep working, and when no adoptable update exists outside the window nothing is appended and the output stays byte-identical.

Before:

```
mid_gem (newest 2.0.0, installed 1.0.0, in cooldown for 6 more days)
```

After:

```
mid_gem (newest 2.0.0, installed 1.0.0, in cooldown for 6 more days, newest out of cooldown 1.5.0)
```

The table's Latest column gets the same information as `2.0.0 (cooldown 6d, 1.5.0 out of cooldown)`.

Closes #9624
