### PR TITLE
Remove Gem::BasicSpecification#datadir and check minor-release deprecation horizons

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -188,10 +188,10 @@ task postrelease: %w[upload guides:publish blog:publish bundler:build_metadata:c
 
 desc "Check for deprecated methods with expired deprecation horizon"
 task :check_deprecations do
-  if v.segments[1] == 0 && v.segments[2] == 0
+  if v.segments[2] == 0
     sh("bin/rubocop -r ./tool/cops/deprecations --only Rubygems/Deprecations lib")
   else
-    puts "Skipping deprecation checks since not releasing a major version."
+    puts "Skipping deprecation checks since not releasing a major or minor version."
   end
 end
 

--- a/lib/rubygems/basic_specification.rb
+++ b/lib/rubygems/basic_specification.rb
@@ -183,17 +183,6 @@ class Gem::BasicSpecification
   end
 
   ##
-  # The path to the data directory for this gem.
-
-  def datadir
-    # TODO: drop the extra ", gem_name" which is uselessly redundant
-    File.expand_path(File.join(gems_dir, full_name, "data", name))
-  end
-
-  extend Gem::Deprecate
-  rubygems_deprecate :datadir, :none, "4.1"
-
-  ##
   # Full path of the target library file.
   # If the file is not in this gem, return nil.
 

--- a/tool/cops/deprecations.rb
+++ b/tool/cops/deprecations.rb
@@ -15,25 +15,34 @@ module RuboCop
       #   # the `deprecate` call is fully removed
       #
       class Deprecations < Base
-        MSG = "Remove `%<method_name>s` calls for the next major release."
+        MSG = "Remove `%<method_name>s` calls whose deprecation horizon has been reached."
         RESTRICT_ON_SEND = [:rubygems_deprecate, :rubygems_deprecate_command].freeze
 
         def on_send(node)
-          if node.method_name == :rubygems_deprecate && node.arguments.size >= 3
-            version_arg = node.arguments[2]
-            if version_arg&.str_type?
-              target_version = version_arg.str_content
-              return if current_version < Gem::Version.new(target_version)
-            end
-          end
+          return unless expired?(horizon_of(node))
 
           add_offense(node, message: format(MSG, method_name: node.method_name))
         end
 
         private
 
+        # Prereleases compare lower than their final version, so the release
+        # segments alone are used to make 4.1.0.beta1 expire a "4.1" horizon.
         def current_version
-          @current_version ||= Gem::Version.new(Gem::VERSION)
+          @current_version ||= Gem::Version.new(Gem::VERSION).release
+        end
+
+        def expired?(horizon)
+          horizon ? current_version >= horizon : major_release?
+        end
+
+        def horizon_of(node)
+          version_arg = node.method_name == :rubygems_deprecate ? node.arguments[2] : node.arguments[0]
+          Gem::Version.new(version_arg.str_content) if version_arg&.str_type?
+        end
+
+        def major_release?
+          current_version.segments[1..].all?(&:zero?)
         end
       end
     end


### PR DESCRIPTION
`Gem::BasicSpecification#datadir` was deprecated in 4.0 with a 4.1 removal horizon, and its tests were dropped back then. It still survived into the 4.1.0.dev tree because nothing flagged it. This PR removes the method.

The release check missed it for two reasons. The `check_deprecations` task only ran the `Rubygems/Deprecations` cop for x.0.0 releases, so a minor horizon like "4.1" was never checked. The cop also compared the prerelease version itself, and 4.1.0.beta1 sorts below "4.1", so it would have passed even if it had run.

The task now runs for any x.y.0 release. The cop compares release segments only, so a prerelease of the horizon version counts as expired. Version-less deprecations keep their next-major meaning by expiring only at x.0.0. The cop is clean on `lib` after the removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
