### PR TITLE
Skip the Rust newgem cargo test where magnus cannot build

### DIFF
--- a/spec/commands/newgem_options_spec.rb
+++ b/spec/commands/newgem_options_spec.rb
@@ -1106,6 +1106,7 @@ RSpec.describe "bundle gem" do
 
       def setup_rust_env
         skip "rust toolchain of mingw is broken" if RUBY_PLATFORM.match?("mingw")
+        skip "magnus has no release supporting the extended rb_data_type_struct yet (https://github.com/matsadler/magnus/issues/173)" if rb_data_type_struct_extended?
 
         env = {
           "CARGO_HOME" => ENV.fetch("CARGO_HOME", File.join(ENV["HOME"], ".cargo")),
@@ -1118,6 +1119,12 @@ RSpec.describe "bundle gem" do
         # Hermetic Cargo setup
         RbConfig::CONFIG.each {|k, v| env["RBCONFIG_#{k}"] = v }
         env
+      end
+
+      def rb_data_type_struct_extended?
+        rtypeddata_h = File.join(RbConfig::CONFIG["rubyhdrdir"], "ruby", "internal", "core", "rtypeddata.h")
+
+        File.exist?(rtypeddata_h) && File.read(rtypeddata_h).include?("handle_weak_references")
       end
     end
 


### PR DESCRIPTION
`bundle gem --ext=rust` generates a crate that no longer compiles on `ruby-head`. Ruby master added `handle_weak_references` to `rb_data_type_struct` and grew its `reserved` array from 1 to 7, and `magnus` initializes that struct with a literal, so no released version builds against it. The latest crates.io release is 0.8.2 and the fix exists only on `main`, tracked in https://github.com/matsadler/magnus/issues/173.

I cannot fix that from here, so this only keeps the example from failing on such a Ruby. The guard looks for `handle_weak_references` in `rtypeddata.h` rather than comparing `RUBY_VERSION` against 4.1, so it tracks the actual incompatibility instead of a version number I would have to maintain. Ruby 3.4 and 4.0 still run the example, and `cargo test` passes there.

When a `magnus` release carries the fix, the template pin moves to it and this skip goes away.
