### PR TITLE
Expand the git source gemspec path before the chdir

### DIFF
--- a/lib/bundler/source/git.rb
+++ b/lib/bundler/source/git.rb
@@ -432,10 +432,12 @@ module Bundler
       def validate_spec(_spec); end
 
       def load_gemspec(file)
-        dirname = Pathname.new(file).dirname
-        SharedHelpers.chdir(dirname.to_s) do
-          stub = Gem::StubSpecification.gemspec_stub(file, install_path.parent, install_path.parent)
-          stub.full_gem_path = dirname.expand_path(root).to_s
+        # Expand the path before the chdir below, since resolving it inside the
+        # block would base it on the gemspec directory instead of `root`.
+        gemspec_path = Pathname.new(file).expand_path(root)
+        SharedHelpers.chdir(gemspec_path.dirname.to_s) do
+          stub = Gem::StubSpecification.gemspec_stub(gemspec_path.to_s, install_path.parent, install_path.parent)
+          stub.full_gem_path = gemspec_path.dirname.to_s
           StubSpecification.from_stub(stub)
         end
       end

--- a/spec/bundler/source/git_spec.rb
+++ b/spec/bundler/source/git_spec.rb
@@ -149,4 +149,30 @@ RSpec.describe Bundler::Source::Git do
       expect(::Bundler::FileUtils).to have_received(:rm_rf).once
     end
   end
+
+  describe "#load_gemspec" do
+    let(:options) do
+      { "uri" => uri, "revision" => "123abc" }
+    end
+
+    before do
+      allow(Bundler).to receive(:root).and_return(tmp)
+      allow(subject).to receive(:install_path).and_return(tmp("install/bar-123abc"))
+
+      create_file(tmp("bar/bar.gemspec"), <<~GEMSPEC)
+        Gem::Specification.new do |s|
+          s.name = "bar"
+          s.version = "1.0"
+        end
+      GEMSPEC
+    end
+
+    it "resolves a relative path against the root, not the gemspec directory" do
+      spec = Dir.chdir(tmp) { subject.send(:load_gemspec, "bar/bar.gemspec") }
+
+      expect(spec.name).to eq("bar")
+      expect(spec.loaded_from).to eq(tmp("bar/bar.gemspec").to_s)
+      expect(spec.full_gem_path).to eq(tmp("bar").to_s)
+    end
+  end
 end


### PR DESCRIPTION
Passing a relative gemspec path to `Bundler::Source::Git#load_gemspec` fails with `Errno::ENOENT`, because the path resolves one directory too deep. The method changes into the gemspec's directory and then hands the still-relative path to `Gem::StubSpecification.gemspec_stub`, which reads the file while that chdir is active. I now expand the path once against `root` before the chdir and use it for both the stub and `full_gem_path`, so absolute inputs keep the same values as before and relative inputs resolve correctly. This is the `Source::Git` counterpart of #9814, which fixed the same double expansion in `Bundler.eval_gemspec`. The added spec fails on master with `ENOENT` and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
