### PR TITLE
Reject created_at years outside four digits in cooldown parsing

### DIFF
--- a/lib/bundler/endpoint_specification.rb
+++ b/lib/bundler/endpoint_specification.rb
@@ -193,11 +193,16 @@ module Bundler
     TIME_ZONE_SUFFIX = /(?:Z|z|[+-]\d{2}(?::?\d{2})?)\z/
     private_constant :TIME_ZONE_SUFFIX
 
+    # See Gem::Cooldown::FOUR_DIGIT_YEAR.
+    FOUR_DIGIT_YEAR = /\A\d{4}-/
+    private_constant :FOUR_DIGIT_YEAR
+
     # A timestamp without a time zone offset is read as UTC, because reading
     # it as local time would shift the cooldown window by the environment's
-    # offset. Unparsable values become nil so the cooldown fails open.
+    # offset. Unparsable values and years outside four digits become nil so
+    # the cooldown fails open.
     def parse_created_at(value)
-      return unless value.is_a?(String)
+      return unless value.is_a?(String) && value.match?(FOUR_DIGIT_YEAR)
 
       require "time"
       begin

--- a/lib/rubygems/cooldown.rb
+++ b/lib/rubygems/cooldown.rb
@@ -94,14 +94,21 @@ class Gem::Cooldown
   TIME_ZONE_SUFFIX = /(?:Z|z|[+-]\d{2}(?::?\d{2})?)\z/ # :nodoc:
   private_constant :TIME_ZONE_SUFFIX
 
+  # Matches the four-digit year an ISO 8601 timestamp starts with.
+  # Time.iso8601 also accepts a year of any length, and one far enough
+  # away overflows the Float arithmetic behind #remaining_days.
+  FOUR_DIGIT_YEAR = /\A\d{4}-/ # :nodoc:
+  private_constant :FOUR_DIGIT_YEAR
+
   ##
   # Parses a +created_at+ timestamp from the compact index.  A timestamp
   # without a time zone offset is read as UTC, because reading it as local
   # time would shift the cooldown window by the environment's offset.
-  # Returns nil for anything unparsable, so the cooldown fails open.
+  # Returns nil for anything unparsable, including a year outside four
+  # digits, so the cooldown fails open.
 
   def self.parse_created_at(value)
-    return unless value.is_a?(String)
+    return unless value.is_a?(String) && value.match?(FOUR_DIGIT_YEAR)
 
     require "time"
     begin

--- a/spec/bundler/endpoint_specification_spec.rb
+++ b/spec/bundler/endpoint_specification_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe Bundler::EndpointSpecification do
       end
     end
 
+    context "when created_at has a year that overflows Float arithmetic" do
+      let(:metadata) { { "created_at" => ["#{"9" * 400}-01-01T00:00:00Z"] } }
+
+      it "leaves created_at as nil" do
+        expect(subject.created_at).to be_nil
+      end
+    end
+
     context "when the metadata has an empty checksum value" do
       let(:metadata) { { "checksum" => [] } }
 

--- a/spec/bundler/resolver/cooldown_spec.rb
+++ b/spec/bundler/resolver/cooldown_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe Bundler::Resolver do
       end
     end
 
+    context "when created_at has a year that overflows Float arithmetic" do
+      it "keeps the spec like one without created_at" do
+        metadata = { "created_at" => ["#{"9" * 400}-01-01T00:00:00Z"] }
+        s = Bundler::EndpointSpecification.new("myrack", "1.0.0", Gem::Platform::RUBY, nil, [], metadata)
+        s.remote = remote(cooldown: 7)
+
+        expect(resolver.send(:filter_cooldown, [s])).to eq([s])
+      end
+    end
+
     context "when the remote has no cooldown" do
       it "keeps every spec" do
         s = spec(created_at: now - 3600, remote: remote(cooldown: nil))

--- a/spec/install/cooldown_spec.rb
+++ b/spec/install/cooldown_spec.rb
@@ -424,6 +424,22 @@ RSpec.describe "bundle install with the cooldown setting" do
       expect(the_bundle).to include_gems("ripe_gem 2.0.0")
     end
 
+    it "treats a created_at with a year that overflows Float arithmetic as unknown" do
+      gemfile <<-G
+        source "https://gem.repo3"
+        gem "ripe_gem"
+      G
+
+      bundle "install --cooldown 7", artifice: "compact_index_cooldown_bad_created_at"
+
+      expect(the_bundle).to include_gems("ripe_gem 2.0.0")
+      expect(out).not_to include("skipped by the cooldown setting")
+
+      bundle "outdated --cooldown 7", artifice: "compact_index_cooldown_bad_created_at", raise_on_error: false
+
+      expect(out).not_to include("cooldown")
+    end
+
     it "annotates in-cooldown versions in bundle outdated table output" do
       gemfile <<-G
         source "https://gem.repo3"

--- a/spec/support/artifice/compact_index_cooldown_bad_created_at.rb
+++ b/spec/support/artifice/compact_index_cooldown_bad_created_at.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "helpers/compact_index_cooldown"
+
+# Serves every version with a created_at year that Time.iso8601 accepts but
+# whose distance from now overflows Float.
+class CompactIndexCooldownBadCreatedAt < CompactIndexCooldownAPI
+  helpers do
+    def build_gem_version(spec, deps, checksum)
+      CompactIndex::GemVersionV2.new(spec.version.version, spec.platform.to_s, checksum, nil,
+        deps, spec.required_ruby_version.to_s, spec.required_rubygems_version.to_s, "#{"9" * 400}-01-01T00:00:00Z")
+    end
+  end
+end
+
+require_relative "helpers/artifice"
+
+Artifice.activate_with(CompactIndexCooldownBadCreatedAt)

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -788,6 +788,25 @@ ERROR:  Possible alternatives: non_existent_with_hint
     assert_match "--cooldown 0", @ui.error
   end
 
+  def test_execute_remote_cooldown_unparsable_created_at_fails_open
+    util_setup_cooldown_repo created_at: {
+      "a-1" => util_cooldown_time(30),
+      "a-2" => "#{"9" * 400}-01-01T00:00:00Z",
+    }
+
+    @cmd.options[:cooldown] = 7
+    @cmd.options[:args] = %w[a]
+
+    use_ui @ui do
+      assert_raise Gem::MockGemUi::SystemExitException, @ui.error do
+        @cmd.execute
+      end
+    end
+
+    assert_equal %w[a-2], @cmd.installed_specs.map(&:full_name)
+    refute_match "skipped by the cooldown setting", @ui.output
+  end
+
   def test_execute_remote_cooldown_missing_created_at_fails_open
     util_setup_cooldown_repo
 

--- a/test/rubygems/test_gem_commands_outdated_command.rb
+++ b/test/rubygems/test_gem_commands_outdated_command.rb
@@ -107,6 +107,20 @@ class TestGemCommandsOutdatedCommand < Gem::TestCase
     assert_equal 1, @ui.error.scan("publish times").size
   end
 
+  def test_execute_cooldown_unparsable_created_at_fails_open
+    util_setup_cooldown_repo "foo-0.2" => util_cooldown_time(30),
+                             "foo-0.3" => "#{"9" * 400}-01-01T00:00:00Z"
+
+    @cmd.options[:cooldown] = 7
+
+    use_ui @ui do
+      @cmd.execute
+    end
+
+    assert_equal "foo (0.1 < 0.3)\n", @ui.output
+    assert_equal "", @ui.error
+  end
+
   def test_cooldown_option
     @cmd.handle_options %w[--cooldown 7]
 

--- a/test/rubygems/test_gem_cooldown.rb
+++ b/test/rubygems/test_gem_cooldown.rb
@@ -113,6 +113,13 @@ class TestGemCooldown < Gem::TestCase
     assert_nil Gem::Cooldown.parse_created_at(7)
   end
 
+  def test_parse_created_at_rejects_years_outside_four_digits
+    # Time.iso8601 accepts these, but the distance from now overflows Float.
+    assert_nil Gem::Cooldown.parse_created_at("#{"9" * 400}-01-01T00:00:00Z")
+    assert_nil Gem::Cooldown.parse_created_at("-2026-06-05T10:30:45Z")
+    assert_nil Gem::Cooldown.parse_created_at("02026-06-05T10:30:45Z")
+  end
+
   def with_tz(tz)
     orig_tz = ENV["TZ"]
     ENV["TZ"] = tz


### PR DESCRIPTION
With a cooldown configured, a compact index `/info/<gem>` line whose `created_at` has an absurdly long year (400 digits reproduces it) aborts `bundle install`, `update`, `lock` and `outdated`, and `gem install`, `update` and `outdated`, with `FloatDomainError: Infinity`. `Time.iso8601` accepts such a year, the distance from now overflows to Infinity, and `ceil` raises while the post-resolve cooldown summary is built. A broken or malicious mirror can therefore break every cooldown user. This is pre-existing in the unreleased 4.1.0 cooldown work and surfaced while reviewing #9801.

I reject years outside four digits at parse time, in both `Gem::Cooldown.parse_created_at` and Bundler's `EndpointSpecification`, so the existing missing-`created_at` handling takes over: the version is treated as having no publish time and stays installable, like a line without `created_at`. A mirror controlling `created_at` could already backdate it, so this fail-open loses nothing. ISO 8601 and rubygems.org both use four-digit years.

Generated with [Claude Code](https://claude.com/claude-code)
