### PR TITLE
Stop resolving locally for empty CHECKSUMS entries

### DIFF
--- a/lib/bundler/definition.rb
+++ b/lib/bundler/definition.rb
@@ -198,7 +198,7 @@ module Bundler
 
       sources.cached!
 
-      if options[:add_checksums] || (!options[:local] && (install_needed? || refetch_needed?(options)))
+      if options[:add_checksums] || (!options[:local] && (install_needed? || refetch_needed?(options) || @locked_spec_with_empty_checksums))
         sources.remote!
         true
       else
@@ -650,13 +650,23 @@ module Bundler
         @missing_lockfile_dep ||
         @unlocking_bundler ||
         @locked_spec_with_missing_checksums ||
-        @locked_spec_with_empty_checksums ||
+        empty_checksums_actionable? ||
         @locked_spec_with_missing_deps ||
         @locked_spec_with_invalid_deps
     end
 
     def resolve_needed?
       unlocking? || something_changed?
+    end
+
+    # Only a remote fetch can fill an empty CHECKSUMS entry, so it justifies a
+    # resolution only when one is coming. Resolving locally for it would repeat
+    # on every `Bundler.setup` without changing the lockfile. Frozen mode still
+    # has to refuse the entry.
+    def empty_checksums_actionable?
+      return false unless @locked_spec_with_empty_checksums
+
+      Bundler.frozen_bundle? || !sources.local_mode?
     end
 
     def should_add_extra_platforms?

--- a/spec/lock/lockfile_spec.rb
+++ b/spec/lock/lockfile_spec.rb
@@ -1682,6 +1682,36 @@ RSpec.describe "the lockfile format" do
     expect(the_bundle).not_to include_gems "myrack 0.9.1"
   end
 
+  it "fills empty CHECKSUMS entries when not frozen, even if every gem is already installed" do
+    system_gems "myrack-0.9.1", gem_repo: gem_repo2
+
+    lockfile <<-L
+      GEM
+        remote: https://gem.repo2/
+        specs:
+          myrack (0.9.1)
+
+      PLATFORMS
+        #{lockfile_platforms}
+
+      DEPENDENCIES
+        myrack
+
+      CHECKSUMS
+        myrack (0.9.1)
+
+      BUNDLED WITH
+         #{Bundler::VERSION}
+    L
+
+    install_gemfile <<-G
+      source "https://gem.repo2"
+      gem "myrack"
+    G
+
+    expect(lockfile).to include("  #{checksum_to_lock(gem_repo2, "myrack", "0.9.1")}\n")
+  end
+
   it "automatically fixes the lockfile when it's missing deps, they conflict with other locked deps, but conflicts are fixable" do
     build_repo4 do
       build_gem "other_dep", "0.9"

--- a/spec/runtime/setup_spec.rb
+++ b/spec/runtime/setup_spec.rb
@@ -259,6 +259,24 @@ RSpec.describe "Bundler.setup" do
     expect(bundled_app_lock).to exist
   end
 
+  it "does not resolve again for the empty CHECKSUMS entries it locked itself" do
+    system_gems "myrack-1.0.0"
+
+    gemfile <<-G
+      source "https://gem.repo1"
+      gem "myrack"
+    G
+
+    ruby "require 'bundler'; Bundler.setup"
+    expect(out).to include("Resolving dependencies...")
+    lockfile = File.read(bundled_app_lock)
+    expect(lockfile).to include("CHECKSUMS\n  myrack (1.0.0)\n")
+
+    ruby "require 'bundler'; Bundler.setup"
+    expect(out).not_to include("Resolving dependencies...")
+    expect(File.read(bundled_app_lock)).to eq(lockfile)
+  end
+
   describe "$BUNDLE_GEMFILE" do
     context "user provides an absolute path" do
       it "uses BUNDLE_GEMFILE to locate the gemfile if present" do


### PR DESCRIPTION
Fixes https://github.com/ruby/rubygems/issues/9109.

`Bundler.setup` without a lockfile writes CHECKSUMS entries without digests, because nothing is fetched on that path. Since 05199ae0c1e those empty entries count as a lockfile change, so every later `Bundler.setup` printed "Resolving dependencies..." and re-resolved although no local resolution can ever fill them. The lockfile ends up identical each time.

I now count an empty entry only when a remote fetch is coming or when frozen mode has to refuse it. `bundle install` still goes remote to fill those entries, and frozen mode still raises the same error. As a side effect `bundle install --local` stops re-resolving for them too, which is the path the original report hit through Fedora's package build.

I did not compute the digests from installed gems on the setup path. Default gems have no `.gem` file to hash, and distributions like Fedora strip the gem cache, so the entries would stay empty there and the loop would remain.

```
$ printf 'source "https://rubygems.org"\ngem "minitest"\n' > Gemfile
$ printf 'require "bundler"\nBundler.setup\n' > setup.rb
$ ruby setup.rb   # resolves and writes the lockfile
Resolving dependencies...
$ ruby setup.rb   # before: resolved again, after: silent, lockfile untouched
```

Generated with [Claude Code](https://claude.com/claude-code)
