### PR TITLE
Make the gem CLI work under RUBY_BOX=1

### DIFF
--- a/lib/rubygems/command.rb
+++ b/lib/rubygems/command.rb
@@ -440,7 +440,7 @@ class Gem::Command
   def handle_options(args)
     args = add_extra_args(args)
     check_deprecated_options(args)
-    @options = Marshal.load Marshal.dump @defaults # deep copy
+    @options = Gem::Util.deep_dup @defaults
     parser.parse!(args)
     @options[:args] = args
   end

--- a/lib/rubygems/commands/exec_command.rb
+++ b/lib/rubygems/commands/exec_command.rb
@@ -79,7 +79,7 @@ to the same gem path as user-installed gems.
   def handle_options(args)
     args = add_extra_args(args)
     check_deprecated_options(args)
-    @options = Marshal.load Marshal.dump @defaults # deep copy
+    @options = Gem::Util.deep_dup @defaults
     parser.order!(args) do |v|
       # put the non-option back at the front of the list of arguments
       args.unshift(v)

--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -252,8 +252,8 @@ class Gem::ConfigFile
     @use_psych = ENV["RUBYGEMS_USE_PSYCH"] == "true" || DEFAULT_USE_PSYCH
     @credential_store = normalize_credential_store(ENV["RUBYGEMS_CREDENTIAL_STORE"], DEFAULT_CREDENTIAL_STORE)
 
-    operating_system_config = Marshal.load Marshal.dump(OPERATING_SYSTEM_DEFAULTS)
-    platform_config = Marshal.load Marshal.dump(PLATFORM_DEFAULTS)
+    operating_system_config = Gem::Util.deep_dup(OPERATING_SYSTEM_DEFAULTS)
+    platform_config = Gem::Util.deep_dup(PLATFORM_DEFAULTS)
     system_config = load_file SYSTEM_WIDE_CONFIG_FILE
     user_config = load_file config_file_name
 

--- a/lib/rubygems/ext/builder.rb
+++ b/lib/rubygems/ext/builder.rb
@@ -101,7 +101,9 @@ class Gem::Ext::Builder
 
       require "open3"
       # Set $SOURCE_DATE_EPOCH for the subprocess.
-      build_env = { "SOURCE_DATE_EPOCH" => Gem.source_date_epoch_string }.merge(env)
+      # Under Ruby::Box mkmf makes RbConfig.expand recurse until SystemStackError.
+      # Drop $RUBY_BOX last so no caller can restore it.
+      build_env = { "SOURCE_DATE_EPOCH" => Gem.source_date_epoch_string }.merge(env).merge("RUBY_BOX" => nil)
       # A single-element command would be parsed as a shell command line,
       # splitting an unquoted command path containing spaces. Use the
       # [cmdname, argv0] form to keep exec semantics.

--- a/lib/rubygems/util.rb
+++ b/lib/rubygems/util.rb
@@ -92,6 +92,26 @@ module Gem::Util
   end
 
   ##
+  # Duplicates +obj+ without Marshal, which cannot resolve Gem:: constants from
+  # the root box under Ruby::Box (RUBY_BOX=1). Hashes and arrays are copied
+  # recursively, anything else with a plain +dup+, so an object's internals stay
+  # shared with the original, as are hash keys. Shared references are not
+  # preserved, and a cyclic +obj+ raises SystemStackError.
+
+  def self.deep_dup(obj) # :nodoc:
+    case obj
+    when Hash then obj.to_h {|k, v| [k, deep_dup(v)] }
+    when Array then obj.map {|e| deep_dup(e) }
+    else
+      begin
+        obj.dup
+      rescue TypeError
+        obj
+      end
+    end
+  end
+
+  ##
   # Corrects +path+ (usually returned by `Gem::URI.parse().path` on Windows), that
   # comes with a leading slash.
 

--- a/test/rubygems/test_gem_command.rb
+++ b/test/rubygems/test_gem_command.rb
@@ -2,6 +2,7 @@
 
 require_relative "helper"
 require "rubygems/command"
+require "open3"
 
 class Gem::Command
   public :parser
@@ -398,5 +399,20 @@ ERROR:  Possible alternatives: non_existent_with_hint
     EXPECTED
 
     assert_equal expected, @ui.error
+  end
+
+  def test_gem_cli_runs_under_ruby_box
+    omit "Ruby::Box is not available" unless defined?(Ruby::Box)
+    # Ruby 4.0 resolves Gem::NameTuple from the root box and fails autoload
+    omit "Ruby::Box is too unstable before 4.1" if Gem.ruby_version < Gem::Version.new("4.1.0.a")
+
+    boxed, warning, = Open3.capture3({ "RUBY_BOX" => "1" }, Gem.ruby, "-e", "print !Ruby::Box.current.nil?")
+    assert_equal "true", boxed, "RUBY_BOX=1 no longer boxes the subprocess: #{warning}"
+
+    env = { "RUBY_BOX" => "1", "GEM_HOME" => Gem.paths.home }
+    run_gem = 'require "rubygems/gem_runner"; Gem::GemRunner.new.run(["list", "--local"])'
+    output = IO.popen(env, [*ruby_with_rubygems_in_load_path, "-e", run_gem], err: [:child, :out], &:read)
+
+    assert Process.last_status.success?, output
   end
 end

--- a/test/rubygems/test_gem_ext_builder.rb
+++ b/test/rubygems/test_gem_ext_builder.rb
@@ -194,6 +194,24 @@ install:
     assert_equal "STDIN: \"\"\n", command_output
   end
 
+  def test_class_run_removes_ruby_box_from_env
+    ENV["RUBY_BOX"] = "1"
+
+    results = []
+
+    Gem::Ext::Builder.run([Gem.ruby, "-e", 'puts ENV.key?("RUBY_BOX")'], results)
+
+    assert_equal "false\n", results.last
+  end
+
+  def test_class_run_removes_ruby_box_passed_by_caller
+    results = []
+
+    Gem::Ext::Builder.run([Gem.ruby, "-e", 'puts ENV.key?("RUBY_BOX")'], results, nil, Dir.pwd, { "RUBY_BOX" => "1" })
+
+    assert_equal "false\n", results.last
+  end
+
   def test_build_extensions
     pend "terminates on mswin" if vc_windows? && ruby_repo?
 

--- a/test/rubygems/test_gem_util.rb
+++ b/test/rubygems/test_gem_util.rb
@@ -83,4 +83,42 @@ class TestGemUtil < Gem::TestCase
     path = "/home/skillet"
     assert_equal "/home/skillet", Gem::Util.correct_for_windows_path(path)
   end
+
+  def test_deep_dup
+    defaults = {
+      args: ["--local", +"extra"],
+      document: %w[ri],
+      nested: { list: [+"a", { key: +"b" }] },
+      version: Gem::Requirement.default,
+      wrappers: true,
+      count: 1,
+      sym: :install,
+    }
+
+    copy = Gem::Util.deep_dup defaults
+
+    assert_equal defaults, copy
+    refute_same defaults, copy
+    refute_same defaults[:args], copy[:args]
+    refute_same defaults[:args][1], copy[:args][1]
+    refute_same defaults[:nested], copy[:nested]
+    refute_same defaults[:nested][:list], copy[:nested][:list]
+    refute_same defaults[:nested][:list][1], copy[:nested][:list][1]
+    refute_same defaults[:version], copy[:version]
+
+    copy[:args] << "added"
+    copy[:nested][:list][1][:key] << "!"
+
+    assert_equal ["--local", "extra"], defaults[:args]
+    assert_equal "b", defaults[:nested][:list][1][:key]
+  end
+
+  def test_deep_dup_shares_the_internals_of_other_objects
+    struct = Struct.new(:list).new([+"a"])
+
+    copy = Gem::Util.deep_dup(struct: struct)[:struct]
+
+    refute_same struct, copy
+    assert_same struct.list, copy.list
+  end
 end


### PR DESCRIPTION
Under Ruby::Box (`RUBY_BOX=1`, experimental in Ruby 4.0), every `gem` command fails to start with `ArgumentError: undefined class/module Gem::` because the builtin `Marshal` runs in the root box and cannot resolve `Gem::` constants defined in the main box (https://bugs.ruby-lang.org/issues/22090). This replaces the `Marshal.load Marshal.dump` deep copies of option defaults with a hand-written `Gem::Util.deep_dup`.

Native extension builds still fail after that because the `extconf.rb` subprocess inherits `RUBY_BOX=1` and hits infinite recursion in `RbConfig.expand` (`SystemStackError`, a known ruby-core issue). Build tools are not a target of box isolation, so `Gem::Ext::Builder.run` now unsets `RUBY_BOX` in the subprocess environment.

With both fixes, `RUBY_BOX=1 gem install` succeeds including native builds. An integration canary runs `gem list --local` under `RUBY_BOX=1` when `Ruby::Box` is available.
