### PR TITLE
Restore lockfile pinning and section handling lost in the Bundler parser switch

### DIFF
--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -349,6 +349,8 @@ class Gem::RequestSet
 
     parser = Bundler::LockfileParser.new(File.read(lock_file), lockfile_path: lock_file)
 
+    locked_versions = {}
+
     parser.specs.group_by(&:source).each do |source, specs|
       case source
       when Bundler::Source::Rubygems
@@ -357,6 +359,7 @@ class Gem::RequestSet
         lock_set = Gem::Resolver::LockSet.new(remotes)
         specs.each do |spec|
           added = lock_set.add(spec.name, spec.version.to_s, spec.platform)
+          locked_versions[spec.name] ||= spec.version
           spec.dependencies.each do |dep|
             added.each {|s| s.add_dependency dep }
           end
@@ -373,6 +376,7 @@ class Gem::RequestSet
             source.revision,
             source.submodules || false
           )
+          locked_versions[spec.name] ||= spec.version
           spec.dependencies.each {|dep| git_spec.add_dependency dep }
         end
         @sets << git_set
@@ -380,6 +384,7 @@ class Gem::RequestSet
         vendor_set = Gem::Resolver::VendorSet.new
         specs.each do |spec|
           loaded = vendor_set.add_vendor_gem(spec.name, source.path.to_s)
+          locked_versions[spec.name] ||= loaded.version
           spec.dependencies.each {|dep| loaded.dependencies << dep }
         end
         @sets << vendor_set
@@ -387,7 +392,17 @@ class Gem::RequestSet
     end
 
     parser.dependencies.each_value do |dep|
-      gem dep.name, *dep.requirement.as_list
+      requirements = dep.requirement.as_list
+
+      # A dependency the lockfile ties to a source replaces whatever it asks
+      # for with the version that source resolved, the way the parser this
+      # replaced did. For a PATH section that is the version of the gemspec on
+      # disk, not the one the lockfile records.
+      if dep.source && (version = locked_versions[dep.name])
+        requirements = [version]
+      end
+
+      gem dep.name, *requirements
     end
   ensure
     Bundler.instance_variable_set(:@root, previous_root) if defined?(previous_root)

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -346,6 +346,7 @@ class Gem::RequestSet
     # `gem install -g` lockfile can be parsed without a Bundler environment.
     previous_root = Bundler.instance_variable_get(:@root)
     Bundler.instance_variable_set(:@root, Pathname.new(File.expand_path(File.dirname(lock_file))))
+    root_swapped = true
 
     parser = Bundler::LockfileParser.new(File.read(lock_file), lockfile_path: lock_file)
 
@@ -408,7 +409,7 @@ class Gem::RequestSet
       gem dep.name, *requirements
     end
   ensure
-    Bundler.instance_variable_set(:@root, previous_root) if defined?(previous_root)
+    Bundler.instance_variable_set(:@root, previous_root) if root_swapped
   end
 
   def pretty_print(q) # :nodoc:

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -348,6 +348,14 @@ class Gem::RequestSet
     Bundler.instance_variable_set(:@root, Pathname.new(File.expand_path(File.dirname(lock_file))))
     root_swapped = true
 
+    # A PLUGIN SOURCE section otherwise sends Bundler::Plugin.from_lock looking
+    # for the plugin that handles it, which loads and runs that plugin's
+    # `plugins.rb`. Nothing here can use a plugin source anyway, so borrow the
+    # flag Bundler itself uses to keep lockfile parsing inert.
+    previous_gemfile_parse = Bundler::Plugin.instance_variable_get(:@gemfile_parse)
+    Bundler::Plugin.instance_variable_set(:@gemfile_parse, true)
+    gemfile_parse_swapped = true
+
     parser = Bundler::LockfileParser.new(File.read(lock_file), lockfile_path: lock_file)
 
     locked_versions = {}
@@ -410,6 +418,7 @@ class Gem::RequestSet
     end
   ensure
     Bundler.instance_variable_set(:@root, previous_root) if root_swapped
+    Bundler::Plugin.instance_variable_set(:@gemfile_parse, previous_gemfile_parse) if gemfile_parse_swapped
   end
 
   def pretty_print(q) # :nodoc:

--- a/lib/rubygems/request_set.rb
+++ b/lib/rubygems/request_set.rb
@@ -354,7 +354,10 @@ class Gem::RequestSet
     parser.specs.group_by(&:source).each do |source, specs|
       case source
       when Bundler::Source::Rubygems
-        remotes = source.remotes.map {|remote| Gem::Source.new(remote.to_s) }
+        # Bundler::Source::Rubygems stores remotes in reverse of the lockfile
+        # order (Bundler::Source::Rubygems#to_lock reverses them back), so
+        # restore the lockfile order here.
+        remotes = source.remotes.reverse.map {|remote| Gem::Source.new(remote.to_s) }
         remotes << Gem::Source.new(Gem::DEFAULT_HOST) if remotes.empty?
         lock_set = Gem::Resolver::LockSet.new(remotes)
         specs.each do |spec|

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -385,6 +385,39 @@ ruby "0"
     assert_equal [dep("a", "~> 1.0")], spec.dependencies
   end
 
+  def test_load_gemdeps_with_lockfile_gem_section_multiple_remotes
+    rs = Gem::RequestSet.new
+
+    File.open "gem.deps.rb", "w" do |io|
+      io.puts 'gem "a"'
+    end
+
+    File.open "gem.deps.rb.lock", "w" do |io|
+      io.puts <<~LOCKFILE
+        GEM
+          remote: https://gems.example/
+          remote: https://other.example/
+          specs:
+            a (2)
+
+        PLATFORMS
+          #{Gem::Platform::RUBY}
+
+        DEPENDENCIES
+          a
+      LOCKFILE
+    end
+
+    rs.load_gemdeps "gem.deps.rb"
+
+    lock_set = rs.sets.find {|set| Gem::Resolver::LockSet === set }
+    refute_nil lock_set, "LockSet should be created from GEM section"
+    assert_equal %w[a-2], lock_set.specs.map(&:full_name)
+
+    assert_equal %w[https://gems.example/ https://other.example/],
+                 lock_set.specs.flat_map {|s| s.sources.map {|src| src.uri.to_s } }
+  end
+
   def test_load_gemdeps_with_lockfile_git_section
     rs = Gem::RequestSet.new
 

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -354,6 +354,7 @@ ruby "0"
             a (1)
             b (1)
               a (~> 1.0)
+            b (3-x86_64-linux)
 
         PLATFORMS
           #{Gem::Platform::RUBY}
@@ -365,9 +366,23 @@ ruby "0"
 
     rs.load_gemdeps "gem.deps.rb"
 
+    assert_equal [dep("b")], rs.dependencies
+
     lock_set = rs.sets.find {|set| Gem::Resolver::LockSet === set }
     refute_nil lock_set, "LockSet should be created from GEM section"
-    assert_equal %w[a-1 b-1], lock_set.specs.map(&:full_name).sort
+    assert_equal %w[a-1 b-1 b-3], lock_set.specs.map(&:full_name).sort
+
+    expected = [
+      Gem::Platform::RUBY,
+      Gem::Platform::RUBY,
+      Gem::Platform.new("x86_64-linux"),
+    ]
+
+    assert_equal expected, lock_set.specs.sort_by(&:full_name).map(&:platform)
+
+    spec = lock_set.specs.find {|s| s.full_name == "b-1" }
+
+    assert_equal [dep("a", "~> 1.0")], spec.dependencies
   end
 
   def test_load_gemdeps_with_lockfile_git_section
@@ -383,7 +398,9 @@ ruby "0"
           remote: git://example/a.git
           revision: deadbeef
           specs:
-            a (1)
+            a (2)
+              b (>= 3)
+              c
 
         PLATFORMS
           #{Gem::Platform::RUBY}
@@ -395,9 +412,42 @@ ruby "0"
 
     rs.load_gemdeps "gem.deps.rb"
 
+    assert_equal [dep("a", "= 2")], rs.dependencies
+
     git_set = rs.sets.find {|set| Gem::Resolver::GitSet === set }
     refute_nil git_set, "GitSet should be created from GIT section"
-    assert_includes git_set.specs.keys, "a"
+    assert_equal %w[a-2], git_set.specs.values.map(&:full_name)
+
+    assert_equal [dep("b", ">= 3"), dep("c")],
+                 git_set.specs.values.first.dependencies
+  end
+
+  def test_load_gemdeps_with_lockfile_git_section_prerelease
+    rs = Gem::RequestSet.new
+
+    File.open "gem.deps.rb", "w" do |io|
+      io.puts 'gem "a", :git => "git://example/a.git"'
+    end
+
+    File.open "gem.deps.rb.lock", "w" do |io|
+      io.puts <<~LOCKFILE
+        GIT
+          remote: git://example/a.git
+          revision: deadbeef
+          specs:
+            a (1.0.0.pre1)
+
+        PLATFORMS
+          #{Gem::Platform::RUBY}
+
+        DEPENDENCIES
+          a!
+      LOCKFILE
+    end
+
+    rs.load_gemdeps "gem.deps.rb"
+
+    assert_equal [dep("a", "= 1.0.0.pre1")], rs.dependencies
   end
 
   def test_load_gemdeps_with_lockfile_path_section
@@ -426,9 +476,44 @@ ruby "0"
 
     rs.load_gemdeps "gem.deps.rb"
 
+    assert_equal [dep("a", "= 1")], rs.dependencies
+
     vendor_set = rs.sets.find {|set| Gem::Resolver::VendorSet === set }
     refute_nil vendor_set, "VendorSet should be created from PATH section"
     assert_equal %w[a-1], vendor_set.specs.values.map(&:full_name)
+  end
+
+  def test_load_gemdeps_with_lockfile_path_section_newer_than_lockfile
+    _, _, directory = vendor_gem "a", 2
+
+    rs = Gem::RequestSet.new
+
+    File.open "gem.deps.rb", "w" do |io|
+      io.puts "gem \"a\", :path => #{directory.inspect}"
+    end
+
+    File.open "gem.deps.rb.lock", "w" do |io|
+      io.puts <<~LOCKFILE
+        PATH
+          remote: #{directory}
+          specs:
+            a (1)
+
+        PLATFORMS
+          #{Gem::Platform::RUBY}
+
+        DEPENDENCIES
+          a!
+      LOCKFILE
+    end
+
+    rs.load_gemdeps "gem.deps.rb"
+
+    assert_equal [dep("a", "= 2")], rs.dependencies
+
+    vendor_set = rs.sets.find {|set| Gem::Resolver::VendorSet === set }
+    assert_equal %w[a-2], vendor_set.specs.values.map(&:full_name)
+    assert_equal %w[a-2], vendor_set.find_all(dep("a", "= 2")).map(&:full_name)
   end
 
   def test_load_gemdeps_with_missing_lockfile

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -549,6 +549,69 @@ ruby "0"
     assert_equal %w[a-2], vendor_set.find_all(dep("a", "= 2")).map(&:full_name)
   end
 
+  def test_load_lockfile_does_not_load_plugins_for_a_plugin_source_section
+    require "bundler"
+    require "bundler/plugin"
+
+    plugin = File.join @tempdir, ".bundle", "plugin", "plugins", "example"
+    loaded = File.join @tempdir, "plugin-was-loaded"
+
+    FileUtils.mkdir_p File.join(plugin, "lib")
+
+    File.open File.join(@tempdir, "Gemfile"), "w" do |io|
+      io.puts 'source "https://rubygems.org"'
+    end
+
+    File.open File.join(plugin, "plugins.rb"), "w" do |io|
+      io.puts "File.write #{loaded.dump}, \"loaded\""
+      io.puts "class ExampleSource"
+      io.puts "  include Bundler::Plugin::API::Source"
+      io.puts "end"
+      io.puts 'Bundler::Plugin::API.source("example_type", ExampleSource)'
+    end
+
+    File.open File.join(@tempdir, ".bundle", "plugin", "index"), "w" do |io|
+      io.puts <<~INDEX
+        ---
+        commands:
+        hooks:
+        load_paths:
+          example:
+          - plugins/example/lib
+        plugin_paths:
+          example: plugins/example
+        sources:
+          example_type: example
+      INDEX
+    end
+
+    File.open "gem.deps.rb.lock", "w" do |io|
+      io.puts <<~LOCKFILE
+        PLUGIN SOURCE
+          remote: https://gems.example/
+          type: example_type
+          specs:
+            a (1)
+
+        PLATFORMS
+          #{Gem::Platform::RUBY}
+
+        DEPENDENCIES
+          a!
+      LOCKFILE
+    end
+
+    Bundler::Plugin.reset!
+
+    rs = Gem::RequestSet.new
+    rs.load_lockfile "gem.deps.rb.lock"
+
+    assert_path_not_exist loaded
+    assert_equal [dep("a")], rs.dependencies
+  ensure
+    Bundler::Plugin.reset!
+  end
+
   def test_load_lockfile_keeps_bundler_root_when_it_cannot_be_swapped
     require "bundler"
 

--- a/test/rubygems/test_gem_request_set.rb
+++ b/test/rubygems/test_gem_request_set.rb
@@ -549,6 +549,46 @@ ruby "0"
     assert_equal %w[a-2], vendor_set.find_all(dep("a", "= 2")).map(&:full_name)
   end
 
+  def test_load_lockfile_keeps_bundler_root_when_it_cannot_be_swapped
+    require "bundler"
+
+    previous_root = Bundler.instance_variable_get(:@root)
+    Bundler.instance_variable_set(:@root, Pathname.new(@tempdir))
+
+    rs = Gem::RequestSet.new
+    def rs.require(*)
+      raise LoadError
+    end
+
+    assert_raise LoadError do
+      rs.load_lockfile "gem.deps.rb.lock"
+    end
+
+    assert_equal Pathname.new(@tempdir), Bundler.instance_variable_get(:@root)
+  ensure
+    Bundler.instance_variable_set(:@root, previous_root)
+  end
+
+  def test_load_lockfile_restores_bundler_root_when_parsing_fails
+    require "bundler"
+
+    previous_root = Bundler.instance_variable_get(:@root)
+    Bundler.instance_variable_set(:@root, Pathname.new(File.join(@tempdir, "elsewhere")))
+
+    File.open "gem.deps.rb.lock", "w" do |io|
+      io.puts "<<<<<<< HEAD"
+    end
+
+    assert_raise Bundler::LockfileError do
+      Gem::RequestSet.new.load_lockfile "gem.deps.rb.lock"
+    end
+
+    assert_equal Pathname.new(File.join(@tempdir, "elsewhere")),
+                 Bundler.instance_variable_get(:@root)
+  ensure
+    Bundler.instance_variable_set(:@root, previous_root)
+  end
+
   def test_load_gemdeps_with_missing_lockfile
     rs = Gem::RequestSet.new
 


### PR DESCRIPTION
The parser removed in #9564 converted `a!` entries in the DEPENDENCIES section into a `= <locked version>` requirement. Bundler's `LockfileParser` records the pinned source on the dependency instead and leaves the requirement at `>= 0`, and `Gem::RequestSet#load_lockfile` ignores the source, so `gem install -g` could resolve a newer published version instead of the locked GIT or PATH one.

Restoring the assertions the old parser test carried surfaced three more regressions. `Bundler::Source::Rubygems` stores remotes in reverse of the lockfile order, flipping source priority for GEM sections with multiple remotes. `Bundler::Plugin.from_lock` raises `UnknownSourceError` for `PLUGIN SOURCE` sections unless the plugin is installed, aborting `gem install -g` where the old parser skipped the section. `defined?(previous_root)` in the `ensure` is true even when the assignment never ran, so an early failure could reset Bundler's root to nil.
