### PR TITLE
Fix gem doctor recursion and quiet the test suite output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -105,7 +105,7 @@ task "coverage:report" do
     next
   end
 
-  $stdout = File.open(File::NULL, "w")
+  $stderr = File.open(File::NULL, "w")
   SimpleCov.collate Dir[resultset] do
     coverage_dir "coverage"
     skip "/test/"
@@ -124,7 +124,7 @@ task "coverage:report" do
     end
   end
 ensure
-  $stdout = STDOUT
+  $stderr = STDERR
 end
 
 spec = Gem::Specification.load(File.expand_path("rubygems-update.gemspec", __dir__))

--- a/lib/rubygems/doctor.rb
+++ b/lib/rubygems/doctor.rb
@@ -117,7 +117,7 @@ class Gem::Doctor
 
       if sub_directory == "specifications" && File.directory?(child) &&
          Gem::ContentAddress.valid_ruby_abi?(ent)
-        doctor_child(File.join(sub_directory, ent), extension) if ent == Gem.ruby_abi && !File.symlink?(child)
+        doctor_child(File.join(sub_directory, ent), *extensions) if ent == Gem.ruby_abi && !File.symlink?(child)
         next
       end
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -20,6 +20,8 @@ begin
       skip ".gemspec"
     end
 
+    SimpleCov.print_error_status = false
+
     # Prevent SimpleCov from running in subprocesses spawned by assert_separately
     ENV["SIMPLECOV_SUBPROCESS"] = "1"
   end

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -1379,6 +1379,15 @@ Also, a list:
     Object.const_set :RUBY_ENGINE_VERSION, engine_version
   end
 
+  ##
+  # Pins the running Ruby to the first release of +ruby_abi+, so that the
+  # "~> X.Y.0" requirement a content addressed gem pins its ABI with is
+  # satisfied on a prerelease Ruby too. Pair with util_restore_RUBY_VERSION.
+
+  def util_pin_ruby_to_abi(ruby_abi)
+    util_set_RUBY_VERSION "#{ruby_abi}.0", 0, RUBY_REVISION, "ruby #{ruby_abi}.0"
+  end
+
   def util_restore_RUBY_VERSION
     util_clear_RUBY_VERSION
 

--- a/test/rubygems/test_gem_dependency_installer.rb
+++ b/test/rubygems/test_gem_dependency_installer.rb
@@ -425,8 +425,8 @@ class TestGemDependencyInstaller < Gem::TestCase
   end
 
   def test_install_local_by_name_preserves_content_address
-    ruby_abi = Gem.ruby_version.segments.first(2).join(".")
-    util_set_RUBY_VERSION "#{ruby_abi}.0", 0, RUBY_REVISION, "ruby #{ruby_abi}.0"
+    ruby_abi = Gem.ruby_abi
+    util_pin_ruby_to_abi ruby_abi
     _spec, ca_gem = util_gem("ca", "1.0.0", ruby_abi: ruby_abi) do |spec|
       spec.platform = Gem::Platform.local
     end

--- a/test/rubygems/test_gem_doctor.rb
+++ b/test/rubygems/test_gem_doctor.rb
@@ -255,10 +255,13 @@ Removed file plugins/a_badly_named_file.rb
 
     doctor = Gem::Doctor.new @gemhome
 
-    use_ui @ui do
-      doctor.doctor
+    _, err = capture_output do
+      use_ui @ui do
+        doctor.doctor
+      end
     end
 
+    assert_include err, "Invalid gemspec"
     assert_path_exist abi_dir
     assert_path_exist gemspec_path
     assert_path_not_exist corrupt_path
@@ -297,10 +300,13 @@ Removed file plugins/a_badly_named_file.rb
 
     doctor = Gem::Doctor.new @gemhome
 
-    use_ui @ui do
-      doctor.doctor
+    _, err = capture_output do
+      use_ui @ui do
+        doctor.doctor
+      end
     end
 
+    assert_include err, "Invalid gemspec"
     assert File.symlink?(link)
     assert_path_exist outside_path
   end

--- a/test/rubygems/test_gem_package_task.rb
+++ b/test/rubygems/test_gem_package_task.rb
@@ -44,6 +44,9 @@ class TestGemPackageTask < Gem::TestCase
   end
 
   def test_moves_filename_returned_by_build
+    original_rake_fileutils_verbosity = RakeFileUtils.verbose_flag
+    RakeFileUtils.verbose_flag = false
+
     gem = Gem::Specification.new do |g|
       g.name = "pkgr"
       g.version = "1.2.3"
@@ -82,6 +85,8 @@ class TestGemPackageTask < Gem::TestCase
       assert_equal "pkg/pkgr-1.2.3-01234567.gem", built_files.first
       assert_path_not_exist "pkg/pkgr-1.2.3-arm64-darwin.gem"
     end
+  ensure
+    RakeFileUtils.verbose_flag = original_rake_fileutils_verbosity
   end
 
   def test_gem_package_prints_to_stdout_by_default

--- a/test/rubygems/test_gem_resolver.rb
+++ b/test/rubygems/test_gem_resolver.rb
@@ -338,7 +338,8 @@ class TestGemResolver < Gem::TestCase
 
   def test_prefers_compatible_content_addressed_gem_over_more_specific_platform
     util_set_arch "arm64-darwin-27"
-    current_abi = "#{Gem.ruby_version.segments[0]}.#{Gem.ruby_version.segments[1]}"
+    current_abi = Gem.ruby_abi
+    util_pin_ruby_to_abi current_abi
 
     ca_spec = util_spec "a", "1"
     fat_spec = util_spec "a", "1"
@@ -352,6 +353,8 @@ class TestGemResolver < Gem::TestCase
     dependency = make_dep "a"
     resolver = Gem::Resolver.new([dependency], s)
     assert_resolves_to [ca_spec], resolver
+  ensure
+    util_restore_RUBY_VERSION
   end
 
   def test_prefers_more_specific_platform_over_content_addressed_gem_for_another_ruby
@@ -419,7 +422,8 @@ class TestGemResolver < Gem::TestCase
   end
 
   def test_prefers_compatible_content_addressed_gem_when_multiple_abis_available
-    current_abi = "#{Gem.ruby_version.segments[0]}.#{Gem.ruby_version.segments[1]}"
+    current_abi = Gem.ruby_abi
+    util_pin_ruby_to_abi current_abi
 
     ca_compatible = util_spec "a", "1"
     ca_incompatible = util_spec "a", "1"
@@ -435,6 +439,8 @@ class TestGemResolver < Gem::TestCase
     dependency = make_dep "a"
     resolver = Gem::Resolver.new([dependency], s)
     assert_resolves_to [ca_compatible], resolver
+  ensure
+    util_restore_RUBY_VERSION
   end
 
   def test_raises_when_only_content_addressed_gem_is_incompatible

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -431,8 +431,15 @@ class Release
     end
   end
 
+  # Runs a git command whose failure the caller handles itself, so git's own
+  # diagnosis stays out of the output. The array form keeps this off the
+  # shell, where a redirect would not be portable.
+  def git_quietly(*args)
+    IO.popen(["git", *args], err: IO::NULL, &:read)
+  end
+
   def pull_requests_merged_into(base, from, to)
-    commits = IO.popen(["git", "rev-list", "#{from}..#{to}"], err: IO::NULL, &:read)
+    commits = git_quietly("rev-list", "#{from}..#{to}")
     raise "Failed to list the commits in #{from}..#{to}" unless $?.success?
 
     reachable = Set.new(commits.split("\n"))
@@ -442,7 +449,7 @@ class Release
 
   # The date bound is deliberately loose. It bounds the query, not the result.
   def merged_pull_requests(base, since_ref)
-    committed_at = IO.popen(["git", "log", "-1", "--format=%cI", since_ref], err: IO::NULL, &:read).strip
+    committed_at = git_quietly("log", "-1", "--format=%cI", since_ref).strip
     raise "Failed to resolve #{since_ref}" unless $?.success?
 
     since = (Time.iso8601(committed_at) - 86_400).utc.strftime("%Y-%m-%d")
@@ -501,7 +508,7 @@ class Release
       shas = Set.new
       log.scan(/cherry picked from commit ([0-9a-f]+)/).flatten.each do |sha|
         shas << sha
-        parents = `git rev-list --parents -n 1 #{sha} 2>/dev/null`.strip.split.drop(1)
+        parents = git_quietly("rev-list", "--parents", "-n", "1", sha).strip.split.drop(1)
         next unless parents.size >= 2
         shas.merge(`git log --format=%H #{parents[0]}..#{parents[1]}`.split("\n"))
       end

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -432,7 +432,7 @@ class Release
   end
 
   def pull_requests_merged_into(base, from, to)
-    commits = `git rev-list #{from}..#{to}`
+    commits = `git rev-list #{from}..#{to} 2>/dev/null`
     raise "Failed to list the commits in #{from}..#{to}" unless $?.success?
 
     reachable = Set.new(commits.split("\n"))
@@ -442,7 +442,7 @@ class Release
 
   # The date bound is deliberately loose. It bounds the query, not the result.
   def merged_pull_requests(base, since_ref)
-    committed_at = `git log -1 --format=%cI #{since_ref}`.strip
+    committed_at = `git log -1 --format=%cI #{since_ref} 2>/dev/null`.strip
     raise "Failed to resolve #{since_ref}" unless $?.success?
 
     since = (Time.iso8601(committed_at) - 86_400).utc.strftime("%Y-%m-%d")

--- a/tool/release.rb
+++ b/tool/release.rb
@@ -432,7 +432,7 @@ class Release
   end
 
   def pull_requests_merged_into(base, from, to)
-    commits = `git rev-list #{from}..#{to} 2>/dev/null`
+    commits = IO.popen(["git", "rev-list", "#{from}..#{to}"], err: IO::NULL, &:read)
     raise "Failed to list the commits in #{from}..#{to}" unless $?.success?
 
     reachable = Set.new(commits.split("\n"))
@@ -442,7 +442,7 @@ class Release
 
   # The date bound is deliberately loose. It bounds the query, not the result.
   def merged_pull_requests(base, since_ref)
-    committed_at = `git log -1 --format=%cI #{since_ref} 2>/dev/null`.strip
+    committed_at = IO.popen(["git", "log", "-1", "--format=%cI", since_ref], err: IO::NULL, &:read).strip
     raise "Failed to resolve #{since_ref}" unless $?.success?
 
     since = (Time.iso8601(committed_at) - 86_400).utc.strftime("%Y-%m-%d")


### PR DESCRIPTION
`Gem::Doctor` has been raising `NameError` on any repository with a `specifications/<abi>` directory. The ABI scoped recursion was written when `doctor_child` took a single extension, and the splat landed in a separate pull request, so neither side saw that the call now passes an undefined `extension`.

Two content addressing resolver tests failed on a prerelease Ruby. They build a `~> X.Y.0` requirement from the running Ruby, and `4.1.0.dev` does not satisfy `~> 4.1.0`, so `filter_specs` dropped the candidate under test. They now pin the running Ruby the way `test_install_local_by_name_preserves_content_address` already did.

The rest is output that leaked into the middle of a run. Three tests feed rubygems something they expect it to reject, and each printed its diagnosis to stderr rather than capturing it. The rake package task lost the `RakeFileUtils.verbose_flag` guard its sibling test has. And the coverage summary appeared twice, because `coverage:report` redirects `$stdout` while SimpleCov writes to `$stderr`, which also meant a failing run ended with SimpleCov reporting that it had stopped, reading like one more failure.

Worth noting separately, a prerelease Ruby cannot resolve a content addressed gem built for its own ABI at all. `Gem.ruby_abi` reports `4.1` and `ruby_abi_match?` accepts the tuple, but `filter_specs` rejects the spec, so rubygems decides ABI membership two different ways. This changes only the tests.

Generated with [Claude Code](https://claude.com/claude-code)
