### PR TITLE
Update simplecov to 1.1 and drop its deprecated API

### DIFF
--- a/.github/workflows/system-rubygems-bundler.yml
+++ b/.github/workflows/system-rubygems-bundler.yml
@@ -32,9 +32,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { ruby: { name: ruby-3.2, value: 3.2.0 } }
-          - { ruby: { name: ruby-3.3, value: 3.3.0 } }
-          - { ruby: { name: ruby-3.4, value: 3.4.1 } }
+          - { ruby: { name: ruby-3.2, value: 3.2.11 } }
+          - { ruby: { name: ruby-3.3, value: 3.3.11 } }
+          - { ruby: { name: ruby-3.4, value: 3.4.9 } }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/Rakefile
+++ b/Rakefile
@@ -787,9 +787,9 @@ namespace :bundler do
   end
 end
 
-Rake::Task[:test].enhance do
-  Rake::Task["coverage:report"].reenable
-  Rake::Task["coverage:report"].invoke end
-Rake::Task["spec:regular"].enhance do
-  Rake::Task["coverage:report"].reenable
-  Rake::Task["coverage:report"].invoke end
+[:test, :spec, "spec:regular"].each do |name|
+  Rake::Task[name].enhance do
+    Rake::Task["coverage:report"].reenable
+    Rake::Task["coverage:report"].invoke
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -108,18 +108,18 @@ task "coverage:report" do
   $stdout = File.open(File::NULL, "w")
   SimpleCov.collate Dir[resultset] do
     coverage_dir "coverage"
-    add_filter "/test/"
-    add_filter "/spec/"
-    add_filter "/tool/"
-    add_filter "/lib/rubygems/vendor/"
-    add_filter "/lib/bundler/vendor/"
-    add_filter "/tmp/"
-    add_filter ".gemspec"
+    skip "/test/"
+    skip "/spec/"
+    skip "/tool/"
+    skip "/lib/rubygems/vendor/"
+    skip "/lib/bundler/vendor/"
+    skip "/tmp/"
+    skip ".gemspec"
 
-    add_group "RubyGems" do |src|
+    group "RubyGems" do |src|
       src.filename.include?("/lib/rubygems/") || src.filename.end_with?("/lib/rubygems.rb")
     end
-    add_group "Bundler" do |src|
+    group "Bundler" do |src|
       src.filename.include?("/lib/bundler/") || src.filename.end_with?("/lib/bundler.rb")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,13 +50,13 @@ begin
     root File.expand_path("../bundler", __dir__)
     coverage_dir File.expand_path("../coverage", __dir__)
 
-    add_filter "/spec/"
-    add_filter "/test/"
-    add_filter "/lib/rubygems/"
-    add_filter "/lib/bundler/vendor/"
-    add_filter "/tool/"
-    add_filter "/tmp/"
-    add_filter ".gemspec"
+    skip "/spec/"
+    skip "/test/"
+    skip "/lib/rubygems/"
+    skip "/lib/bundler/vendor/"
+    skip "/tool/"
+    skip "/tmp/"
+    skip ".gemspec"
   end
 
   SimpleCov.print_error_status = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,6 @@ require_relative "support/shards"
 begin
   raise LoadError if File.exist?(File.expand_path("../../lib/bundler/bundler.gemspec", __dir__))
 
-  gem "simplecov_json_formatter"
   require "simplecov"
 
   SimpleCov.start do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ begin
 
   SimpleCov.start do
     command_name "bundler:#{Process.pid}"
-    root File.expand_path("../bundler", __dir__)
+    root File.expand_path("..", __dir__)
     coverage_dir File.expand_path("../coverage", __dir__)
 
     skip "/spec/"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,12 +60,10 @@ begin
   end
 
   SimpleCov.print_error_status = false
-  SimpleCov.at_exit do
-    $stdout = File.open(File::NULL, "w")
-    SimpleCov.result.format!
-  ensure
-    $stdout = STDOUT
-  end
+
+  # Only merge this process result into the resultset. Parallel workers share a
+  # coverage directory, so the report is formatted once by `rake coverage:report`.
+  SimpleCov.at_exit { SimpleCov.result }
 rescue LoadError
   # SimpleCov is not installed
 end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -5,7 +5,6 @@ require "rubygems"
 begin
   raise LoadError if ENV["GEM_COMMAND"]
 
-  gem "simplecov_json_formatter"
   require "simplecov"
 
   unless ENV["SIMPLECOV_SUBPROCESS"]

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -13,11 +13,11 @@ begin
       root File.expand_path("../..", __dir__)
       coverage_dir File.expand_path("../../coverage", __dir__)
 
-      add_filter "/test/"
-      add_filter "/bundler/"
-      add_filter "/tool/"
-      add_filter "/lib/rubygems/vendor/"
-      add_filter ".gemspec"
+      skip "/test/"
+      skip "/bundler/"
+      skip "/tool/"
+      skip "/lib/rubygems/vendor/"
+      skip ".gemspec"
     end
 
     # Prevent SimpleCov from running in subprocesses spawned by assert_separately

--- a/tool/bundler/dev_gems.rb
+++ b/tool/bundler/dev_gems.rb
@@ -14,7 +14,7 @@ gem "rspec-core", "~> 3.12"
 gem "rspec-expectations", "~> 3.12"
 gem "rspec-mocks", "~> 3.12"
 gem "rubygems-generate_index", "~> 1.1"
-gem "simplecov", "~> 0.22"
+gem "simplecov", "~> 1.1"
 
 group :doc do
   gem "ronn-ng", "~> 0.10.1", platform: :ruby

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -3,7 +3,6 @@ GEM
   specs:
     compact_index (0.15.0)
     diff-lcs (1.6.2)
-    docile (1.4.1)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
@@ -58,12 +57,7 @@ GEM
     rspec-support (3.13.7)
     rubygems-generate_index (1.1.3)
       compact_index (~> 0.15.0)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+    simplecov (1.1.1)
     test-unit (3.7.7)
       power_assert
     test-unit-ruby-core (1.0.14)
@@ -96,7 +90,7 @@ DEPENDENCIES
   rspec-expectations (~> 3.12)
   rspec-mocks (~> 3.12)
   rubygems-generate_index (~> 1.1)
-  simplecov (~> 0.22)
+  simplecov (~> 1.1)
   test-unit (~> 3.0)
   test-unit-ruby-core
   turbo_tests (~> 2.2.3)
@@ -104,7 +98,6 @@ DEPENDENCIES
 CHECKSUMS
   compact_index (0.15.0) sha256=5c6c404afca8928a7d9f4dde9524f6e1610db17e675330803055db282da84a8b
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
@@ -133,9 +126,7 @@ CHECKSUMS
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
   rubygems-generate_index (1.1.3) sha256=3571424322666598e9586a906485e1543b617f87644913eaf137d986a3393f5c
-  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
-  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
-  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+  simplecov (1.1.1) sha256=25825ef13f0b2e74694d769817dad6ab8e90131dabdaa666e522fea105521e78
   test-unit (3.7.7) sha256=3c89d5ff0690a16bef9946156c4624390402b9d54dfcf4ce9cbd5b06bead1e45
   test-unit-ruby-core (1.0.14) sha256=d2e997796c9c5c5e8e31ac014f83a473ff5c2523a67cfa491b08893e12d43d22
   turbo_tests (2.2.5) sha256=3fa31497d12976d11ccc298add29107b92bda94a90d8a0a5783f06f05102509f


### PR DESCRIPTION
Running the test suites outside the dev bundle resolves simplecov 1.x, which warns once per `SimpleCov.add_filter` call. The current names are `skip` and `group`, and they only exist from simplecov 1.0, so the dev pin moves to `~> 1.1`. That release also ships the HTML and JSON formatters in the gem itself, so the explicit `simplecov_json_formatter` activation no longer resolves and goes away.

Two adjacent fixes ride along, each in its own commit. Moving `bundler/spec` to `spec/` rewrote the bundler coverage root to `spec/../bundler`, which does not exist, so bundler spec runs have been reporting 0 / 0 lines ever since. And simplecov 1.x warns when a worker overwrites a `coverage.json` another worker just wrote, which is what `turbo_tests` does here, so workers now only store their resultset and `coverage:report` builds the report once.
