### PR TITLE
Rename the no_prune setting to keep_outdated_cache

### DIFF
--- a/lib/bundler/cli.rb
+++ b/lib/bundler/cli.rb
@@ -276,9 +276,11 @@ module Bundler
     method_option "with", type: :array, banner: "Include gems that are part of the specified named group (removed)."
     method_option "cooldown", type: :numeric, banner: "Only consider gem versions published at least N days ago. Use 0 to disable."
     def install
-      %w[clean deployment frozen no-prune path shebang without with].each do |option|
+      %w[clean deployment frozen path shebang without with].each do |option|
         remembered_flag_deprecation(option)
       end
+
+      remembered_flag_deprecation("no-prune", option_name: "keep_outdated_cache")
 
       print_remembered_flag_deprecation("--system", "path.system", "true") if ARGV.include?("--system")
 
@@ -473,9 +475,8 @@ module Bundler
       print_remembered_flag_deprecation("--all", "cache_all", "true") if ARGV.include?("--all")
       print_remembered_flag_deprecation("--no-all", "cache_all", "false") if ARGV.include?("--no-all")
 
-      %w[frozen no-prune].each do |option|
-        remembered_flag_deprecation(option)
-      end
+      remembered_flag_deprecation("frozen")
+      remembered_flag_deprecation("no-prune", option_name: "keep_outdated_cache")
 
       if flag_passed?("--path")
         removed_message =

--- a/lib/bundler/cli/install.rb
+++ b/lib/bundler/cli/install.rb
@@ -118,8 +118,6 @@ module Bundler
       Bundler::CLI::Common.validate_cooldown!(options["cooldown"])
       Bundler.settings.set_command_option_if_given :cooldown, options["cooldown"]
 
-      Bundler.settings.set_command_option_if_given :no_prune, options["no-prune"]
-
       Bundler.settings.set_command_option_if_given :no_install, options["no-install"]
 
       Bundler.settings.set_command_option_if_given :clean, options["clean"]

--- a/lib/bundler/man/bundle-config.1
+++ b/lib/bundler/man/bundle-config.1
@@ -151,6 +151,8 @@ The store can also be selected per host with \fBcredential_store\.<host>\fR (\fB
 .IP "\(bu" 4
 \fBjobs\fR (\fBBUNDLE_JOBS\fR): The number of gems Bundler can download and install in parallel\. Defaults to the number of available processors\.
 .IP "\(bu" 4
+\fBkeep_outdated_cache\fR (\fBBUNDLE_KEEP_OUTDATED_CACHE\fR): Whether Bundler should leave outdated gems unpruned when caching\. Defaults to false\.
+.IP "\(bu" 4
 \fBlockfile\fR (\fBBUNDLE_LOCKFILE\fR): The path to the lockfile that bundler should use\. By default, Bundler adds \fB\.lock\fR to the end of the \fBgemfile\fR entry\. Can be set to \fBfalse\fR in the Gemfile to disable lockfile creation entirely (see gemfile(5))\.
 .IP "\(bu" 4
 \fBlockfile_checksums\fR (\fBBUNDLE_LOCKFILE_CHECKSUMS\fR): Whether Bundler should include a checksums section in new lockfiles, to protect from compromised gem sources\. Defaults to true\. Bundler's own checksum is only included when its \fB\.gem\fR file is cached, which may not be the case when Bundler is installed as a default gem\.
@@ -161,7 +163,7 @@ The store can also be selected per host with \fBcredential_store\.<host>\fR (\fB
 .IP "\(bu" 4
 \fBno_install_plugin\fR (\fBBUNDLE_NO_INSTALL_PLUGIN\fR): Whether Bundler should skip installing RubyGems plugins during installation\. When set, plugin files are not written to the plugins directory\. To install plugins later, unset this setting and run \fBbundle pristine <gem>\fR\.
 .IP "\(bu" 4
-\fBno_prune\fR (\fBBUNDLE_NO_PRUNE\fR): Whether Bundler should leave outdated gems unpruned when caching\.
+\fBno_prune\fR (\fBBUNDLE_NO_PRUNE\fR): Deprecated name for \fBkeep_outdated_cache\fR\. Each priority level is checked for \fBkeep_outdated_cache\fR and then for \fBno_prune\fR, and the first value found wins\. \fBno_prune\fR will be removed in Bundler 5\.
 .IP "\(bu" 4
 \fBonly\fR (\fBBUNDLE_ONLY\fR): A space\-separated list of groups to install only gems of the specified groups\. Please check carefully if you want to install also gems without a group, because they get put inside \fBdefault\fR group\. For example \fBonly test:default\fR will install all gems specified in test group and without one\.
 .IP "\(bu" 4

--- a/lib/bundler/man/bundle-config.1.ronn
+++ b/lib/bundler/man/bundle-config.1.ronn
@@ -276,6 +276,9 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `jobs` (`BUNDLE_JOBS`):
    The number of gems Bundler can download and install in parallel.
    Defaults to the number of available processors.
+* `keep_outdated_cache` (`BUNDLE_KEEP_OUTDATED_CACHE`):
+   Whether Bundler should leave outdated gems unpruned when caching. Defaults
+   to false.
 * `lockfile` (`BUNDLE_LOCKFILE`):
    The path to the lockfile that bundler should use. By default, Bundler adds
    `.lock` to the end of the `gemfile` entry. Can be set to `false` in the
@@ -295,7 +298,9 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
    When set, plugin files are not written to the plugins directory.
    To install plugins later, unset this setting and run `bundle pristine <gem>`.
 * `no_prune` (`BUNDLE_NO_PRUNE`):
-   Whether Bundler should leave outdated gems unpruned when caching.
+   Deprecated name for `keep_outdated_cache`. Each priority level is checked
+   for `keep_outdated_cache` and then for `no_prune`, and the first value
+   found wins. `no_prune` will be removed in Bundler 5.
 * `only` (`BUNDLE_ONLY`):
    A space-separated list of groups to install only gems of the specified groups.
    Please check carefully if you want to install also gems without a group, because

--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -148,7 +148,7 @@ module Bundler
         FileUtils.touch(File.expand_path("../.bundlecache", git_dir))
       end
 
-      prune_cache(cache_path) unless Bundler.settings[:no_prune]
+      prune_cache(cache_path) unless Bundler.settings[:keep_outdated_cache]
     end
 
     def prune_cache(cache_path)

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -29,6 +29,7 @@ module Bundler
       ignore_messages
       init_gems_rb
       inline
+      keep_outdated_cache
       lockfile_checksums
       no_build_extension
       no_install
@@ -95,6 +96,14 @@ module Bundler
       "BUNDLE_UPDATE_REQUIRES_ALL_FLAG" => false,
     }.freeze
 
+    ##
+    # Settings renamed in Bundler 4, mapping the current name to the one it
+    # replaced. The old name is still read, and goes away in Bundler 5.
+
+    RENAMED_KEYS = {
+      "keep_outdated_cache" => "no_prune",
+    }.freeze
+
     def initialize(root = nil)
       @root            = root
       @local_config    = load_config(local_config_file)
@@ -111,16 +120,7 @@ module Bundler
     end
 
     def [](name)
-      key = key_for(name)
-
-      value = nil
-      configs.each do |_, config|
-        value = config[key]
-        next if value.nil?
-        break
-      end
-
-      converted_value(value, name)
+      converted_value(configured_value(name), name)
     end
 
     def set_command_option(key, value)
@@ -396,6 +396,35 @@ module Bundler
 
     def value_for(name, config)
       converted_value(config[key_for(name)], name)
+    end
+
+    ##
+    # A renamed setting is resolved one level at a time rather than by looking
+    # for the current name everywhere first, so that the old name keeps the
+    # documented priority order: an old name set locally still beats a current
+    # name set globally.
+
+    def configured_value(name)
+      key = key_for(name)
+      old_name = RENAMED_KEYS[self.class.key_to_s(name)]
+      old_key = key_for(old_name) if old_name
+
+      configs.each do |_, config|
+        value = config[key]
+        return value unless value.nil?
+
+        next if old_key.nil?
+
+        value = config[old_key]
+        next if value.nil?
+
+        SharedHelpers.feature_deprecated! "The `#{old_name}` setting has been renamed to `#{name}` and will be " \
+                                          "removed in Bundler 5. Use `#{name}` instead."
+
+        return value
+      end
+
+      nil
     end
 
     def parent_setting_for(name)

--- a/spec/bundler/settings_spec.rb
+++ b/spec/bundler/settings_spec.rb
@@ -136,6 +136,28 @@ that would suck --ehhh=oh geez it looks like i might have broken bundler somehow
       end
     end
 
+    context "when the setting has been renamed" do
+      it "reads the value set under the old name" do
+        settings.set_local :no_prune, "true"
+
+        expect(settings[:keep_outdated_cache]).to be true
+      end
+
+      it "prefers the current name set at the same level" do
+        settings.set_local :no_prune, "true"
+        settings.set_local :keep_outdated_cache, "false"
+
+        expect(settings[:keep_outdated_cache]).to be false
+      end
+
+      it "prefers the old name set at a higher priority level" do
+        settings.set_global :keep_outdated_cache, "false"
+        settings.set_local :no_prune, "true"
+
+        expect(settings[:keep_outdated_cache]).to be true
+      end
+    end
+
     context "when it's not possible to create the settings directory" do
       it "raises an PermissionError with explanation" do
         settings_dir = settings.send(:local_config_file).dirname

--- a/spec/cache/gems_spec.rb
+++ b/spec/cache/gems_spec.rb
@@ -266,6 +266,47 @@ RSpec.describe "bundle cache" do
       expect(cached_gem("activesupport-2.3.2")).not_to exist
     end
 
+    it "keeps outdated .gems when keep_outdated_cache is set" do
+      setup_main_repo
+      bundle_config "keep_outdated_cache true"
+
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        gem "myrack"
+      G
+      expect(cached_gem("myrack-1.0.0")).to exist
+      expect(cached_gem("actionpack-2.3.2")).to exist
+      expect(cached_gem("activesupport-2.3.2")).to exist
+    end
+
+    it "keeps outdated .gems when only the deprecated no_prune is set" do
+      setup_main_repo
+      bundle_config "no_prune true"
+
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        gem "myrack"
+      G
+      expect(cached_gem("myrack-1.0.0")).to exist
+      expect(cached_gem("actionpack-2.3.2")).to exist
+      expect(cached_gem("activesupport-2.3.2")).to exist
+      expect(deprecations.count {|d| d.include?("no_prune") }).to eq 1
+    end
+
+    it "lets keep_outdated_cache win over the deprecated no_prune" do
+      setup_main_repo
+      bundle_config "no_prune true"
+      bundle_config "keep_outdated_cache false"
+
+      install_gemfile <<-G
+        source "https://gem.repo2"
+        gem "myrack"
+      G
+      expect(cached_gem("actionpack-2.3.2")).not_to exist
+      expect(cached_gem("activesupport-2.3.2")).not_to exist
+      expect(err).not_to include("no_prune")
+    end
+
     it "removes .gems when gem changes to git source" do
       setup_main_repo
       build_git "myrack"

--- a/spec/other/major_deprecation_spec.rb
+++ b/spec/other/major_deprecation_spec.rb
@@ -255,6 +255,24 @@ RSpec.describe "major deprecations" do
     end
   end
 
+  context "bundle config no_prune" do
+    before do
+      install_gemfile <<-G
+        source "https://gem.repo1"
+        gem "myrack"
+      G
+
+      bundle_config "no_prune true"
+      bundle :cache
+    end
+
+    it "warns that the setting has been renamed" do
+      expect(deprecations).to include(
+        "The `no_prune` setting has been renamed to `keep_outdated_cache` and will be removed in Bundler 5. Use `keep_outdated_cache` instead."
+      )
+    end
+  end
+
   context "bundle cache --no-prune" do
     before do
       gemfile <<-G
@@ -269,7 +287,7 @@ RSpec.describe "major deprecations" do
       expect(err).to include(
         "The `--no-prune` flag has been removed because it relied on being " \
         "remembered across bundler invocations, which bundler no longer " \
-        "does. Instead please use `bundle config set no_prune true`, " \
+        "does. Instead please use `bundle config set keep_outdated_cache true`, " \
         "and stop using this flag"
       )
     end
@@ -448,7 +466,7 @@ RSpec.describe "major deprecations" do
       "deployment" => ["deployment", "true"],
       "frozen" => ["frozen", "true"],
       "no-deployment" => ["deployment", "false"],
-      "no-prune" => ["no_prune", "true"],
+      "no-prune" => ["keep_outdated_cache", "true"],
       "path" => ["path", "'vendor/bundle'"],
       "shebang" => ["shebang", "'ruby27'"],
       "system" => ["path.system", "true"],


### PR DESCRIPTION
`no_prune` only decides whether `bundle cache` keeps `.gem` files that dropped out of the resolution, and naming it after the negation of `prune` made that hard to read. A separate `prune` setting is on its way, so the vocabulary needs sorting out before the two collide.

`keep_outdated_cache` is the new name, with the same polarity and the same default of false. Bundler 4 still reads `no_prune`, and each priority level is checked for `keep_outdated_cache` first and then for `no_prune`, so an old name set locally still beats a new name set globally the way the documented order promises. Reading a value through the old name prints a deprecation warning. `no_prune` goes away in Bundler 5. The `--no-prune` flag, already removed in favour of a config key, keeps behaving the same way and now names the new key in its error message.
