### PR TITLE
Stop depending on `getconf` in env helper specs

### DIFF
--- a/spec/runtime/env_helpers_spec.rb
+++ b/spec/runtime/env_helpers_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "env helpers" do
       create_file("source.rb", <<-RUBY)
         print Bundler.original_env["PATH"]
       RUBY
-      path = `getconf PATH`.strip + "#{File::PATH_SEPARATOR}/foo"
+      path = default_system_path + "#{File::PATH_SEPARATOR}/foo"
       with_path_as(path) do
         bundle_exec_ruby(bundled_app("source.rb").to_s)
         expect(stdboth).to eq(path)
@@ -49,7 +49,7 @@ RSpec.describe "env helpers" do
         end
         exec(Gem.ruby, __FILE__, (count - 1).to_s)
       RUBY
-      path = `getconf PATH`.strip + File::PATH_SEPARATOR + File.dirname(Gem.ruby)
+      path = default_system_path + File::PATH_SEPARATOR + File.dirname(Gem.ruby)
       with_path_as(path) do
         build_bundler_context
         bundle_exec_ruby("#{bundled_app("exe.rb")} 2")

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -428,6 +428,12 @@ module Spec
       end
     end
 
+    # Windows has no `getconf`, and its current PATH holds the directories the
+    # Ruby under test finds its DLLs in, so keep it as is there.
+    def default_system_path
+      Gem.win_platform? ? ENV["PATH"] : `getconf PATH`.strip
+    end
+
     def with_path_as(path)
       without_env_side_effects do
         ENV["PATH"] = path.to_s


### PR DESCRIPTION
`nmake test-bundler-parallel` on mswin fails in `spec/runtime/env_helpers_spec.rb` with `Errno::ENOENT: No such file or directory - getconf PATH`. Windows has no `getconf`, so these two examples only pass when MSYS2 or Git for Windows happens to be on `PATH`, and neither is a requirement for running the specs.

Even when it did resolve, `getconf PATH` returned `/bin:/usr/bin`, so the examples set `PATH` to a value that means nothing on Windows. They passed only because every command they run is invoked by absolute path.

The examples just need some base `PATH` to round-trip through `BUNDLER_ORIG_PATH`, so `default_system_path` keeps the current `PATH` on Windows, which also preserves the directories the Ruby under test loads its DLLs from. Verified on mswin: 18 examples, 0 failures.

Generated with [Claude Code](https://claude.com/claude-code)
