### PR TITLE
Fix relative gemspec paths being expanded twice

### DIFF
--- a/lib/bundler.rb
+++ b/lib/bundler.rb
@@ -527,11 +527,11 @@ module Bundler
     end
 
     def load_gemspec_uncached(file, validate = false)
-      path = Pathname.new(file)
-      contents = read_file(file)
+      path = Pathname.new(file).expand_path
+      contents = read_file(path.to_s)
       spec = eval_gemspec(path, contents)
       return unless spec
-      spec.loaded_from = path.expand_path.to_s
+      spec.loaded_from = path.to_s
       Bundler.rubygems.validate(spec) if validate
       spec
     end
@@ -646,7 +646,9 @@ module Bundler
         eval_yaml_gemspec(path, contents)
       else
         # Eval the gemspec from its parent directory, because some gemspecs
-        # depend on "./" relative paths.
+        # depend on "./" relative paths. The caller expands `path` first, since
+        # expanding it here would resolve against the gemspec directory once
+        # the chdir is active.
         SharedHelpers.chdir(path.dirname.to_s) do
           # TOPLEVEL_BINDING always belongs to the main box, so inside a
           # Ruby::Box use a binding from the box Bundler is loaded in, where
@@ -656,7 +658,7 @@ module Bundler
           else
             TOPLEVEL_BINDING.dup
           end
-          eval(contents, eval_binding, path.expand_path.to_s)
+          eval(contents, eval_binding, path.to_s)
         end
       end
     rescue ScriptError, StandardError => e

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -128,6 +128,49 @@ RSpec.describe Bundler do
       expect(subject.loaded_from).to eq(app_gemspec_path.expand_path.to_s)
     end
 
+    context "with a relative path" do
+      before do
+        create_file(tmp("nested/test.gemspec"), <<~GEMSPEC)
+          Gem::Specification.new do |gem|
+            gem.name = "nested"
+            gem.summary = __FILE__
+          end
+        GEMSPEC
+      end
+
+      it "resolves a relative gemspec path against the original working directory" do
+        spec, expanded = Dir.chdir(tmp) do
+          [Bundler.load_gemspec_uncached("nested/test.gemspec"), File.expand_path("nested/test.gemspec")]
+        end
+
+        expect(spec.summary).to eq(expanded)
+        expect(spec.loaded_from).to eq(expanded)
+      end
+    end
+
+    context "with a relative path whose \"..\" crosses a symlink", if: !Gem.win_platform? do
+      before do
+        create_file(tmp("lexical/target.gemspec"), <<~GEMSPEC)
+          Gem::Specification.new do |gem|
+            gem.name = "lexical"
+            gem.summary = __FILE__
+          end
+        GEMSPEC
+        create_file(tmp("lexical/physical/target.gemspec"), "raise \"read the physical path\"")
+        tmp("lexical/physical/elsewhere").mkpath
+        File.symlink(tmp("lexical/physical/elsewhere"), tmp("lexical/link"))
+      end
+
+      it "resolves the path lexically" do
+        spec, expanded = Dir.chdir(tmp("lexical")) do
+          [Bundler.load_gemspec_uncached("link/../target.gemspec"), File.expand_path("link/../target.gemspec")]
+        end
+
+        expect(spec.summary).to eq(expanded)
+        expect(spec.loaded_from).to eq(expanded)
+      end
+    end
+
     context "validate is true" do
       subject { Bundler.load_gemspec_uncached(app_gemspec_path, true) }
 


### PR DESCRIPTION
`Bundler.eval_gemspec` computed `path.expand_path` inside its `SharedHelpers.chdir(path.dirname.to_s)` block, so a relative path resolved against the gemspec directory instead of the original working directory. Loading `foo/foo.gemspec` handed `eval` a file name of `<root>/foo/foo/foo.gemspec`, which breaks `__FILE__`, `__dir__` and `require_relative` inside the gemspec as well as every `GemspecError` backtrace line, and disagrees with the `loaded_from` that `load_gemspec_uncached` computes outside the block.

Expanding the path once in `load_gemspec_uncached` fixes it, and `read_file` now opens that same expanded path so the file Bundler reads is the file it evaluates and records. `Pathname#expand_path` collapses `..` lexically, which is the rule `load_gemspec` has always used for its cache key, so all five of the read, the chdir, the eval file name, `loaded_from`, and the cache key now agree. A relative path whose `..` crosses a symlink previously produced three different answers among them.

Most callers are unaffected because they pass a path `File.expand_path` has already normalized. The exception is `Gem::PathSupport`, which does not expand `GEM_SPEC_CACHE`, so a relative value there reaches `Bundler.load_gemspec` through `gemspec_cached_path` as a multi-segment relative path and hits the bug. Plugin sources returning relative paths from `fetch_gemspec_files` and external callers of `Bundler.load_gemspec` reach it too.

I found this while reviewing #9809 and it was out of scope there.
