### PR TITLE
Read git source credentials through Settings#credentials_for

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -369,7 +369,7 @@ module Bundler
         def configured_uri
           @configured_uri ||= if /https?:/.match?(uri)
             remote = Gem::URI(uri)
-            config_auth = Bundler.settings[remote.to_s] || Bundler.settings[remote.host]
+            config_auth = Bundler.settings.credentials_for(remote)
             remote.userinfo ||= config_auth
             remote.to_s
           else

--- a/spec/bundler/source/git/git_proxy_spec.rb
+++ b/spec/bundler/source/git/git_proxy_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "rubygems/credential_store"
+require_relative "../../../support/fake_credential_backend"
+
 RSpec.describe Bundler::Source::Git::GitProxy do
   let(:path) { Pathname("path") }
   let(:uri) { "https://github.com/ruby/rubygems.git" }
@@ -89,6 +92,36 @@ RSpec.describe Bundler::Source::Git::GitProxy do
 
     it "keeps original userinfo" do
       Bundler.settings.temporary("github.com" => "u:p") do
+        original = "https://orig:info@github.com/ruby/rubygems.git"
+        git_proxy = described_class.new(Pathname("path"), original, options)
+        allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+        expect(git_proxy).to receive(:capture).with([*base_clone_args, "--", original, path.to_s], nil).and_return(["", "", clone_result])
+        git_proxy.checkout
+      end
+    end
+  end
+
+  context "with credentials in the credential store" do
+    let(:fake_store) { Gem::CredentialStore.new(backend: FakeCredentialBackend.new) }
+
+    before do
+      Gem::CredentialStore.instance = fake_store
+      fake_store.set(Bundler::Settings.key_for("github.com"), "u:p")
+    end
+
+    after { Gem::CredentialStore.reset! }
+
+    it "adds username and password from the store to URI for host" do
+      Bundler.settings.temporary("credential_store" => "true") do
+        expect(Bundler.settings["github.com"]).to be_nil
+        allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")
+        expect(git_proxy).to receive(:capture).with([*base_clone_args, "--", "https://u:p@github.com/ruby/rubygems.git", path.to_s], nil).and_return(["", "", clone_result])
+        subject.checkout
+      end
+    end
+
+    it "keeps original userinfo" do
+      Bundler.settings.temporary("credential_store" => "true") do
         original = "https://orig:info@github.com/ruby/rubygems.git"
         git_proxy = described_class.new(Pathname("path"), original, options)
         allow(git_proxy).to receive(:git_local).with("--version").and_return("git version 2.14.0")


### PR DESCRIPTION
With `credential_store` enabled, a Gemfile pointing at a private `https://` git source is cloned without credentials and fails with 401 or 404, even after `bundle config set github.com user:token`. Since PR #9671 that command writes the credential to the OS store and removes it from the config file, but `GitProxy#configured_uri` still reads `Bundler.settings[host]`, which only sees the config file.

I switched the lookup to `Bundler.settings.credentials_for`, which the rubygems source already uses, so git sources now see environment, store, and config file credentials in the same order. Explicit userinfo in the Gemfile URI still wins. The new specs cover a credential that exists only in the store.

Generated with [Claude Code](https://claude.com/claude-code)
