### PR TITLE
Reject Bundler redirects that downgrade https to http

### DIFF
--- a/lib/bundler/fetcher/downloader.rb
+++ b/lib/bundler/fetcher/downloader.rb
@@ -51,6 +51,11 @@ module Bundler
           response
         when Gem::Net::HTTPRedirection
           new_uri = Gem::URI.parse(response["location"])
+          # Following a downgrade would put the credentials this request carries
+          # on a plaintext connection, so refuse it like Gem::RemoteFetcher does.
+          if https?(uri) && !https?(new_uri)
+            raise HTTPError, "Redirecting to a non-https URI is not allowed: #{URICredentialsFilter.credential_filtered_uri(new_uri)}"
+          end
           if new_uri.host == uri.host
             new_uri.user = uri.user
             new_uri.password = uri.password
@@ -118,6 +123,10 @@ module Bundler
         host = host_port if filtered_uri.to_s.include?(host_port)
         NetworkDownError.new("Could not reach host #{host}. Check your network " \
           "connection and try again.")
+      end
+
+      def https?(uri)
+        uri.scheme&.casecmp("https")&.zero?
       end
 
       def validate_uri_scheme!(uri)

--- a/spec/bundler/fetcher/downloader_spec.rb
+++ b/spec/bundler/fetcher/downloader_spec.rb
@@ -59,6 +59,19 @@ RSpec.describe Bundler::Fetcher::Downloader do
           subject.fetch(uri, options, counter)
         end
       end
+
+      context "when the redirect uri downgrades https to http" do
+        let(:uri) { Gem::URI("https://username:password@www.uri-to-fetch.com/api/v2/endpoint") }
+
+        before { http_response["location"] = "http://www.uri-to-fetch.com/api/v2/endpoint" }
+
+        it "should raise a Bundler::HTTPError instead of following the redirect" do
+          expect(subject).to receive(:fetch).with(uri, options, 0).and_call_original
+          expect(subject).not_to receive(:fetch).with(Gem::URI("http://username:password@www.uri-to-fetch.com/api/v2/endpoint"), options, 1)
+          expect { subject.fetch(uri, options, counter) }.to raise_error(Bundler::HTTPError,
+            "Redirecting to a non-https URI is not allowed: http://www.uri-to-fetch.com/api/v2/endpoint")
+        end
+      end
     end
 
     context "when the request response is a Gem::Net::HTTPSuccess" do


### PR DESCRIPTION
When an https gem source answers with a redirect to http on the same host, Bundler follows it and copies the source's user and password onto the plaintext request. `Bundler::Fetcher::Downloader` decides whether to carry credentials by comparing `uri.host` alone, so the scheme change goes unnoticed.

`Gem::RemoteFetcher` and `Gem::CompactIndexClient::HTTPFetcher` already refuse a redirect that leaves https, so this brings Bundler in line with them. The downgrade now raises `Bundler::HTTPError`, the same type the sibling `Too many redirects` case uses, rather than dropping the credentials and continuing.

Same-scheme redirects are untouched, and a port change on its own is still followed.

Generated with [Claude Code](https://claude.com/claude-code)
