### PR TITLE
Document :credential_store in the gemrc option list

### DIFF
--- a/lib/rubygems/config_file.rb
+++ b/lib/rubygems/config_file.rb
@@ -36,6 +36,7 @@ require "rbconfig"
 # +:ipv4_fallback_enabled+:: See #ipv4_fallback_enabled
 # +:global_gem_cache+:: See #global_gem_cache
 # +:use_psych+:: See #use_psych
+# +:credential_store+:: See #credential_store
 # +:gemhome+:: See #home
 # +:gempath+:: See #path
 # +:sources+:: Sets Gem::sources


### PR DESCRIPTION
The class RDoc in `lib/rubygems/config_file.rb` lists the valid gemrc options, and `:credential_store` never got a row there even though gemrc has read it since the option landed. Someone reading that list would conclude the setting is only reachable through `RUBYGEMS_CREDENTIAL_STORE` or the command line. The new row goes between `:use_psych` and `:gemhome`, matching the order of both the key conversion list and the assignment block below it. `attr_accessor :credential_store` already explains what the values mean, so the row only points there.
