### PR TITLE
Point bundler's changelog_uri at the unified CHANGELOG.md

### DIFF
--- a/bundler/bundler.gemspec
+++ b/bundler/bundler.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/ruby/rubygems/issues?q=is%3Aopen+is%3Aissue+label%3ABundler",
-    "changelog_uri" => "https://github.com/ruby/rubygems/blob/master/CHANGELOG-bundler.md",
+    "changelog_uri" => "https://github.com/ruby/rubygems/blob/master/CHANGELOG.md",
     "homepage_uri" => "https://bundler.io/",
     "source_code_uri" => "https://github.com/ruby/rubygems",
   }


### PR DESCRIPTION
The `bundler` gem published from this branch advertises `changelog_uri` as `https://github.com/ruby/rubygems/blob/master/CHANGELOG-bundler.md`. #9847 folds `CHANGELOG-bundler.md` into `CHANGELOG.md` on master, so that path disappears and the link on rubygems.org starts returning 404 for 4.0.21 and every release after it.

This points the metadata at the unified `CHANGELOG.md` on master instead. That is the only change here. The 4.0 branch keeps its own two-file changelog layout, and `bundler/CHANGELOG.md`, `bundler/LICENSE.md` and `bundler/README.md` still ship inside the gem.

The new URL does not exist until #9847 lands, so please merge this after that one.

Generated with [Claude Code](https://claude.com/claude-code)
