### PR TITLE
Apply --platform in gem build when it matches the local platform

### DIFF
--- a/lib/rubygems/commands/build_command.rb
+++ b/lib/rubygems/commands/build_command.rb
@@ -90,6 +90,15 @@ Platform gems can be built for a single Ruby ABI with the --ruby-abi option:
   def build_package(gemspec)
     spec = Gem::Specification.load(gemspec)
     if spec
+      # Gem::Specification#initialize infers the platform from
+      # Gem.platforms.last, but skips it when that equals Gem::Platform.local,
+      # because Gem.platforms includes the local platform by default and every
+      # spec would otherwise become platform specific. Passing --platform
+      # resets Gem.platforms, so the request is unambiguous and is applied here
+      # rather than left to that inference, which would drop it whenever the
+      # requested platform happened to be the local one.
+      spec.platform = Gem.platforms.last if options[:added_platform]
+
       Gem::Package.build(
         spec,
         options[:force],

--- a/test/rubygems/test_gem_commands_build_command.rb
+++ b/test/rubygems/test_gem_commands_build_command.rb
@@ -122,6 +122,36 @@ class TestGemCommandsBuildCommand < Gem::TestCase
     util_test_build_gem @gem
   end
 
+  # Regression test for https://github.com/rubygems/rubygems/issues/9344:
+  # `gem build --platform X` must produce a platform-specific gem even when X
+  # happens to equal the local platform. `Gem::Specification#initialize` infers
+  # the platform from `Gem.platforms.last` but deliberately skips it when that
+  # equals `Gem::Platform.local`, because `Gem.platforms` includes the local
+  # platform by default and every spec would otherwise become platform-specific.
+  # `gem build` relied entirely on that inference, so the one case where the
+  # requested platform matched the local one was silently dropped.
+  def test_execute_with_platform_matching_local_platform
+    gemspec_file = File.join(@tempdir, @gem.spec_name)
+
+    File.open gemspec_file, "w" do |gs|
+      gs.write @gem.to_ruby
+    end
+
+    @cmd.handle_options [gemspec_file, "--platform", Gem::Platform.local.to_s]
+
+    use_ui @ui do
+      Dir.chdir @tempdir do
+        @cmd.execute
+      end
+    end
+
+    gem_file = File.join @tempdir, "some_gem-2-#{Gem::Platform.local}.gem"
+    assert File.exist?(gem_file), "expected a platform-specific gem at #{gem_file}"
+
+    spec = Gem::Package.new(gem_file).spec
+    assert_equal Gem::Platform.local, spec.platform
+  end
+
   def test_ruby_abi_rejects_ruby_platform
     gem = util_spec "some_gem" do |s|
       s.license = "AGPL-3.0-only"


### PR DESCRIPTION
Fixes #9344. @kou wrote there that "`gem build --platform` should build a platform-specific gem" — this makes it do that in the one case where it currently doesn't.

## What was the end-user or developer problem that led to this PR?

`gem build --platform aarch64-linux` on aarch64 Linux produces `hello-0.1.0.gem` instead of `hello-0.1.0-aarch64-linux.gem`. The flag is silently dropped, but only when the requested platform happens to equal the machine's own — on any other platform it works, which is what makes it easy to miss.

## What is your fix for the problem, implemented in this PR?

`gem build` never applied `--platform` itself. It relied on the inference in `Gem::Specification#initialize`:

```ruby
if (platform = Gem.platforms.last) && platform != Gem::Platform::RUBY && platform != Gem::Platform.local
  self.platform = platform
end
```

That `!= Gem::Platform.local` guard is load-bearing and I deliberately left it alone: `Gem.platforms` is `[RUBY, Gem::Platform.local]` by default, so without it *every* spec instantiated anywhere in the process would silently become platform-specific. The cost is that a legitimate explicit request matching the local platform is indistinguishable from the ambient default, and gets dropped.

But it is distinguishable one level up. `add_platform_option` resets `Gem.platforms` to `[RUBY]` before appending the requested value and sets `options[:added_platform]`, so at the command layer an explicit `--platform` is unambiguous. The fix applies it there:

```ruby
spec.platform = Gem.platforms.last if options[:added_platform]
```

One line in `build_package`, plus a comment explaining why the inference can't be relied on. Nothing shared changes, so no other caller of `Gem::Specification.new` is affected.

**Alternative considered:** relaxing the guard in `Gem::Specification#initialize` to consult `added_platform`. I didn't, because that guard protects every spec instantiation in the process and the command layer already has the unambiguous signal — fixing it where the ambiguity doesn't exist seemed safer than widening the blast radius.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [x] Write tests for features and bug fixes

`test_execute_with_platform_matching_local_platform` builds with `--platform Gem::Platform.local` and asserts both the output filename and `spec.platform`. It fails on master:

```
Failure: test_execute_with_platform_matching_local_platform:
  expected a platform-specific gem at .../some_gem-2-x86-darwin-8.gem.
  <false> is not true.
```

Verified green: the full `test_gem_commands_build_command.rb` (35 tests), plus `test_gem_specification.rb` (296), `test_gem_package.rb` (78), `test_gem_platform.rb` (33) and `test_gem_commands_install_command.rb` (87) for regressions. `bin/rake rubocop` reports no offenses across 852 files.

## Disclosure

This was written with AI assistance (Claude). I can explain every line, and the behaviour was verified by running the tests rather than inferred.
