### PR TITLE
Normalize absolute symlink targets during gem extraction

### DIFF
--- a/lib/rubygems/package.rb
+++ b/lib/rubygems/package.rb
@@ -511,7 +511,7 @@ EOM
 
         if entry.symlink?
           link_target = entry.header.linkname
-          real_destination = link_target.start_with?("/") ? link_target : File.expand_path(link_target, File.dirname(destination))
+          real_destination = File.expand_path(link_target, File.dirname(destination))
 
           raise Gem::Package::SymlinkError.new(full_name, real_destination, destination_dir) unless
             normalize_path(real_destination).start_with? normalize_path(destination_dir + "/")

--- a/test/rubygems/test_gem_package.rb
+++ b/test/rubygems/test_gem_package.rb
@@ -1147,6 +1147,36 @@ class TestGemPackage < Gem::Package::TarTestCase
     assert_path_not_exist File.join(destination_subdir, "lib/link")
   end
 
+  def test_extract_symlink_parent_absolute_path
+    package = Gem::Package.new @gem
+
+    # Extract into a subdirectory of @destination; if this test fails it writes
+    # a file outside destination_subdir, but we want the file to remain inside
+    # @destination so it will be cleaned up.
+    destination_subdir = File.join @destination, "subdir"
+    FileUtils.mkdir_p destination_subdir
+
+    pend "TMPDIR seems too long to add it as symlink into tar" if destination_subdir.size > 90
+
+    tgz_io = util_tar_gz do |tar|
+      tar.mkdir       "lib", 0o755
+      tar.add_symlink "lib/link", File.join(destination_subdir, ".."), 0o644
+      tar.add_file    "lib/link/outside.txt", 0o644 do |io|
+        io.write "hi"
+      end
+    end
+
+    e = assert_raise(Gem::Package::SymlinkError) do
+      package.extract_tar_gz tgz_io, destination_subdir
+    end
+
+    assert_equal("installing symlink 'lib/link' pointing to parent path #{@destination} of " \
+                "#{destination_subdir} is not allowed", e.message)
+
+    assert_path_not_exist File.join(@destination, "outside.txt")
+    assert_path_not_exist File.join(destination_subdir, "lib/link")
+  end
+
   def test_extract_symlink_parent_doesnt_delete_user_dir
     package = Gem::Package.new @gem
 


### PR DESCRIPTION
`Gem::Package#extract_tar_gz` expands relative symlink targets with `File.expand_path` but passed absolute ones through untouched, so their `..` components survived into the containment check. A target such as `<destination_dir>/../../etc` starts with the destination prefix and passed the check even though it resolves to `/etc`.

Both cases now go through `File.expand_path`, which folds `..` lexically for absolute paths as well. Absolute targets pointing inside the extraction root and all relative targets keep their current behavior, and the new test in `test/rubygems/test_gem_package.rb` covers the escaping absolute target.

`de19bc4c7e9` dropped the `realpath` check in `install_location` on the grounds that "symlinks and absolute paths are already checked", relying on the check added the same day in `555692b8deb`. Absolute targets were never normalized there, so this restores the premise of that removal.

Generated with [Claude Code](https://claude.com/claude-code)
