### PR TITLE
Error out when `bundle init --gemspec` gets no specification

### DIFF
--- a/lib/bundler/cli/init.rb
+++ b/lib/bundler/cli/init.rb
@@ -26,6 +26,10 @@ module Bundler
         end
 
         spec = Bundler.load_gemspec_uncached(gemspec)
+        unless spec
+          Bundler.ui.error "Gem specification #{gemspec} did not produce a specification"
+          exit 1
+        end
 
         File.open(gemfile, "wb") do |file|
           file << "# Generated from #{gemspec}\n"

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -116,6 +116,16 @@ RSpec.describe "bundle init" do
         expect(err).to include("There was an error while loading `test.gemspec`")
       end
     end
+
+    context "when gemspec file does not define a specification" do
+      it "notifies the user that no specification was produced" do
+        FileUtils.touch(spec_file)
+
+        bundle :init, gemspec: spec_file, raise_on_error: false
+        expect(err).to include("Gem specification #{spec_file} did not produce a specification")
+        expect(bundled_app_gemfile).not_to exist
+      end
+    end
   end
 
   context "when init_gems_rb setting is enabled" do


### PR DESCRIPTION
`Bundler.load_gemspec_uncached` returns nil when the gemspec evaluates to nil, which is what an empty gemspec file does. Every caller guards against that except `CLI::Init`, which passed the result straight to `spec.to_gemfile`, so `bundle init --gemspec=empty.gemspec` printed a `NoMethodError` backtrace instead of a Bundler error and left behind a Gemfile holding only the generated header. Adding the missing guard before the Gemfile is opened makes the command report the problem and exit 1 without writing anything.
