### PR TITLE
Speed up release preparation by listing merged pull requests

### DIFF
--- a/test/test_release.rb
+++ b/test/test_release.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "tmpdir"
+
 require_relative "../tool/release"
 require_relative "rubygems/helper"
 
@@ -45,17 +47,15 @@ class ReleaseTest < Test::Unit::TestCase
   end
 
   def test_pull_requests_merged_into_keeps_only_the_ones_whose_merge_commit_landed
-    release = self.release
-    landed = "a" * 40
-    json = listing([
-      record("number" => 1, "mergeCommit" => { "oid" => landed }),
-      record("number" => 2, "mergeCommit" => { "oid" => "b" * 40 }),
-    ])
-    pulls = release.send(:pull_requests_from, json, "master since 2026-01-01")
+    in_a_repo_with_two_commits do |first, second|
+      json = listing([
+        record("number" => 1, "mergeCommit" => { "oid" => second }),
+        record("number" => 2, "mergeCommit" => { "oid" => first }),
+      ])
+      pulls = release.send(:pull_requests_from, json, "master since 2026-01-01")
 
-    release.stub(:`, "#{landed}\n") do
       release.stub(:merged_pull_requests, pulls) do
-        assert_equal [1], release.send(:pull_requests_merged_into, "master", "v4.0.0", "HEAD").map(&:number)
+        assert_equal [1], release.send(:pull_requests_merged_into, "master", first, second).map(&:number)
       end
     end
   end
@@ -65,7 +65,29 @@ class ReleaseTest < Test::Unit::TestCase
   # A minor release, so that the constructor derives the previous release tag
   # from the version instead of shelling out to `git describe`.
   def release
-    Release.new("4.1.0")
+    @release ||= Release.new("4.1.0")
+  end
+
+  # `pull_requests_merged_into` resolves its range against the working
+  # directory, and CI checks out with no history to resolve one against.
+  def in_a_repo_with_two_commits
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        git("init")
+        git("commit", "--allow-empty", "-m", "first")
+        first = `git rev-parse HEAD`.strip
+        git("commit", "--allow-empty", "-m", "second")
+
+        yield first, `git rev-parse HEAD`.strip
+      end
+    end
+  end
+
+  def git(*args)
+    system(
+      "git", "-c", "user.name=Release Test", "-c", "user.email=test@example.com", "-c", "commit.gpgsign=false",
+      *args, out: IO::NULL, err: IO::NULL, exception: true
+    )
   end
 
   def listing(records)

--- a/test/test_release.rb
+++ b/test/test_release.rb
@@ -60,6 +60,22 @@ class ReleaseTest < Test::Unit::TestCase
     end
   end
 
+  def test_pull_requests_merged_into_fails_when_the_range_does_not_resolve
+    error = assert_raise(RuntimeError) do
+      release.send(:pull_requests_merged_into, "master", "no-such-ref-for-a-test", "HEAD")
+    end
+
+    assert_include error.message, "no-such-ref-for-a-test..HEAD"
+  end
+
+  def test_merged_pull_requests_fails_when_the_bounding_ref_does_not_resolve
+    error = assert_raise(RuntimeError) do
+      release.send(:merged_pull_requests, "master", "no-such-ref-for-a-test")
+    end
+
+    assert_include error.message, "no-such-ref-for-a-test"
+  end
+
   private
 
   # A minor release, so that the constructor derives the previous release tag

--- a/test/test_release.rb
+++ b/test/test_release.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative "../tool/release"
+require_relative "rubygems/helper"
+
+class ReleaseTest < Test::Unit::TestCase
+  def test_pull_requests_from_maps_a_listing_record_to_the_fields_the_changelog_uses
+    pull = release.send(:pull_requests_from, listing([record]), "master since 2026-01-01").first
+
+    assert_equal 9852, pull.number
+    assert_equal "Let the gem and bundle cooldown settings cover each other", pull.title
+    assert_equal "https://github.com/ruby/rubygems/pull/9852", pull.html_url
+    assert_equal ["bundler: bug fix"], pull.labels.map(&:name)
+    assert_equal Time.utc(2026, 9, 4, 2, 23, 29), pull.merged_at
+    assert_equal "Hiroshi SHIBATA", pull.user.name
+    assert_equal "hsbt", pull.user.login
+    assert_equal "0602168df08a985b635ea24fb80f9048465f9530", pull.merge_commit_sha
+  end
+
+  def test_pull_requests_from_falls_back_to_the_login_when_the_author_has_no_name
+    json = listing([record("author" => { "login" => "app/dependabot", "name" => "" })])
+
+    pull = release.send(:pull_requests_from, json, "master since 2026-01-01").first
+
+    assert_nil pull.user.name
+    assert_equal "app/dependabot", pull.user.login
+  end
+
+  def test_pull_requests_from_refuses_a_truncated_listing
+    json = listing(Array.new(Release::MERGED_PULL_REQUEST_LIMIT) { record })
+
+    error = assert_raise(RuntimeError) do
+      release.send(:pull_requests_from, json, "master since 2026-01-01")
+    end
+
+    assert_include error.message, "truncated"
+  end
+
+  def test_pull_requests_merged_into_keeps_only_the_ones_whose_merge_commit_landed
+    release = self.release
+    landed = "a" * 40
+    json = listing([
+      record("number" => 1, "mergeCommit" => { "oid" => landed }),
+      record("number" => 2, "mergeCommit" => { "oid" => "b" * 40 }),
+    ])
+    pulls = release.send(:pull_requests_from, json, "master since 2026-01-01")
+
+    release.stub(:`, "#{landed}\n") do
+      release.stub(:merged_pull_requests, pulls) do
+        assert_equal [1], release.send(:pull_requests_merged_into, "master", "v4.0.0", "HEAD").map(&:number)
+      end
+    end
+  end
+
+  private
+
+  # A minor release, so that the constructor derives the previous release tag
+  # from the version instead of shelling out to `git describe`.
+  def release
+    Release.new("4.1.0")
+  end
+
+  def listing(records)
+    JSON.dump(records)
+  end
+
+  def record(overrides = {})
+    {
+      "number" => 9852,
+      "title" => "Let the gem and bundle cooldown settings cover each other",
+      "url" => "https://github.com/ruby/rubygems/pull/9852",
+      "labels" => [{ "name" => "bundler: bug fix" }],
+      "mergedAt" => "2026-09-04T02:23:29Z",
+      "author" => { "login" => "hsbt", "name" => "Hiroshi SHIBATA" },
+      "mergeCommit" => { "oid" => "0602168df08a985b635ea24fb80f9048465f9530" },
+    }.merge(overrides)
+  end
+end

--- a/test/test_release.rb
+++ b/test/test_release.rb
@@ -36,6 +36,14 @@ class ReleaseTest < Test::Unit::TestCase
     assert_include error.message, "truncated"
   end
 
+  def test_pull_requests_from_skips_a_pull_request_whose_merge_commit_is_gone
+    json = listing([record, record("number" => 1, "mergeCommit" => nil)])
+
+    pulls = release.send(:pull_requests_from, json, "master since 2026-01-01")
+
+    assert_equal [9852], pulls.map(&:number)
+  end
+
   def test_pull_requests_merged_into_keeps_only_the_ones_whose_merge_commit_landed
     release = self.release
     landed = "a" * 40

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -426,7 +426,7 @@ class Release
 
       pulls.reject! {|pull| released_commit_shas.include?(pull.merge_commit_sha) } if @level == :patch
 
-      pulls.sort_by(&:merged_at)
+      pulls
     end
   end
 

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -461,7 +461,9 @@ class Release
       raise "More than #{MERGED_PULL_REQUEST_LIMIT} pull requests were merged into #{window}, so the listing is truncated. Split the query into narrower date ranges."
     end
 
-    records.map {|record| build_pull_request(record) }
+    # GitHub reports no merge commit for a pull request whose merge commit is
+    # gone, and a commit that is gone is never reachable.
+    records.reject {|record| record["mergeCommit"].nil? }.map {|record| build_pull_request(record) }
   end
 
   def build_pull_request(record)

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -12,8 +12,9 @@ class Release
   User = Struct.new(:name, :login)
   PullRequest = Struct.new(:number, :title, :html_url, :labels, :merged_at, :user, :merge_commit_sha)
 
-  # `gh pr list` refuses to return more than this many results, and truncates
-  # silently once the window holds more.
+  # `gh pr list` refuses to return more than this many results and truncates
+  # silently once a window holds more, so a listing that reaches the cap is
+  # refused rather than cut from a partial one.
   MERGED_PULL_REQUEST_LIMIT = 1000
 
   module GithubAPI
@@ -412,15 +413,15 @@ class Release
 
   # Pull requests included in this release. `mergeCommit.oid` is the commit a
   # pull request leaves on its base branch under every merge strategy, so
-  # intersecting the merged pull requests with the local history answers
-  # "is this one included?" exactly, without asking the commit search index.
+  # intersecting one listing with the local history answers "is this one
+  # included?" exactly, in place of a search per commit.
   def unreleased_pull_requests
     @unreleased_pull_requests ||= begin
       head = @level == :minor_or_major ? "HEAD" : "origin/master"
       pulls = pull_requests_merged_into("master", @previous_release_tag, head)
 
       # Dedicated backport PRs target the stable branch instead of master, so
-      # the scan above cannot see them and their changelog entries would
+      # the listing above cannot see them and their changelog entries would
       # otherwise be dropped from the release.
       pulls += pull_requests_merged_into(@stable_branch, @last_release_tag, "origin/#{@stable_branch}") if @level == :patch
 
@@ -430,8 +431,6 @@ class Release
     end
   end
 
-  # Pull requests merged into `base` whose merge commit is reachable in
-  # `from..to`.
   def pull_requests_merged_into(base, from, to)
     commits = `git rev-list #{from}..#{to}`
     raise "Failed to list the commits in #{from}..#{to}" unless $?.success?
@@ -441,10 +440,7 @@ class Release
     merged_pull_requests(base, from).select {|pull| reachable.include?(pull.merge_commit_sha) }
   end
 
-  # Merged pull requests targeting `base`, bounded to those merged no earlier
-  # than the commit `since_ref` points at. The bound exists only to keep the
-  # query small, since reachability is what makes the result exact, so it is
-  # deliberately loose: the UTC day before that commit.
+  # The date bound is deliberately loose. It bounds the query, not the result.
   def merged_pull_requests(base, since_ref)
     committed_at = `git log -1 --format=%cI #{since_ref}`.strip
     raise "Failed to resolve #{since_ref}" unless $?.success?
@@ -457,9 +453,6 @@ class Release
     pull_requests_from(json, "#{base} since #{since}")
   end
 
-  # `gh pr list` truncates silently once a window holds more than its result
-  # cap, which would drop changelog entries without a word, so refuse a listing
-  # that reaches it rather than cutting a release from a partial one.
   def pull_requests_from(json, window)
     records = JSON.parse(json)
 

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -433,7 +433,10 @@ class Release
   # Pull requests merged into `base` whose merge commit is reachable in
   # `from..to`.
   def pull_requests_merged_into(base, from, to)
-    reachable = Set.new(`git rev-list #{from}..#{to}`.split("\n"))
+    commits = `git rev-list #{from}..#{to}`
+    raise "Failed to list the commits in #{from}..#{to}" unless $?.success?
+
+    reachable = Set.new(commits.split("\n"))
 
     merged_pull_requests(base, from).select {|pull| reachable.include?(pull.merge_commit_sha) }
   end
@@ -443,7 +446,10 @@ class Release
   # query small, since reachability is what makes the result exact, so it is
   # deliberately loose: the UTC day before that commit.
   def merged_pull_requests(base, since_ref)
-    since = (Time.iso8601(`git log -1 --format=%cI #{since_ref}`.strip) - 86_400).utc.strftime("%Y-%m-%d")
+    committed_at = `git log -1 --format=%cI #{since_ref}`.strip
+    raise "Failed to resolve #{since_ref}" unless $?.success?
+
+    since = (Time.iso8601(committed_at) - 86_400).utc.strftime("%Y-%m-%d")
 
     json = `gh pr list --repo ruby/rubygems --state merged --base #{base} --search 'merged:>=#{since}' --limit #{MERGED_PULL_REQUEST_LIMIT} --json number,title,labels,mergeCommit,mergedAt,author,url`
     raise "Failed to list pull requests merged into #{base} since #{since}" unless $?.success?

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -1,8 +1,21 @@
 # frozen_string_literal: true
 
+require "json"
+require "time"
+
 require_relative "changelog"
 
 class Release
+  # The pull request data the release tooling consumes, built from a
+  # `gh pr list` record so that no per pull request API call is needed.
+  Label = Struct.new(:name)
+  User = Struct.new(:name, :login)
+  PullRequest = Struct.new(:number, :title, :html_url, :labels, :merged_at, :user, :merge_commit_sha)
+
+  # `gh pr list` refuses to return more than this many results, and truncates
+  # silently once the window holds more.
+  MERGED_PULL_REQUEST_LIMIT = 1000
+
   module GithubAPI
     def gh_client
       @gh_client ||= begin
@@ -272,7 +285,7 @@ class Release
     # another cherry-pick.
     prs = prs.reject {|pr| already_on_stable_branch?(pr) }
 
-    puts "The following unreleased prs were found:\n#{prs.map {|pr| "* #{pr.url}" }.join("\n")}"
+    puts "The following unreleased prs were found:\n#{prs.map {|pr| "* #{pr.html_url}" }.join("\n")}"
 
     prs.each do |pr|
       args = cherry_pick_args_for(pr)
@@ -280,7 +293,7 @@ class Release
 
       warn <<~MSG
 
-        Cherry-picking #{pr.url} failed. Opening a new shell to fix the errors manually. You can do the following now:
+        Cherry-picking #{pr.html_url} failed. Opening a new shell to fix the errors manually. You can do the following now:
 
         * If you'd like to include that PR in the release, fix conflicts manually, run `git add . && git cherry-pick --continue` once done, and if it succeeds, run `exit 0` to resume the release preparation.
         * If you don't want to include that PR in the release, run `git cherry-pick --abort` and then `exit 0` to skip it and resume.
@@ -397,8 +410,75 @@ class Release
     @relevant_pull_requests ||= unreleased_pull_requests.select {|pull| @changelog.labelled?(pull) }.sort_by(&:merged_at)
   end
 
+  # Pull requests included in this release. `mergeCommit.oid` is the commit a
+  # pull request leaves on its base branch under every merge strategy, so
+  # intersecting the merged pull requests with the local history answers
+  # "is this one included?" exactly, without asking the commit search index.
   def unreleased_pull_requests
-    @unreleased_pull_requests ||= scan_unreleased_pull_requests(unreleased_pr_ids)
+    @unreleased_pull_requests ||= begin
+      head = @level == :minor_or_major ? "HEAD" : "origin/master"
+      pulls = pull_requests_merged_into("master", @previous_release_tag, head)
+
+      # Dedicated backport PRs target the stable branch instead of master, so
+      # the scan above cannot see them and their changelog entries would
+      # otherwise be dropped from the release.
+      pulls += pull_requests_merged_into(@stable_branch, @last_release_tag, "origin/#{@stable_branch}") if @level == :patch
+
+      pulls.reject! {|pull| released_commit_shas.include?(pull.merge_commit_sha) } if @level == :patch
+
+      pulls.sort_by(&:merged_at)
+    end
+  end
+
+  # Pull requests merged into `base` whose merge commit is reachable in
+  # `from..to`.
+  def pull_requests_merged_into(base, from, to)
+    reachable = Set.new(`git rev-list #{from}..#{to}`.split("\n"))
+
+    merged_pull_requests(base, from).select {|pull| reachable.include?(pull.merge_commit_sha) }
+  end
+
+  # Merged pull requests targeting `base`, bounded to those merged no earlier
+  # than the commit `since_ref` points at. The bound exists only to keep the
+  # query small, since reachability is what makes the result exact, so it is
+  # deliberately loose: the UTC day before that commit.
+  def merged_pull_requests(base, since_ref)
+    since = (Time.iso8601(`git log -1 --format=%cI #{since_ref}`.strip) - 86_400).utc.strftime("%Y-%m-%d")
+
+    json = `gh pr list --repo ruby/rubygems --state merged --base #{base} --search 'merged:>=#{since}' --limit #{MERGED_PULL_REQUEST_LIMIT} --json number,title,labels,mergeCommit,mergedAt,author,url`
+    raise "Failed to list pull requests merged into #{base} since #{since}" unless $?.success?
+
+    pull_requests_from(json, "#{base} since #{since}")
+  end
+
+  # `gh pr list` truncates silently once a window holds more than its result
+  # cap, which would drop changelog entries without a word, so refuse a listing
+  # that reaches it rather than cutting a release from a partial one.
+  def pull_requests_from(json, window)
+    records = JSON.parse(json)
+
+    if records.size >= MERGED_PULL_REQUEST_LIMIT
+      raise "More than #{MERGED_PULL_REQUEST_LIMIT} pull requests were merged into #{window}, so the listing is truncated. Split the query into narrower date ranges."
+    end
+
+    records.map {|record| build_pull_request(record) }
+  end
+
+  def build_pull_request(record)
+    author = record["author"]
+    # `gh` reports a missing author name as an empty string, while the changelog
+    # entry template expects to fall back to the login when there is none.
+    name = author["name"]
+
+    PullRequest.new(
+      record["number"],
+      record["title"],
+      record["url"],
+      record["labels"].map {|label| Label.new(label["name"]) },
+      Time.iso8601(record["mergedAt"]),
+      User.new(name.to_s.empty? ? nil : name, author["login"]),
+      record["mergeCommit"]["oid"]
+    )
   end
 
   # True when the PR's merged commit is already reachable from the release
@@ -408,21 +488,12 @@ class Release
     system("git", "merge-base", "--is-ancestor", pr.merge_commit_sha, "HEAD", out: IO::NULL, err: IO::NULL)
   end
 
-  # Commits merged directly onto the stable branch since the last release, such
-  # as dedicated backport PRs that target the stable branch instead of being
-  # cherry-picked from master. They never land on master, so the master scan in
-  # `unreleased_pr_ids` cannot see them and their changelog entries would
-  # otherwise be dropped from the release.
-  def stable_branch_backport_commits
-    `git log --format=%H #{@last_release_tag}..origin/#{@stable_branch}`.split("\n").reject(&:empty?)
-  end
-
   # Source SHAs already cherry-picked onto the stable branch, derived from the
   # `(cherry picked from commit X)` footer that `git cherry-pick -x` records.
   # When the footer references a merge commit (PRs merged with "Create a merge
   # commit", picked with `-m 1`), also include the individual PR commits the
-  # merge introduced, otherwise `gh search prs` would still re-discover the PR
-  # through those commits left on master.
+  # merge introduced, so that a pull request is recognized as released no
+  # matter which of its commits the footer names.
   def released_commit_shas
     @released_commit_shas ||= begin
       log = `git log --format=%B #{@previous_release_tag}..origin/#{@stable_branch}`
@@ -435,52 +506,5 @@ class Release
       end
       shas
     end
-  end
-
-  def scan_unreleased_pull_requests(ids)
-    pulls = []
-    ids.each do |id|
-      pull = gh_client.pull_request("ruby/rubygems", id)
-      next unless pull.merged_at
-      # `gh search prs` can associate a PR with commits left behind by
-      # force-pushes that no longer match the merged HEAD. Confirm the PR is
-      # actually unreleased by comparing its merge commit SHA directly.
-      next if @level == :patch && released_commit_shas.include?(pull.merge_commit_sha)
-      pulls << pull
-    end
-    pulls
-  end
-
-  def unreleased_pr_ids
-    head = @level == :minor_or_major ? "HEAD" : "origin/master"
-    commits = `git log --format=%H #{@previous_release_tag}..#{head}`.split("\n")
-    commits.reject! {|sha| released_commit_shas.include?(sha) } if @level == :patch
-    commits.concat(stable_branch_backport_commits) if @level == :patch
-
-    # GitHub search API has a rate limit of 30 requests per minute for authenticated users
-    rate_limit = 28
-    # GitHub search API only accepts 250 characters per search query
-    batch_size = 15
-    sleep_duration = 60 # seconds
-
-    pr_ids = Set.new
-
-    commits.each_slice(batch_size).with_index do |batch, index|
-      puts "Processing batch #{index + 1}/#{(commits.size / batch_size.to_f).ceil}"
-      result = `gh search prs --repo ruby/rubygems #{batch.join(",")} --json number --jq '.[].number'`.strip
-      raise "gh search prs failed for batch #{index + 1}" unless $?.success?
-      unless result.empty?
-        result.split("\n").each do |pr_number|
-          pr_ids.add(pr_number.to_i)
-        end
-      end
-
-      if index != 0 && index % rate_limit == 0
-        puts "Sleeping for #{sleep_duration} seconds to avoid rate limiting..."
-        sleep(sleep_duration)
-      end
-    end
-
-    pr_ids.to_a
   end
 end


### PR DESCRIPTION
Preparing a release now takes seconds instead of minutes.

Mapping commits back to pull requests used about 570 requests: 102 `gh search prs` calls with a forced sleep every 28, then one REST fetch per pull request found. `mergeCommit.oid` names the commit a pull request leaves on its base branch under every merge strategy, so one `gh pr list` call intersected with the local history answers the same question exactly.

For 4.1.0.beta1 the old scan and the new listing find the same set of pull requests, and the listing takes six seconds instead of eight to ten minutes. A full `DRYRUN=1 rake prepare_release[4.1.0.beta1]` now finishes in 39 seconds and produces the same changelog section.

This also drops the workaround for force-pushed commits that `gh search prs` could still associate with a pull request, since reachability answers that directly.

One narrowing worth naming: the listing asks for `--base master`, so a pull request that targeted an intermediate branch which was later merged into master no longer shows up, where the commit scan found it through its commits. Nothing in the last nine months hits that, and this repository merges into master directly.

Generated with [Claude Code](https://claude.com/claude-code)
