### PR TITLE
Fix gemspec evaluation under Ruby::Box

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -648,7 +648,15 @@ module Bundler
         # Eval the gemspec from its parent directory, because some gemspecs
         # depend on "./" relative paths.
         SharedHelpers.chdir(path.dirname.to_s) do
-          eval(contents, TOPLEVEL_BINDING.dup, path.expand_path.to_s)
+          # TOPLEVEL_BINDING always belongs to the main box, so inside a
+          # Ruby::Box use a binding from the box Bundler is loaded in, where
+          # Gem::Specification carries Bundler's own monkey patches.
+          eval_binding = if defined?(Ruby::Box) && Ruby::Box.enabled?
+            Ruby::Box.current.eval("binding")
+          else
+            TOPLEVEL_BINDING.dup
+          end
+          eval(contents, eval_binding, path.expand_path.to_s)
         end
       end
     rescue ScriptError, StandardError => e

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -890,4 +890,40 @@ end
       expect(lines).to include("LS MANPAGE")
     end
   end
+
+  context "when Ruby::Box is enabled" do
+    before do
+      skip "requires Ruby 4.0.6+, where each box loads its own RubyGems" unless defined?(Ruby::Box) && Gem.ruby_version >= Gem::Version.new("4.0.6")
+
+      build_lib "foo", "1.0", path: bundled_app
+
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gemspec
+      G
+    end
+
+    it "evaluates gemspecs in the box Bundler is loaded in" do
+      ruby <<~RUBY, env: { "RUBY_BOX" => "1" }
+        box = Ruby::Box.new
+        box.eval(<<~'BOX')
+          require "bundler/setup"
+          require "foo"
+          puts FOO
+        BOX
+      RUBY
+
+      expect(out).to eq("1.0")
+    end
+
+    it "still evaluates gemspecs when no box is created" do
+      ruby <<~RUBY, env: { "RUBY_BOX" => "1" }
+        require "bundler/setup"
+        require "foo"
+        puts FOO
+      RUBY
+
+      expect(out).to eq("1.0")
+    end
+  end
 end


### PR DESCRIPTION
When Bundler is loaded inside a `Ruby::Box`, evaluating a gemspec through the `gemspec` Gemfile directive fails with `NoMethodError: undefined method 'source='`. `TOPLEVEL_BINDING` always belongs to the main box, so `Gem::Specification` inside the gemspec resolves to the main box's class, which lacks the monkey patches Bundler applies to its own copy. This is the user box counterpart of #9740, whose root box case was fixed on the ruby/ruby side.

`eval_gemspec` now evaluates gemspecs with a binding taken from the box Bundler is loaded in when boxes are enabled, and keeps using `TOPLEVEL_BINDING.dup` otherwise. Ruby core has a TODO to make `TOPLEVEL_BINDING` per-box, and this branch can be folded once that lands.
