### PR TITLE
Bundler::Source::Git: avoid re-fetching the repo

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -91,9 +91,9 @@ module Bundler
 
       def to_s
         begin
-          at = humanized_ref || current_branch
-
-          rev = "at #{at}@#{shortref_for_display(revision)}"
+          at = humanized_ref
+          at = "#{at}@" if at
+          rev = "at #{at}#{shortref_for_display(revision)}"
         rescue GitError
           ""
         end

--- a/spec/install/git_spec.rb
+++ b/spec/install/git_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "bundle install" do
         gem "foo", :git => "#{lib_path("foo")}"
       G
 
-      expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at main@#{revision_for(lib_path("foo"))[0..6]})")
+      expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at #{revision_for(lib_path("foo"))[0..6]})")
       expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
     end
 
@@ -23,7 +23,7 @@ RSpec.describe "bundle install" do
         gem "foo", :git => "#{relative_path}"
       G
 
-      expect(out).to include("Using foo 1.0 from #{relative_path} (at main@#{revision_for(lib_path("foo"))[0..6]})")
+      expect(out).to include("Using foo 1.0 from #{relative_path} (at #{revision_for(lib_path("foo"))[0..6]})")
       expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
     end
 
@@ -35,7 +35,7 @@ RSpec.describe "bundle install" do
         gem "foo", :git => "#{lib_path("foo")}"
       G
 
-      expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at non-standard@#{revision_for(lib_path("foo"))[0..6]})")
+      expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at #{revision_for(lib_path("foo"))[0..6]})")
       expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
     end
 
@@ -193,7 +193,7 @@ RSpec.describe "bundle install" do
         gem "foo", :git => "#{lib_path("foo")}"
       G
 
-      expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at main@#{rev[0..6]})")
+      expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at #{rev[0..6]})")
       expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
 
       old_lockfile = lockfile
@@ -202,20 +202,20 @@ RSpec.describe "bundle install" do
       rev2 = revision_for(lib_path("foo"))
 
       bundle :update, all: true, verbose: true
-      expect(out).to include("Using foo 2.0 (was 1.0) from #{lib_path("foo")} (at main@#{rev2[0..6]})")
+      expect(out).to include("Using foo 2.0 (was 1.0) from #{lib_path("foo")} (at #{rev2[0..6]})")
       expect(out).to include("Removing foo (#{rev[0..11]})")
       expect(the_bundle).to include_gems "foo 2.0", source: "git@#{lib_path("foo")}"
 
       lockfile(old_lockfile)
 
       bundle :install, verbose: true
-      expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at main@#{rev[0..6]})")
+      expect(out).to include("Using foo 1.0 from #{lib_path("foo")} (at #{rev[0..6]})")
       expect(the_bundle).to include_gems "foo 1.0", source: "git@#{lib_path("foo")}"
     end
 
     context "when install directory exists" do
       let(:checkout_confirmation_log_message) { "Checking out revision" }
-      let(:using_foo_confirmation_log_message) { "Using foo 1.0 from #{lib_path("foo")} (at main@#{revision_for(lib_path("foo"))[0..6]})" }
+      let(:using_foo_confirmation_log_message) { "Using foo 1.0 from #{lib_path("foo")} (at #{revision_for(lib_path("foo"))[0..6]})" }
 
       context "and no contents besides .git directory are present" do
         it "reinstalls gem" do

--- a/spec/update/git_spec.rb
+++ b/spec/update/git_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe "bundle update" do
       update_git "rails", "3.0", path: lib_path("rails"), gemspec: true
 
       bundle "update", all: true
-      expect(out).to include("Using rails 3.0 (was 2.3.2) from #{lib_path("rails")} (at main@#{revision_for(lib_path("rails"))[0..6]})")
+      expect(out).to include("Using rails 3.0 (was 2.3.2) from #{lib_path("rails")} (at #{revision_for(lib_path("rails"))[0..6]})")
     end
   end
 


### PR DESCRIPTION
In `install`, `self.to_s` is called by `print_using_message "Using ... from #{self}`. This in turn calls `current_branch` which if the local git cache is missing will re-clone it from scratch.

This is an issue, because a common optimisation for build system that are bundler aware is to prune bundler's cache to remove large git repositories.

See my feature request from 2020 for context: https://github.com/ruby/rubygems/discussions/7018

In our case, these git repositories account for over 50% of the bundler cache, causing the cache restoration and persist steps to be very significantly slowed down.

Overall I don't think triggering a full on git clone operation from a call to `to_s` make sense.

NB: This can be worked around by always specifying a `ref: ` argument on the gem.