### PR TITLE
Ignore plugin index entries that point outside the plugin root

### DIFF
--- a/lib/bundler/plugin/index.rb
+++ b/lib/bundler/plugin/index.rb
@@ -231,7 +231,7 @@ module Bundler
       end
 
       # Expanded here, not by the caller: what gets stored stays joined, because
-      # the rest of the class matches it against Plugin.root as written.
+      # #installed_in_plugin_root? matches it against Plugin.root as written.
       def contained_in?(path, base)
         path = File.expand_path(path)
         base = File.expand_path(base)
@@ -264,12 +264,9 @@ module Bundler
         pathname = Pathname.new(path)
         return path unless pathname.absolute?
 
-        base_path = Pathname.new(base)
-        if pathname == base_path || pathname.to_s.start_with?(base_path.to_s + File::SEPARATOR)
-          pathname.relative_path_from(base_path).to_s
-        else
-          path
-        end
+        return path unless contained_in?(pathname.to_s, base)
+
+        pathname.relative_path_from(Pathname.new(base)).to_s
       end
 
       def absolutize_path(path, base)

--- a/lib/bundler/plugin/index.rb
+++ b/lib/bundler/plugin/index.rb
@@ -176,11 +176,15 @@ module Bundler
           # older Bundler versions, which dumped empty hashes as a bare key.
           index = Gem::YAMLSerializer.load(data) || {}
 
-          @commands.merge!(index["commands"] || {})
-          @hooks.merge!(index["hooks"] || {})
-          @load_paths.merge!(transform_index_paths(index["load_paths"]) {|p| absolutize_path(p, base) })
-          @plugin_paths.merge!(transform_index_paths(index["plugin_paths"]) {|p| absolutize_path(p, base) })
-          @sources.merge!(index["sources"] || {}) unless global
+          escaping = escaping_plugins(index, base)
+          hooks = (index["hooks"] || {}).transform_values {|names| Array(names) - escaping }
+
+          @commands.merge!(owned_by(index["commands"] || {}, escaping))
+          # An event whose plugins all escaped is left out rather than merged in empty.
+          @hooks.merge!(hooks.reject {|_, names| names.empty? })
+          @load_paths.merge!(named(transform_index_paths(index["load_paths"]) {|p| absolutize_path(p, base) }, escaping))
+          @plugin_paths.merge!(named(transform_index_paths(index["plugin_paths"]) {|p| absolutize_path(p, base) }, escaping))
+          @sources.merge!(owned_by(index["sources"] || {}, escaping)) unless global
         end
       end
 
@@ -207,6 +211,41 @@ module Bundler
 
       def base_for_index(global)
         global ? Plugin.global_root : Plugin.root
+      end
+
+      # A relative path only means anything inside the root, so an entry that escapes is not one Bundler installed.
+      def escaping_plugins(index, base)
+        names = []
+
+        %w[load_paths plugin_paths].each do |key|
+          (index[key] || {}).each do |name, value|
+            escapes = Array(value).any? do |path|
+              !Pathname.new(path).absolute? && !contained_in?(absolutize_path(path, base), base)
+            end
+
+            names << name if escapes
+          end
+        end
+
+        names.uniq
+      end
+
+      # Expanded here, not by the caller: what gets stored stays joined, because
+      # the rest of the class matches it against Plugin.root as written.
+      def contained_in?(path, base)
+        path = File.expand_path(path)
+        base = File.expand_path(base)
+
+        path == base || path.start_with?("#{base}#{File::SEPARATOR}")
+      end
+
+      # commands and sources are keyed by what they provide, load_paths and plugin_paths by the plugin.
+      def owned_by(mapping, names)
+        mapping.reject {|_, plugin| names.include?(plugin) }
+      end
+
+      def named(mapping, names)
+        mapping.reject {|plugin, _| names.include?(plugin) }
       end
 
       def transform_index_paths(paths)

--- a/spec/bundler/plugin/index_spec.rb
+++ b/spec/bundler/plugin/index_spec.rb
@@ -277,6 +277,15 @@ RSpec.describe Bundler::Plugin::Index do
       expect(new_index.load_paths(plugin_name)).to eq([plugin_root.join("~nosuchuser", "lib").to_s])
     end
 
+    it "keeps an absolute path that only looks like it is under the plugin root" do
+      escaping_path = File.join(Bundler::Plugin.root.to_s, "..", "..", "escaping-plugin")
+
+      index.register_plugin("escaping-plugin", escaping_path, [File.join(escaping_path, "lib")], [], [], [])
+
+      new_index = Index.new
+      expect(new_index.installed?("escaping-plugin")).to eq(escaping_path)
+    end
+
     it "keeps paths outside the plugin root as absolute" do
       outside_path = tmp.join("outside", "external-plugin")
       FileUtils.mkdir_p(outside_path.join("lib"))

--- a/spec/bundler/plugin/index_spec.rb
+++ b/spec/bundler/plugin/index_spec.rb
@@ -238,6 +238,45 @@ RSpec.describe Bundler::Plugin::Index do
       expect(new_index.load_paths(plugin_name)).to eq([plugin_root.join(plugin_name, "lib").to_s])
     end
 
+    it "ignores entries that climb out only after an interior parent reference" do
+      require "rubygems/yaml_serializer"
+
+      escaping_index = {
+        "commands" => {},
+        "hooks" => {},
+        "load_paths" => { "escaping-plugin" => [File.join("escaping-plugin", "..", "..", "elsewhere", "lib")] },
+        "plugin_paths" => { "escaping-plugin" => File.join("escaping-plugin", "..", "..", "elsewhere") },
+        "sources" => {},
+      }
+
+      File.open(index.index_file, "w") {|f| f.puts Gem::YAMLSerializer.dump(escaping_index) }
+
+      new_index = Index.new
+
+      expect(new_index.installed?("escaping-plugin")).to be_nil
+      expect(new_index.load_paths("escaping-plugin")).to be_nil
+    end
+
+    it "reads a leading tilde in a relative path literally" do
+      require "rubygems/yaml_serializer"
+
+      plugin_root = Bundler::Plugin.root
+
+      tilde_index = {
+        "commands" => {},
+        "hooks" => {},
+        "load_paths" => { plugin_name => [File.join("~nosuchuser", "lib")] },
+        "plugin_paths" => { plugin_name => "~nosuchuser" },
+        "sources" => {},
+      }
+
+      File.open(index.index_file, "w") {|f| f.puts Gem::YAMLSerializer.dump(tilde_index) }
+
+      new_index = Index.new
+      expect(new_index.plugin_path(plugin_name)).to eq(plugin_root.join("~nosuchuser"))
+      expect(new_index.load_paths(plugin_name)).to eq([plugin_root.join("~nosuchuser", "lib").to_s])
+    end
+
     it "keeps paths outside the plugin root as absolute" do
       outside_path = tmp.join("outside", "external-plugin")
       FileUtils.mkdir_p(outside_path.join("lib"))
@@ -249,6 +288,70 @@ RSpec.describe Bundler::Plugin::Index do
 
       expect(data["plugin_paths"]["external-plugin"]).to eq(outside_path.to_s)
       expect(data["load_paths"]["external-plugin"]).to eq([outside_path.join("lib").to_s])
+    end
+
+    it "ignores entries whose relative paths climb out of the plugin root" do
+      require "rubygems/yaml_serializer"
+
+      escaping_index = {
+        "commands" => { "escape" => "escaping-plugin" },
+        "hooks" => { "before-eval" => ["escaping-plugin", plugin_name] },
+        "load_paths" => {
+          "escaping-plugin" => ["../../elsewhere/lib"],
+          plugin_name => [File.join(plugin_name, "lib")],
+        },
+        "plugin_paths" => { "escaping-plugin" => "../../elsewhere", plugin_name => plugin_name },
+        "sources" => { "escape" => "escaping-plugin" },
+      }
+
+      File.open(index.index_file, "w") {|f| f.puts Gem::YAMLSerializer.dump(escaping_index) }
+
+      new_index = Index.new
+
+      expect(new_index.installed?("escaping-plugin")).to be_nil
+      expect(new_index.load_paths("escaping-plugin")).to be_nil
+      expect(new_index.command_plugin("escape")).to be_nil
+      expect(new_index.source_plugin("escape")).to be_nil
+      expect(new_index.hook_plugins("before-eval")).to eq([plugin_name])
+      expect(new_index.installed?(plugin_name)).to eq(Bundler::Plugin.root.join(plugin_name).to_s)
+    end
+
+    it "ignores entries whose load paths alone climb out of the plugin root" do
+      require "rubygems/yaml_serializer"
+
+      escaping_index = {
+        "commands" => {},
+        "hooks" => {},
+        "load_paths" => { "escaping-plugin" => ["../../elsewhere/lib"] },
+        "plugin_paths" => { "escaping-plugin" => "escaping-plugin" },
+        "sources" => {},
+      }
+
+      File.open(index.index_file, "w") {|f| f.puts Gem::YAMLSerializer.dump(escaping_index) }
+
+      new_index = Index.new
+
+      expect(new_index.installed?("escaping-plugin")).to be_nil
+      expect(new_index.load_paths("escaping-plugin")).to be_nil
+    end
+
+    it "drops hook events whose plugins all climb out of the plugin root" do
+      require "rubygems/yaml_serializer"
+
+      escaping_index = {
+        "commands" => {},
+        "hooks" => { "before-eval" => ["escaping-plugin"] },
+        "load_paths" => { "escaping-plugin" => ["../../elsewhere/lib"] },
+        "plugin_paths" => { "escaping-plugin" => "../../elsewhere" },
+        "sources" => {},
+      }
+
+      File.open(index.index_file, "w") {|f| f.puts Gem::YAMLSerializer.dump(escaping_index) }
+
+      new_index = Index.new
+      new_index.register_plugin("aplugin", lib_path("aplugin").to_s, [lib_path("aplugin").join("lib").to_s], [], [], [])
+
+      expect(new_index.index_file.read).to_not include("before-eval")
     end
 
     it "reads legacy index files with absolute paths" do


### PR DESCRIPTION
`Bundler::Plugin::Index` resolves the relative `load_paths` and `plugin_paths` it reads from the index file against the plugin root. A path stored relative to that root only means anything inside it, so an entry that climbs out of it did not come from a plugin Bundler installed there, and resolving it points a plugin load path at an unrelated directory.

I drop those entries when the index is loaded, and remove the same plugin name from `commands`, `hooks` and `sources` at the same time. Otherwise a name with no path left behind stays reachable through a hook and makes `plugin_path` return `nil`. An event that loses its last plugin that way is dropped rather than stored empty, matching `unregister_plugin`.

Absolute paths are untouched. `bundle plugin install --path` and older index files record them that way, because `relativize_path` only relativizes below the base, so plugins installed outside the root keep working.
