### PR TITLE
Only coerce exact true and false gemrc values to booleans

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -763,13 +763,13 @@ if you believe they were disclosed to a third party.
 
   def self.deep_transform_config_keys!(config)
     config.transform_keys! do |k|
-      if k.match?(/\A:(.*)\Z/)
+      if k.match?(/\A:(.*)\z/)
         k[1..-1].to_sym
-      elsif k.include?("__") || k.match?(%r{/\Z})
+      elsif k.include?("__") || k.end_with?("/")
         if k.is_a?(Symbol)
-          k.to_s.gsub(/__/,".").gsub(%r{/\Z}, "").to_sym
+          k.to_s.gsub(/__/,".").delete_suffix("/").to_sym
         else
-          k.dup.gsub(/__/,".").gsub(%r{/\Z}, "")
+          k.dup.gsub(/__/,".").delete_suffix("/")
         end
       else
         k
@@ -778,11 +778,11 @@ if you believe they were disclosed to a third party.
 
     config.transform_values! do |v|
       if v.is_a?(String)
-        if v.match?(/\A:(.*)\Z/)
+        if v.match?(/\A:(.*)\z/)
           v[1..-1].to_sym
-        elsif v.match?(/\A[+-]?\d+\Z/)
+        elsif v.match?(/\A[+-]?\d+\z/)
           v.to_i
-        elsif v.match?(/\Atrue|false\Z/)
+        elsif v.match?(/\A(?:true|false)\z/)
           v == "true"
         elsif v.empty?
           nil

--- a/test/rubygems/test_gem_config_file.rb
+++ b/test/rubygems/test_gem_config_file.rb
@@ -896,6 +896,20 @@ if you believe they were disclosed to a third party.
     assert_equal false, @cfg.verbose
   end
 
+  def test_gemrc_coerces_only_exact_boolean_spellings
+    File.open @temp_conf, "w" do |fp|
+      fp.puts ":credential_store: truestore"
+      fp.puts ":ssl_ca_cert: /home/me/certs-false"
+      fp.puts ":verbose: false"
+    end
+
+    util_config_file
+
+    assert_equal "truestore", @cfg.credential_store
+    assert_equal "/home/me/certs-false", @cfg.ssl_ca_cert
+    assert_equal false, @cfg.verbose
+  end
+
   def test_load_ssl_verify_mode_from_config
     File.open @temp_conf, "w" do |fp|
       fp.puts ":ssl_verify_mode: 1"


### PR DESCRIPTION
`Gem::ConfigFile.deep_transform_config_keys!` coerced string values with `/\Atrue|false\Z/`. Alternation binds looser than the anchors, so that reads as `(\Atrue)|(false\Z)`, and every gemrc string starting with `true` or ending with `false` was silently turned into the boolean `false`. A gemrc holding `:credential_store: truestore` disabled the credential store instead of naming a backend, while `RUBYGEMS_CREDENTIAL_STORE=truestore` returned the backend name. Every string value in a gemrc is affected, not just `credential_store`.

The neighbouring branches move from `\Z` to `\z` for a related reason. `\Z` also accepts a trailing newline, so `":foo\n"` matched the symbol branch and produced a symbol that still carried the newline. The key side ends up on `end_with?` and `delete_suffix` because `Performance/EndWith` fires once the anchor is exact.
