### PR TITLE
Load RDoc before the test sandbox in TestGemRDoc

### DIFF
--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -4,6 +4,11 @@ require "rubygems"
 require_relative "helper"
 require "rubygems/rdoc"
 
+# RDoc resolves its own dependencies lazily, on require. Load them here, while
+# the real gem paths are still in effect, because Gem::TestCase#setup points
+# GEM_HOME at an empty temporary directory where they cannot be found.
+Gem::RDoc.load_rdoc if defined?(Gem::RDoc)
+
 class TestGemRDoc < Gem::TestCase
   def setup
     super


### PR DESCRIPTION
`TestGemRDoc` fails locally with `LoadError: cannot load such file -- rbs` on `test_setup`, `test_setup_unwritable` and `test_new_rdoc`. RDoc 8 declares a runtime dependency on `rbs`, and that dependency stays unresolved when several `rbs` versions are installed, because activating RDoc cannot pick one of them. It is resolved on the first `require "rbs"` instead, which happens inside `Gem::RDoc#setup` through `RDoc::RubyGemsHook.load_rdoc`, after `Gem::TestCase#setup` has already pointed `GEM_HOME` at an empty temporary directory where nothing can be found.

Loading RDoc at the top of the file, while the real gem paths are still in effect, leaves the sandbox with nothing left to resolve. CI does not hit this today because it installs a single `rbs` version, so the dependency is resolved eagerly when RDoc is activated.
