### PR TITLE
Harden the compact index client cache and HTTP fetcher

### DIFF
--- a/lib/rubygems/compact_index_client/cache.rb
+++ b/lib/rubygems/compact_index_client/cache.rb
@@ -79,7 +79,7 @@ class Gem::CompactIndexClient
     # validated, so refuse anything that would escape the cache
     # directory when used as a path component.
     def validate_name!(name)
-      return if File.basename(name) == name
+      return unless name.empty? || name.include?("\0") || name == "." || name == ".." || File.basename(name) != name
 
       raise Gem::Exception, "malformed gem name: #{name.inspect}"
     end

--- a/lib/rubygems/compact_index_client/http_fetcher.rb
+++ b/lib/rubygems/compact_index_client/http_fetcher.rb
@@ -34,7 +34,7 @@ class Gem::CompactIndexClient
       when Gem::Net::HTTPSuccess
         # The callers write the body into the cache, so a body-less success
         # such as 204 would truncate the cached file.
-        raise Gem::RemoteFetcher::FetchError.new("bad response #{response.message} #{response.code}", uri) unless response.class.body_permitted?
+        raise bad_response(response, uri) unless response.class.body_permitted?
 
         response
       when Gem::Net::HTTPMovedPermanently, Gem::Net::HTTPFound, Gem::Net::HTTPSeeOther,
@@ -51,14 +51,14 @@ class Gem::CompactIndexClient
 
         fetch(redirect, headers, redirects_remaining - 1)
       when Gem::Net::HTTPRangeNotSatisfiable
-        raise Gem::RemoteFetcher::FetchError.new("bad response #{response.message} #{response.code}", uri) unless headers.key?("Range")
+        raise bad_response(response, uri) unless headers.key?("Range")
 
         # The local cache is longer than the remote file, refetch it whole. A
         # matching ETag would otherwise turn the retry into a 304 and keep the
         # oversized cache.
         fetch(uri, headers.except("Range", "If-None-Match"), redirects_remaining)
       else
-        raise Gem::RemoteFetcher::FetchError.new("bad response #{response.message} #{response.code}", uri)
+        raise bad_response(response, uri)
       end
     end
 
@@ -71,6 +71,11 @@ class Gem::CompactIndexClient
     rescue Gem::Timeout::Error, IOError, SocketError, SystemCallError,
            *(OpenSSL::SSL::SSLError if Gem::HAVE_OPENSSL) => e
       raise Gem::RemoteFetcher::FetchError.new("#{e.class}: #{e}", uri)
+    end
+
+    def bad_response(response, uri)
+      detail = response["X-Error-Message"] || response.message
+      Gem::RemoteFetcher::FetchError.new("bad response #{detail} #{response.code}", uri)
     end
 
     def https?(uri)

--- a/lib/rubygems/compact_index_client/http_fetcher.rb
+++ b/lib/rubygems/compact_index_client/http_fetcher.rb
@@ -47,8 +47,10 @@ class Gem::CompactIndexClient
       when Gem::Net::HTTPRangeNotSatisfiable
         raise Gem::RemoteFetcher::FetchError.new("bad response #{response.message} #{response.code}", uri) unless headers.key?("Range")
 
-        # The local cache is longer than the remote file, refetch it whole.
-        fetch(uri, headers.except("Range"), redirects_remaining)
+        # The local cache is longer than the remote file, refetch it whole. A
+        # matching ETag would otherwise turn the retry into a 304 and keep the
+        # oversized cache.
+        fetch(uri, headers.except("Range", "If-None-Match"), redirects_remaining)
       else
         raise Gem::RemoteFetcher::FetchError.new("bad response #{response.message} #{response.code}", uri)
       end

--- a/lib/rubygems/compact_index_client/http_fetcher.rb
+++ b/lib/rubygems/compact_index_client/http_fetcher.rb
@@ -48,6 +48,9 @@ class Gem::CompactIndexClient
         if https?(uri) && !https?(redirect)
           raise Gem::RemoteFetcher::FetchError.new("redirecting to non-https resource: #{Gem::Uri.redact(redirect)}", uri)
         end
+        # An absolute Location on the same host drops the credentials that a
+        # relative one would have kept.
+        redirect.userinfo = uri.userinfo if redirect.host == uri.host && !redirect.userinfo
 
         fetch(redirect, headers, redirects_remaining - 1)
       when Gem::Net::HTTPRangeNotSatisfiable

--- a/lib/rubygems/compact_index_client/http_fetcher.rb
+++ b/lib/rubygems/compact_index_client/http_fetcher.rb
@@ -29,7 +29,13 @@ class Gem::CompactIndexClient
       response = request(uri, headers)
 
       case response
-      when Gem::Net::HTTPSuccess, Gem::Net::HTTPNotModified
+      when Gem::Net::HTTPNotModified
+        response
+      when Gem::Net::HTTPSuccess
+        # The callers write the body into the cache, so a body-less success
+        # such as 204 would truncate the cached file.
+        raise Gem::RemoteFetcher::FetchError.new("bad response #{response.message} #{response.code}", uri) unless response.class.body_permitted?
+
         response
       when Gem::Net::HTTPMovedPermanently, Gem::Net::HTTPFound, Gem::Net::HTTPSeeOther,
            Gem::Net::HTTPTemporaryRedirect, Gem::Net::HTTPPermanentRedirect

--- a/test/rubygems/test_gem_compact_index_client_cache.rb
+++ b/test/rubygems/test_gem_compact_index_client_cache.rb
@@ -136,6 +136,22 @@ class TestGemCompactIndexClientCache < Gem::TestCase
     assert_empty fetcher.requests
   end
 
+  def test_info_rejects_dot_dot_name
+    assert_rejects_malformed_name ".."
+  end
+
+  def test_info_rejects_dot_name
+    assert_rejects_malformed_name "."
+  end
+
+  def test_info_rejects_empty_name
+    assert_rejects_malformed_name ""
+  end
+
+  def test_info_rejects_name_with_null_byte
+    assert_rejects_malformed_name "a\0b"
+  end
+
   def test_info_with_special_characters_uses_hashed_path
     fetcher = FakeFetcher.new("1.0.0\n")
     cache = Gem::CompactIndexClient::Cache.new(@dir, fetcher)
@@ -145,5 +161,25 @@ class TestGemCompactIndexClientCache < Gem::TestCase
     hashed = "Rails-#{Digest::MD5.hexdigest("Rails").downcase}"
     assert_equal "1.0.0\n", @dir.join("info-special-characters", hashed).read
     refute @dir.join("info", "Rails").exist?
+  end
+
+  private
+
+  def assert_rejects_malformed_name(name)
+    fetcher = FakeFetcher.new("1.0.0\n")
+    cache = Gem::CompactIndexClient::Cache.new(@dir, fetcher)
+    before = Dir.glob("**/*", File::FNM_DOTMATCH, base: @tempdir).sort
+
+    e = assert_raise Gem::Exception do
+      cache.info(name, "no-match")
+    end
+    assert_includes e.message, "malformed gem name"
+
+    assert_raise Gem::Exception do
+      cache.fetch_info(name)
+    end
+
+    assert_empty fetcher.requests
+    assert_equal before, Dir.glob("**/*", File::FNM_DOTMATCH, base: @tempdir).sort
   end
 end

--- a/test/rubygems/test_gem_compact_index_client_http_fetcher.rb
+++ b/test/rubygems/test_gem_compact_index_client_http_fetcher.rb
@@ -39,8 +39,9 @@ class TestGemCompactIndexClientHTTPFetcher < Gem::TestCase
   end
 
   class FakeNotFound < Gem::Net::HTTPNotFound
-    def initialize
+    def initialize(error_message = nil)
       super("1.1", "404", "Not Found")
+      self["X-Error-Message"] = error_message if error_message
     end
   end
 
@@ -305,5 +306,17 @@ class TestGemCompactIndexClientHTTPFetcher < Gem::TestCase
     end
 
     assert_match(/bad response Not Found 404/, error.message)
+  end
+
+  def test_call_includes_x_error_message_in_fetch_error
+    fetcher, _remote = fetcher_for(
+      "https://index.example/versions" => FakeNotFound.new("blocked by corporate proxy policy")
+    )
+
+    error = assert_raise Gem::RemoteFetcher::FetchError do
+      fetcher.call("versions")
+    end
+
+    assert_match(/bad response blocked by corporate proxy policy 404/, error.message)
   end
 end

--- a/test/rubygems/test_gem_compact_index_client_http_fetcher.rb
+++ b/test/rubygems/test_gem_compact_index_client_http_fetcher.rb
@@ -246,14 +246,20 @@ class TestGemCompactIndexClientHTTPFetcher < Gem::TestCase
     assert_match(/too many redirects/, error.message)
   end
 
-  def test_call_retries_without_range_on_range_not_satisfiable
+  def test_call_retries_without_range_and_etag_on_range_not_satisfiable
     requests = []
     remote = Object.new
     remote.define_singleton_method(:request) do |uri, request_class, &block|
       request = request_class.new(uri)
       block&.call(request)
       requests << request
-      request["Range"] ? FakeRangeNotSatisfiable.new : FakeResponse.new("full data")
+      if request["Range"]
+        FakeRangeNotSatisfiable.new
+      elsif request["If-None-Match"]
+        Gem::Net::HTTPNotModified.new("1.1", "304", "Not Modified")
+      else
+        FakeResponse.new("full data")
+      end
     end
 
     fetcher = Gem::CompactIndexClient::HTTPFetcher.new("https://index.example", remote)
@@ -262,7 +268,7 @@ class TestGemCompactIndexClientHTTPFetcher < Gem::TestCase
     assert_equal "full data", response.body
     assert_equal 2, requests.size
     assert_nil requests.last["Range"]
-    assert_equal '"abc"', requests.last["If-None-Match"]
+    assert_nil requests.last["If-None-Match"]
   end
 
   def test_call_raises_on_range_not_satisfiable_without_range

--- a/test/rubygems/test_gem_compact_index_client_http_fetcher.rb
+++ b/test/rubygems/test_gem_compact_index_client_http_fetcher.rb
@@ -230,6 +230,17 @@ class TestGemCompactIndexClientHTTPFetcher < Gem::TestCase
     assert_equal "s3cr3t", remote.requests.last.first.password
   end
 
+  def test_call_keeps_credentials_on_an_absolute_same_host_redirect
+    remote = FakeRemoteFetcher.new(
+      "https://user:s3cr3t@index.example/versions" => FakeRedirect.new("https://index.example/v2/versions"),
+      "https://user:s3cr3t@index.example/v2/versions" => FakeResponse.new("data")
+    )
+    fetcher = Gem::CompactIndexClient::HTTPFetcher.new("https://user:s3cr3t@index.example", remote)
+
+    assert_equal "data", fetcher.call("versions").body
+    assert_equal "s3cr3t", remote.requests.last.first.password
+  end
+
   def test_call_drops_credentials_on_a_cross_host_redirect
     remote = FakeRemoteFetcher.new(
       "https://user:s3cr3t@index.example/versions" => FakeRedirect.new("https://mirror.example/versions"),

--- a/test/rubygems/test_gem_compact_index_client_http_fetcher.rb
+++ b/test/rubygems/test_gem_compact_index_client_http_fetcher.rb
@@ -44,6 +44,12 @@ class TestGemCompactIndexClientHTTPFetcher < Gem::TestCase
     end
   end
 
+  class FakeNoContent < Gem::Net::HTTPNoContent
+    def initialize
+      super("1.1", "204", "No Content")
+    end
+  end
+
   class FakeRangeNotSatisfiable < Gem::Net::HTTPRangeNotSatisfiable
     def initialize
       super("1.1", "416", "Range Not Satisfiable")
@@ -279,6 +285,16 @@ class TestGemCompactIndexClientHTTPFetcher < Gem::TestCase
     end
 
     assert_match(/bad response Range Not Satisfiable 416/, error.message)
+  end
+
+  def test_call_raises_fetch_error_on_no_content
+    fetcher, _remote = fetcher_for("https://index.example/versions" => FakeNoContent.new)
+
+    error = assert_raise Gem::RemoteFetcher::FetchError do
+      fetcher.call("versions")
+    end
+
+    assert_match(/bad response No Content 204/, error.message)
   end
 
   def test_call_raises_fetch_error_on_failure_response


### PR DESCRIPTION
With 4.1.0 the `gem` CLI resolves through `Gem::CompactIndexClient`, and a few edge cases on that path corrupt the local cache or fail without a useful message. A cache file longer than the remote one was retried after a 416 with `If-None-Match` still set, so a matching ETag turned the retry into a 304 and the oversized file was kept forever. A 204 No Content passed the success branch and truncated the cached file to zero bytes. A same-host absolute redirect on a private index dropped the credentials, and the `X-Error-Message` a corporate proxy sends never reached the error.

I fixed each of these in `HTTPFetcher`, one commit each, and tightened `Cache#validate_name!` to also reject `.`, `..`, the empty string and names containing NUL, which the `File.basename` comparison let through. These are fixups of the unreleased #9606 and #9753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
