### PR TITLE
Preserve non-UTF-8 legacy gem metadata

### DIFF
--- a/lib/rubygems/safe_yaml.rb
+++ b/lib/rubygems/safe_yaml.rb
@@ -53,8 +53,8 @@ module Gem
       alias_method :load, :safe_load
     end
 
-    private_class_method def valid_encoding?(input)
-      return false unless input.is_a?(String)
+    private_class_method def self.valid_encoding?(input)
+      return true unless input.is_a?(String)
 
       input.dup.force_encoding(Encoding::UTF_8).valid_encoding?
     end

--- a/lib/rubygems/safe_yaml.rb
+++ b/lib/rubygems/safe_yaml.rb
@@ -35,7 +35,8 @@ module Gem
     end
 
     def self.safe_load(input)
-      if Gem.use_psych?
+      # Psych rejects legacy metadata bytes, so preserve them with the internal parser.
+      if Gem.use_psych? && valid_encoding?(input)
         ::Psych.safe_load(input, permitted_classes: PERMITTED_CLASSES,
                                  permitted_symbols: PERMITTED_SYMBOLS, aliases: @aliases_enabled)
       else
@@ -50,6 +51,12 @@ module Gem
 
     class << self
       alias_method :load, :safe_load
+    end
+
+    private_class_method def valid_encoding?(input)
+      return false unless input.is_a?(String)
+
+      input.dup.force_encoding(Encoding::UTF_8).valid_encoding?
     end
   end
 end

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1146,9 +1146,7 @@ class Gem::Specification < Gem::BasicSpecification
     result = result.dup
     # Ruby 1.8 gem metadata may contain Latin-1 bytes without an encoding declaration.
     if [Encoding::BINARY, Encoding::UTF_8].include?(result.encoding)
-      result.force_encoding(Encoding::UTF_8).scrub! do |bytes|
-        bytes.encode(Encoding::UTF_8, Encoding::ISO_8859_1)
-      end
+      result.force_encoding(Encoding::UTF_8).scrub! {|bytes| bytes.encode(Encoding::UTF_8, Encoding::ISO_8859_1) }
     end
     result = "--- " + result unless result.start_with?("--- ")
     result.gsub!(/ !!null \n/, " \n")

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1143,8 +1143,14 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.normalize_yaml_input(input)
     result = input.respond_to?(:read) ? input.read : input
-    result = "--- " + result unless result.start_with?("--- ")
     result = result.dup
+    # Ruby 1.8 gem metadata may contain Latin-1 bytes without an encoding declaration.
+    if [Encoding::BINARY, Encoding::UTF_8].include?(result.encoding)
+      result.force_encoding(Encoding::UTF_8).scrub! do |bytes|
+        bytes.encode(Encoding::UTF_8, Encoding::ISO_8859_1)
+      end
+    end
+    result = "--- " + result unless result.start_with?("--- ")
     result.gsub!(/ !!null \n/, " \n")
     # date: 2011-04-26 00:00:00.000000000Z
     # date: 2011-04-26 00:00:00.000000000 Z

--- a/lib/rubygems/specification.rb
+++ b/lib/rubygems/specification.rb
@@ -1143,12 +1143,8 @@ class Gem::Specification < Gem::BasicSpecification
 
   def self.normalize_yaml_input(input)
     result = input.respond_to?(:read) ? input.read : input
-    result = result.dup
-    # Ruby 1.8 gem metadata may contain Latin-1 bytes without an encoding declaration.
-    if [Encoding::BINARY, Encoding::UTF_8].include?(result.encoding)
-      result.force_encoding(Encoding::UTF_8).scrub! {|bytes| bytes.encode(Encoding::UTF_8, Encoding::ISO_8859_1) }
-    end
     result = "--- " + result unless result.start_with?("--- ")
+    result = result.dup
     result.gsub!(/ !!null \n/, " \n")
     # date: 2011-04-26 00:00:00.000000000Z
     # date: 2011-04-26 00:00:00.000000000 Z

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -932,22 +932,8 @@ class TestGemPackage < Gem::Package::TarTestCase
   end
 
   def test_load_spec_from_metadata
-    entry = StringIO.new Gem::Util.gzip @spec.to_yaml
-    def entry.full_name
-      "metadata.gz"
-    end
-
-    package = Gem::Package.new "nonexistent.gem"
-
-    spec = package.load_spec_from_metadata entry
-
-    assert_equal @spec, spec
-  end
-
-  def test_load_spec_from_metadata_with_latin1
     @spec.description = "Based on Mauricio Fern\u00E1ndez's implementation"
-    metadata = @spec.to_yaml.encode Encoding::ISO_8859_1
-    entry = StringIO.new Gem::Util.gzip metadata
+    entry = StringIO.new Gem::Util.gzip @spec.to_yaml.encode(Encoding::ISO_8859_1)
     def entry.full_name
       "metadata.gz"
     end

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -944,6 +944,22 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_equal @spec, spec
   end
 
+  def test_load_spec_from_metadata_with_latin1
+    @spec.description = "Based on Mauricio Fern\u00E1ndez's implementation"
+    metadata = @spec.to_yaml.encode Encoding::ISO_8859_1
+    entry = StringIO.new Gem::Util.gzip metadata
+    def entry.full_name
+      "metadata.gz"
+    end
+
+    package = Gem::Package.new "nonexistent.gem"
+
+    spec = package.load_spec_from_metadata entry
+
+    assert_equal @spec, spec
+    assert_equal @spec.description, spec.description
+  end
+
   def test_verify
     package = Gem::Package.new @gem
 

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -931,6 +931,19 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_path_not_exist parent
   end
 
+  def test_load_spec_from_metadata
+    entry = StringIO.new Gem::Util.gzip @spec.to_yaml
+    def entry.full_name
+      "metadata.gz"
+    end
+
+    package = Gem::Package.new "nonexistent.gem"
+
+    spec = package.load_spec_from_metadata entry
+
+    assert_equal @spec, spec
+  end
+
   def test_load_spec_from_metadata_with_legacy_encodings
     {
       "Based on Mauricio Fern\u00E1ndez's implementation" => Encoding::ISO_8859_1,

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -931,19 +931,24 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_path_not_exist parent
   end
 
-  def test_load_spec_from_metadata
-    @spec.description = "Based on Mauricio Fern\u00E1ndez's implementation"
-    entry = StringIO.new Gem::Util.gzip @spec.to_yaml.encode(Encoding::ISO_8859_1)
-    def entry.full_name
-      "metadata.gz"
+  def test_load_spec_from_metadata_with_legacy_encodings
+    {
+      "Based on Mauricio Fern\u00E1ndez's implementation" => Encoding::ISO_8859_1,
+      "\u65E5\u672C\u8A9E" => Encoding::EUC_JP,
+    }.each do |description, encoding|
+      @spec.description = description
+      metadata = @spec.to_yaml.encode encoding
+      entry = StringIO.new Gem::Util.gzip metadata
+      def entry.full_name
+        "metadata.gz"
+      end
+
+      package = Gem::Package.new "nonexistent.gem"
+      spec = package.load_spec_from_metadata entry
+
+      assert_equal @spec, spec
+      assert_equal description.encode(encoding).b, spec.description.b
     end
-
-    package = Gem::Package.new "nonexistent.gem"
-
-    spec = package.load_spec_from_metadata entry
-
-    assert_equal @spec, spec
-    assert_equal @spec.description, spec.description
   end
 
   def test_verify


### PR DESCRIPTION
Fixes #9833

This is reproducible for Psych based parser. 

Internal YAML Serializer is able to preserve bytes without a crash.

## What was the end-user or developer problem that led to this PR?

I cannot extract the `archive-tar-minitar-0.5.1.gem` gem due to an encoding error. Old gems, written in the pre-ruby-1.8 era, have a chance of having similar encoding issues.

## What is your fix for the problem, implemented in this PR?

Fall back to RubyGems' safe YAML parser when Psych cannot accept the metadata as UTF-8. This preserves bytes from ISO-8859-1, EUC-JP, and other legacy encodings without guessing their encoding.
 
## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write [tests](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/ruby/rubygems/blob/master/doc/PULL_REQUESTS.md#commit-messages)
