### PR TITLE
Prepare RubyGems 4.1.0.beta1 and Bundler 4.1.0.beta1

### DIFF
--- a/.github/workflows/ubuntu-lint.yml
+++ b/.github/workflows/ubuntu-lint.yml
@@ -131,7 +131,9 @@ jobs:
           bin/rake dev:deps version:update_locked_bundler
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "Simulate release version"
+          # On release branches the version constants already have no .dev suffix,
+          # so there is nothing to simulate and nothing to commit.
+          git diff --quiet || git commit -am "Simulate release version"
       - name: Check lockfiles do not depend on the local gem cache
         run: |
           version=$(ruby -Ilib -rbundler/version -e 'puts Bundler::VERSION')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,103 @@
 
 Bundler's changelog before 4.0.0, when it was versioned separately from RubyGems, is in [doc/CHANGELOG-bundler-2.x.md](https://github.com/ruby/rubygems/blob/master/doc/CHANGELOG-bundler-2.x.md).
 
+## 4.1.0.beta1 / 2026-09-09
+
+### RubyGems
+
+Changes already released in 4.0.x are not repeated here.
+
+#### Features:
+
+* Add content addressable gems support. Pull request [#9773](https://github.com/ruby/rubygems/pull/9773) by Jenny Shen
+* Let the gem and bundle cooldown settings cover each other. Pull request [#9852](https://github.com/ruby/rubygems/pull/9852) by Hiroshi SHIBATA
+* Rubygems: Add PQC ML-DSA support for cryptographically signed gems workflow. Pull request [#9697](https://github.com/ruby/rubygems/pull/9697) by Jun Aruga
+* Preserve non-UTF-8 legacy gem metadata. Pull request [#9835](https://github.com/ruby/rubygems/pull/9835) by Stanislav (Stas) Katkov
+* Add an opt-in OS credential store for gem and bundler credentials. Pull request [#9671](https://github.com/ruby/rubygems/pull/9671) by Hiroshi SHIBATA
+* Add --cooldown to gem install, update and outdated. Pull request [#9734](https://github.com/ruby/rubygems/pull/9734) by Hiroshi SHIBATA
+* Adopt the compact index for gem commands. Pull request [#9606](https://github.com/ruby/rubygems/pull/9606) by Hiroshi SHIBATA
+* Replace Molinillo with PubGrub for dependency resolution. Pull request [#9402](https://github.com/ruby/rubygems/pull/9402) by Matt Larraz
+* Replace the rubygems-specific lockfile parser with Bundler's parser. Pull request [#9564](https://github.com/ruby/rubygems/pull/9564) by Hiroshi SHIBATA
+* Remove pessimistic versioning in gem command output. Pull request [#9550](https://github.com/ruby/rubygems/pull/9550) by Jeremy Evans
+* Change Gem::Version#approximate_recommendation to be optimistic. Pull request [#9537](https://github.com/ruby/rubygems/pull/9537) by Jeremy Evans
+* Add `--no-build-extension` and `--no-install-plugin` options to gem install. Pull request [#9473](https://github.com/ruby/rubygems/pull/9473) by Hiroshi SHIBATA
+* Push with auto-attestation. Pull request [#9325](https://github.com/ruby/rubygems/pull/9325) by Hiroshi SHIBATA
+* Imprement yaml parser written by pure ruby instead of Psych. Pull request [#9352](https://github.com/ruby/rubygems/pull/9352) by Hiroshi SHIBATA
+* Honor concurrent_downloads from .gemrc in Gem::ConfigFile. Pull request [#9339](https://github.com/ruby/rubygems/pull/9339) by Andrii Furmanets
+* Add support for custom error response from external registries. Pull request [#9270](https://github.com/ruby/rubygems/pull/9270) by Luis J. Gonzalez
+* Add global gem cache shared by RubyGems and Bundler. Pull request [#9230](https://github.com/ruby/rubygems/pull/9230) by Anthony Panozzo
+* Write gem files atomically. Pull request [#9154](https://github.com/ruby/rubygems/pull/9154) by Eileen
+
+#### Performance:
+
+* Remove `verify_gz`. Pull request [#9093](https://github.com/ruby/rubygems/pull/9093) by Eileen
+
+#### Enhancements:
+
+* Normalize absolute symlink targets during gem extraction. Pull request [#9860](https://github.com/ruby/rubygems/pull/9860) by Hiroshi SHIBATA
+* Installs bundler 4.1.0.beta1 as a default gem.
+
+#### Breaking changes:
+
+* Stop installing native extension build logs. Pull request [#9700](https://github.com/ruby/rubygems/pull/9700) by Hiroshi SHIBATA
+* Remove Gem::BasicSpecification#datadir and check minor-release deprecation horizons. Pull request [#9842](https://github.com/ruby/rubygems/pull/9842) by Hiroshi SHIBATA
+* Raise an error when building a gem that has a self reference. Pull request [#9392](https://github.com/ruby/rubygems/pull/9392) by Edouard CHIN
+* Revert `DEFAULT_INSTALL_EXTENSION_IN_LIB` and warn `require_relative` with C ext. Pull request [#9390](https://github.com/ruby/rubygems/pull/9390) by Hiroshi SHIBATA
+* Remove deprecated and unused `Gem::List`. Pull request [#9161](https://github.com/ruby/rubygems/pull/9161) by Hiroshi SHIBATA
+
+### Bundler
+
+Changes already released in 4.0.x are not repeated here.
+
+#### Features:
+
+* Add content addressable gems support. Pull request [#9773](https://github.com/ruby/rubygems/pull/9773) by Jenny Shen
+* Let the gem and bundle cooldown settings cover each other. Pull request [#9852](https://github.com/ruby/rubygems/pull/9852) by Hiroshi SHIBATA
+* Add a `prune` setting to drop rebuildable install artifacts. Pull request [#9815](https://github.com/ruby/rubygems/pull/9815) by Hiroshi SHIBATA
+* Add an opt-in OS credential store for gem and bundler credentials. Pull request [#9671](https://github.com/ruby/rubygems/pull/9671) by Hiroshi SHIBATA
+* Fetch Bundler metadata through Gem::Request instead of net-http-persistent. Pull request [#9786](https://github.com/ruby/rubygems/pull/9786) by Hiroshi SHIBATA
+* Reuse RubyGems' compact index client in Bundler. Pull request [#9753](https://github.com/ruby/rubygems/pull/9753) by Hiroshi SHIBATA
+* Reuse RubyGems' vendored PubGrub in Bundler. Pull request [#9752](https://github.com/ruby/rubygems/pull/9752) by Hiroshi SHIBATA
+* Use RubyGems' YAML serializer in Bundler. Pull request [#9751](https://github.com/ruby/rubygems/pull/9751) by Hiroshi SHIBATA
+* Reuse RubyGems' vendored SecureRandom in Bundler. Pull request [#9651](https://github.com/ruby/rubygems/pull/9651) by Hiroshi SHIBATA
+* Reuse RubyGems' vendored URI in Bundler. Pull request [#9650](https://github.com/ruby/rubygems/pull/9650) by Hiroshi SHIBATA
+* Fix two issues by including the ruby platform variants in the lock file. Pull request [#9556](https://github.com/ruby/rubygems/pull/9556) by Randy Stauner
+* Fix plugin installation from gemfile. Pull request [#6957](https://github.com/ruby/rubygems/pull/6957) by Cody Cutrer
+* Add plugin hooks for Gemfile evaluation and source fetching. Pull request [#9488](https://github.com/ruby/rubygems/pull/9488) by Hiroshi SHIBATA
+* Use optimistic version constraints in bundle gem output. Pull request [#9533](https://github.com/ruby/rubygems/pull/9533) by Jeremy Evans
+* Extend Gemfile `override` DSL with `:all` target and metadata fields (Phase 2). Pull request [#9530](https://github.com/ruby/rubygems/pull/9530) by Hiroshi SHIBATA
+* Switch bundle add to use optimistic versioning by default. Pull request [#9526](https://github.com/ruby/rubygems/pull/9526) by Jeremy Evans
+* Add Gemfile `override` DSL for version constraints (Phase 1). Pull request [#9517](https://github.com/ruby/rubygems/pull/9517) by Hiroshi SHIBATA
+* Add `--no-build-extension` and `--no-install-plugin` options to gem install. Pull request [#9473](https://github.com/ruby/rubygems/pull/9473) by Hiroshi SHIBATA
+* Include detailed dependencies when gemfile and lockfile are conflicts. Pull request [#9332](https://github.com/ruby/rubygems/pull/9332) by Hiroshi SHIBATA
+* Implement relative path handling for plugin paths. Pull request [#9299](https://github.com/ruby/rubygems/pull/9299) by Hiroshi SHIBATA
+* Bundler/inline: perform installation from a forked child. Pull request [#7941](https://github.com/ruby/rubygems/pull/7941) by Jean byroot Boussier
+* Add global gem cache shared by RubyGems and Bundler. Pull request [#9230](https://github.com/ruby/rubygems/pull/9230) by Anthony Panozzo
+* Update custom errors with Exception#full_message. Pull request [#8488](https://github.com/ruby/rubygems/pull/8488) by neimadTL
+
+#### Performance:
+
+* Use separate Bundler download and installation workers. Pull request [#9777](https://github.com/ruby/rubygems/pull/9777) by Joshua Young
+* Cache a shared git source only once per command. Pull request [#9689](https://github.com/ruby/rubygems/pull/9689) by Hiroshi SHIBATA
+
+#### Enhancements:
+
+* Reject Bundler redirects that downgrade https to http. Pull request [#9859](https://github.com/ruby/rubygems/pull/9859) by Hiroshi SHIBATA
+
+#### Bug fixes:
+
+* Expand the git source gemspec path before the chdir. Pull request [#9845](https://github.com/ruby/rubygems/pull/9845) by Hiroshi SHIBATA
+
+#### Breaking changes:
+
+* Remove external tool version checks from `bundle env`. Pull request [#9593](https://github.com/ruby/rubygems/pull/9593) by Hiroshi SHIBATA
+* Bundler: ignore patchlevel kwarg in ruby DSL. Pull request [#6023](https://github.com/ruby/rubygems/pull/6023) by Takuya N
+* Unify RubyGems and Bundler documentation. Pull request [#9237](https://github.com/ruby/rubygems/pull/9237) by Hiroshi SHIBATA
+
+#### Deprecations:
+
+* Rename the no_prune setting to keep_outdated_cache. Pull request [#9816](https://github.com/ruby/rubygems/pull/9816) by Hiroshi SHIBATA
+
 ## 4.0.20 / 2026-09-02
 
 ### RubyGems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Changes already released in 4.0.x are not repeated here.
 * Change Gem::Version#approximate_recommendation to be optimistic. Pull request [#9537](https://github.com/ruby/rubygems/pull/9537) by Jeremy Evans
 * Add `--no-build-extension` and `--no-install-plugin` options to gem install. Pull request [#9473](https://github.com/ruby/rubygems/pull/9473) by Hiroshi SHIBATA
 * Push with auto-attestation. Pull request [#9325](https://github.com/ruby/rubygems/pull/9325) by Hiroshi SHIBATA
-* Imprement yaml parser written by pure ruby instead of Psych. Pull request [#9352](https://github.com/ruby/rubygems/pull/9352) by Hiroshi SHIBATA
+* Implement yaml parser written by pure ruby instead of Psych. Pull request [#9352](https://github.com/ruby/rubygems/pull/9352) by Hiroshi SHIBATA
 * Honor concurrent_downloads from .gemrc in Gem::ConfigFile. Pull request [#9339](https://github.com/ruby/rubygems/pull/9339) by Andrii Furmanets
 * Add support for custom error response from external registries. Pull request [#9270](https://github.com/ruby/rubygems/pull/9270) by Luis J. Gonzalez
 * Add global gem cache shared by RubyGems and Bundler. Pull request [#9230](https://github.com/ruby/rubygems/pull/9230) by Anthony Panozzo

--- a/lib/bundler/version.rb
+++ b/lib/bundler/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 module Bundler
-  VERSION = "4.1.0.dev".freeze
+  VERSION = "4.1.0.beta1".freeze
 
   def self.bundler_major_version
     @bundler_major_version ||= gem_version.segments.first

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -9,7 +9,7 @@
 require "rbconfig"
 
 module Gem
-  VERSION = "4.1.0.dev"
+  VERSION = "4.1.0.beta1"
 end
 
 require_relative "rubygems/defaults"

--- a/spec/realworld/fixtures/tapioca/Gemfile.lock
+++ b/spec/realworld/fixtures/tapioca/Gemfile.lock
@@ -46,4 +46,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-  4.1.0.dev
+  4.1.0.beta1

--- a/spec/realworld/fixtures/warbler/Gemfile.lock
+++ b/spec/realworld/fixtures/warbler/Gemfile.lock
@@ -32,4 +32,4 @@ DEPENDENCIES
   warbler (~> 2.1)
 
 BUNDLED WITH
-  4.1.0.dev
+  4.1.0.beta1

--- a/tool/bundler/dev_gems.rb.lock
+++ b/tool/bundler/dev_gems.rb.lock
@@ -132,4 +132,4 @@ CHECKSUMS
   turbo_tests (2.2.5) sha256=3fa31497d12976d11ccc298add29107b92bda94a90d8a0a5783f06f05102509f
 
 BUNDLED WITH
-  4.1.0.dev
+  4.1.0.beta1

--- a/tool/bundler/lint_gems.rb.lock
+++ b/tool/bundler/lint_gems.rb.lock
@@ -129,4 +129,4 @@ CHECKSUMS
   wmi-lite (1.0.7) sha256=116ef5bb470dbe60f58c2db9047af3064c16245d6562c646bc0d90877e27ddda
 
 BUNDLED WITH
-  4.1.0.dev
+  4.1.0.beta1

--- a/tool/bundler/release_gems.rb.lock
+++ b/tool/bundler/release_gems.rb.lock
@@ -87,4 +87,4 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH
-  4.1.0.dev
+  4.1.0.beta1

--- a/tool/bundler/rubocop_gems.rb.lock
+++ b/tool/bundler/rubocop_gems.rb.lock
@@ -157,4 +157,4 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
 
 BUNDLED WITH
-  4.1.0.dev
+  4.1.0.beta1

--- a/tool/bundler/standard_gems.rb.lock
+++ b/tool/bundler/standard_gems.rb.lock
@@ -177,4 +177,4 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
 
 BUNDLED WITH
-  4.1.0.dev
+  4.1.0.beta1

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -99,4 +99,4 @@ CHECKSUMS
   tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
 
 BUNDLED WITH
-  4.1.0.dev
+  4.1.0.beta1

--- a/tool/bundler/vendor_gems.rb.lock
+++ b/tool/bundler/vendor_gems.rb.lock
@@ -57,4 +57,4 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH
-  4.1.0.dev
+  4.1.0.beta1


### PR DESCRIPTION
* Silence Bundler UI in plugin installer specs [#9152](https://github.com/ruby/rubygems/pull/9152)
* Update contributing docs with `RGV` [#9155](https://github.com/ruby/rubygems/pull/9155)
* Increase connection pool to allow for up to 70% speed increase on `bundle install` [#9087](https://github.com/ruby/rubygems/pull/9087)
* Prepare toolchain for patch release [#9157](https://github.com/ruby/rubygems/pull/9157)
* Try to split and run multiple runners for Windows [#9158](https://github.com/ruby/rubygems/pull/9158)
* Skip Windows runner group warning under ruby/ruby repo [#9160](https://github.com/ruby/rubygems/pull/9160)
* Fix native extension loading in newgem template for RHEL-based systems [#9156](https://github.com/ruby/rubygems/pull/9156)
* Fixed unexpected default bundler installation [#9167](https://github.com/ruby/rubygems/pull/9167)
* Fix the config suggestion in the warning for `$ bundle` [#9164](https://github.com/ruby/rubygems/pull/9164)
* Fix Bundler removing executables after creating them [#9169](https://github.com/ruby/rubygems/pull/9169)
* Refine release task for the next patch release [#9178](https://github.com/ruby/rubygems/pull/9178)
* Exclude released PR on stable branch [#9179](https://github.com/ruby/rubygems/pull/9179)
* Fixed wrong target branch [#9180](https://github.com/ruby/rubygems/pull/9180)
* Write gem files atomically [#9154](https://github.com/ruby/rubygems/pull/9154)
* Allow bundle pristine to work for git gems in the same repo [#9196](https://github.com/ruby/rubygems/pull/9196)
* Tweak the Bundler's "X gems now installed message": [#9194](https://github.com/ruby/rubygems/pull/9194)
* Allow to show cli_help with `bundler` executable [#9198](https://github.com/ruby/rubygems/pull/9198)
* Support single quotes in mise format ruby version [#9183](https://github.com/ruby/rubygems/pull/9183)
* Pass down value of `BUNDLE_JOBS` to RubyGems before compiling & introduce a new `gem install -j` flag [#9171](https://github.com/ruby/rubygems/pull/9171)
* Reset MAKEFLAGS option for build jobs tests [#9200](https://github.com/ruby/rubygems/pull/9200)
* Added assertion for Windows and nmake [#9201](https://github.com/ruby/rubygems/pull/9201)
* Remove deprecated and unused `Gem::List` [#9161](https://github.com/ruby/rubygems/pull/9161)
* Fix leaky tests [#9212](https://github.com/ruby/rubygems/pull/9212)
* Fix broken documentation links [#9208](https://github.com/ruby/rubygems/pull/9208)
* Add URINormalizer trailing slash specs [#9214](https://github.com/ruby/rubygems/pull/9214)
* Fall back to ruby platform gem when precompiled variant is incompatible [#9211](https://github.com/ruby/rubygems/pull/9211)
* Fix fragile tests [#9217](https://github.com/ruby/rubygems/pull/9217)
* Support Ruby 4.1 [#9219](https://github.com/ruby/rubygems/pull/9219)
* Remove date require from rebuild command [#9232](https://github.com/ruby/rubygems/pull/9232)
* Retain current bundler version on `bundle clean` [#9221](https://github.com/ruby/rubygems/pull/9221)
* Test with Ruby 4.0 and update the latest stable versions of 3.x [#9235](https://github.com/ruby/rubygems/pull/9235)
* Unify RubyGems and Bundler documentation [#9237](https://github.com/ruby/rubygems/pull/9237)
* Fix dependency source bug in bundler [#9213](https://github.com/ruby/rubygems/pull/9213)
* Update custom errors with Exception#full_message [#8488](https://github.com/ruby/rubygems/pull/8488)
* Validate more options for add sub-command [#5905](https://github.com/ruby/rubygems/pull/5905)
* Add a missing "require 'etc'" statement: [#9242](https://github.com/ruby/rubygems/pull/9242)
* Added another usage of pristine command [#9255](https://github.com/ruby/rubygems/pull/9255)
* Remove special behavior for rake [#9245](https://github.com/ruby/rubygems/pull/9245)
* Validate executable names for invalid characters [#9257](https://github.com/ruby/rubygems/pull/9257)
* Fix RubyGems not able to require the right gem: [#9246](https://github.com/ruby/rubygems/pull/9246)
* Re-generate certificates with sha256WithRSAEncryption for modern OS [#9264](https://github.com/ruby/rubygems/pull/9264)
* Fix Bundler that re-exec $0 when a `version` is present in the config: [#9249](https://github.com/ruby/rubygems/pull/9249)
* Removed unused deprecate loading [#9266](https://github.com/ruby/rubygems/pull/9266)
* Only use parent source with Git and Path sources [#9269](https://github.com/ruby/rubygems/pull/9269)
* Workaround for directly loading `Gem::Version` [#9268](https://github.com/ruby/rubygems/pull/9268)
* Remove outdated TODO in RemoteFetcher [#9112](https://github.com/ruby/rubygems/pull/9112)
* Ensure revision is always re-resolved in `git_proxy.rb` [#9294](https://github.com/ruby/rubygems/pull/9294)
* Update vendored resolv to 0.7.0 [#9298](https://github.com/ruby/rubygems/pull/9298)
* Lock diff-lcs < 2.0 [#9304](https://github.com/ruby/rubygems/pull/9304)
* Removed unused slack channel [#9302](https://github.com/ruby/rubygems/pull/9302)
* Fallback git/path sources to default source [#9301](https://github.com/ruby/rubygems/pull/9301)
* Clarify local gem override docs to require git-sourced gems [#9305](https://github.com/ruby/rubygems/pull/9305)
* Fix gzip cache corruption when recovering from HTTP 416 responses [#9272](https://github.com/ruby/rubygems/pull/9272)
* Remove "##" from a comment to require [#9306](https://github.com/ruby/rubygems/pull/9306)
* Cleaned up bundler .gem and .gemspec files in ensure block. [#9311](https://github.com/ruby/rubygems/pull/9311)
* Print message when signing in with an existing API key [#9312](https://github.com/ruby/rubygems/pull/9312)
* Do not create unnecessary directories [#9313](https://github.com/ruby/rubygems/pull/9313)
* [DOC] Fix link in Bundler [#9315](https://github.com/ruby/rubygems/pull/9315)
* Remove `verify_gz` [#9093](https://github.com/ruby/rubygems/pull/9093)
* Document gemspecs must be deterministic [#9321](https://github.com/ruby/rubygems/pull/9321)
* Fixed tsort dependency for rails new [#9324](https://github.com/ruby/rubygems/pull/9324)
* Add global gem cache shared by RubyGems and Bundler [#9230](https://github.com/ruby/rubygems/pull/9230)
* Add support for help flag in plugin commands [#9263](https://github.com/ruby/rubygems/pull/9263)
* Raise error when gem contains capital letters [#5432](https://github.com/ruby/rubygems/pull/5432)
* fix(bundler): only preload git sources for requested groups [#9234](https://github.com/ruby/rubygems/pull/9234)
* [rust gem] Major improvements for gem scaffolding (rebased) [#8455](https://github.com/ruby/rubygems/pull/8455)
* Add Gem.disable_system_update_message in setup.rb [#9020](https://github.com/ruby/rubygems/pull/9020)
* Add support for custom error response from external registries [#9270](https://github.com/ruby/rubygems/pull/9270)
* Run git operations in parallel (take 2): [#9323](https://github.com/ruby/rubygems/pull/9323)
* Fix Bundler crashing when it tries to install plugin: [#9335](https://github.com/ruby/rubygems/pull/9335)
* Honor concurrent_downloads from .gemrc in Gem::ConfigFile [#9339](https://github.com/ruby/rubygems/pull/9339)
* Don't check whether a plugin needs to be installed: [#9328](https://github.com/ruby/rubygems/pull/9328)
* Suppress unnecessary warns for Windows tag group [#9354](https://github.com/ruby/rubygems/pull/9354)
* Restrict GitHub Actions workflow permissions for newgem [#9361](https://github.com/ruby/rubygems/pull/9361)
* Show release date with bundle outdated [#9337](https://github.com/ruby/rubygems/pull/9337)
* Add a new Bundler config to control how many specs are fetched [#9363](https://github.com/ruby/rubygems/pull/9363)
* Fix plugin new version not registering [#9355](https://github.com/ruby/rubygems/pull/9355)
* Fix NameError in Gem::Request.get_proxy_from_env when requiring rubygems/request directly [#9362](https://github.com/ruby/rubygems/pull/9362)
* Skip flaky webauthn test on TruffleRuby [#9370](https://github.com/ruby/rubygems/pull/9370)
* Remove dead code in dependency installer tests [#9371](https://github.com/ruby/rubygems/pull/9371)
* Use JSON for cargo metadata parsing [#9373](https://github.com/ruby/rubygems/pull/9373)
* Imprement yaml parser written by pure ruby instead of Psych [#9352](https://github.com/ruby/rubygems/pull/9352)
* Unify Compact Index API naming. [#9372](https://github.com/ruby/rubygems/pull/9372)
* bundler/inline: perform installation from a forked child [#7941](https://github.com/ruby/rubygems/pull/7941)
* Revert `DEFAULT_INSTALL_EXTENSION_IN_LIB` and warn `require_relative` with C ext [#9390](https://github.com/ruby/rubygems/pull/9390)
* Raise an error when building a gem that has a self reference [#9392](https://github.com/ruby/rubygems/pull/9392)
* Split the download and install process of a gem [#9381](https://github.com/ruby/rubygems/pull/9381)
* Fix gem which command test isolation [#9222](https://github.com/ruby/rubygems/pull/9222)
* Introduce a priority queue [#9389](https://github.com/ruby/rubygems/pull/9389)
* fix: include owner role in `gem owner` [#9403](https://github.com/ruby/rubygems/pull/9403)
* Fix NoMethodError in Gem.try_activate when activation conflicts occur [#9404](https://github.com/ruby/rubygems/pull/9404)
* Retry git fetch without --depth for dumb HTTP transport [#9405](https://github.com/ruby/rubygems/pull/9405)
* Add exponential backoff to bundler retries [#9163](https://github.com/ruby/rubygems/pull/9163)
* fix: Ensure trailing slash is added to source URIs added via gem sources [#9055](https://github.com/ruby/rubygems/pull/9055)
* Prevent tests from modifying user's global git config [#9397](https://github.com/ruby/rubygems/pull/9397)
* Refactor Bundler tests to invoke RubyGems API directly [#9195](https://github.com/ruby/rubygems/pull/9195)
* Normalize the number of workers when performing parallel operations [#9400](https://github.com/ruby/rubygems/pull/9400)
* Check the git version only **once** per `bundle install` [#9406](https://github.com/ruby/rubygems/pull/9406)
* Lock the checksum of Bundler itself in the lockfile [#9366](https://github.com/ruby/rubygems/pull/9366)
* [DOC] Fix link [#9409](https://github.com/ruby/rubygems/pull/9409)
* Introduce a fast path for comparing Gem::Version [#9414](https://github.com/ruby/rubygems/pull/9414)
* Respect Gemfile bundler setting in `Bundler.setup` [#4892](https://github.com/ruby/rubygems/pull/4892)
* Bundler: ignore patchlevel kwarg in ruby DSL [#6023](https://github.com/ruby/rubygems/pull/6023)
* Workaround a memory corruption issue on Windows Ruby 3.3 [#9420](https://github.com/ruby/rubygems/pull/9420)
* [feature] default_cli_command for config what command bundler runs when no specific command is provided [#8886](https://github.com/ruby/rubygems/pull/8886)
* Implement relative path handling for plugin paths [#9299](https://github.com/ruby/rubygems/pull/9299)
* Include detailed dependencies when gemfile and lockfile are conflicts [#9332](https://github.com/ruby/rubygems/pull/9332)
* Skip flaky test_with_webauthn_enabled_failure on TruffleRuby [#9428](https://github.com/ruby/rubygems/pull/9428)
* Check happy path first when comparing gem version [#9417](https://github.com/ruby/rubygems/pull/9417)
* Cache package version selection [#9410](https://github.com/ruby/rubygems/pull/9410)
* Fallback to copy symlinks on Windows [#9296](https://github.com/ruby/rubygems/pull/9296)
* Register native extension files in default spec map [#9431](https://github.com/ruby/rubygems/pull/9431)
* Skip flaky `test_with_webauthn_enabled_failure` on TruffleRuby  [#9433](https://github.com/ruby/rubygems/pull/9433)
* Update SPDX license list as of 2026-02-20 [#9434](https://github.com/ruby/rubygems/pull/9434)
* Better algorithm for sorting gem version [#9421](https://github.com/ruby/rubygems/pull/9421)
* Restore rb_sys dependency for Rust [#9416](https://github.com/ruby/rubygems/pull/9416)
* Ensure the release CI doesn't break due to the Bundler checksum feature [#9436](https://github.com/ruby/rubygems/pull/9436)
* Improve error message when current platform is not in lockfile [#9439](https://github.com/ruby/rubygems/pull/9439)
* Push with auto-attestation [#9325](https://github.com/ruby/rubygems/pull/9325)
* Fix incompatible function pointer type error with Xcode 26.5 beta [#9453](https://github.com/ruby/rubygems/pull/9453)
* Suppressed `zlib` warnings [#9452](https://github.com/ruby/rubygems/pull/9452)
* Ignore warnings with spec different platforms [#8508](https://github.com/ruby/rubygems/pull/8508)
* Fix inconsistent indentation in git_spec.rb [#9464](https://github.com/ruby/rubygems/pull/9464)
* Fix incorrect gem name in lockfile DEPENDENCIES section of resolving_spec.rb [#9465](https://github.com/ruby/rubygems/pull/9465)
* Fix mismatched gem name/version in test_execute_allowed_push_host response message [#9466](https://github.com/ruby/rubygems/pull/9466)
* Fix typo in test description: "does not to" → "does not do" [#9468](https://github.com/ruby/rubygems/pull/9468)
* Fix gemspec filename mismatches in stub helper methods [#9467](https://github.com/ruby/rubygems/pull/9467)
* Fix typo by copilot review findings [#9471](https://github.com/ruby/rubygems/pull/9471)
* Fix the bundler version not being updated in dev/test lockfile [#9463](https://github.com/ruby/rubygems/pull/9463)
* fix formatting for BUNDLE_PREFER_PATCH variable in man page [#9474](https://github.com/ruby/rubygems/pull/9474)
* Clarify the name and meaning of the first argument to `gem spec` [#9476](https://github.com/ruby/rubygems/pull/9476)
* Print a warning for a potential confusion from the indirect dependencies. [#5029](https://github.com/ruby/rubygems/pull/5029)
* Add commented-out rubygems_mfa_required to bundle gem template [#9487](https://github.com/ruby/rubygems/pull/9487)
* Fix installing gems with native extensions + transitive dependencies [#9477](https://github.com/ruby/rubygems/pull/9477)
* Add `--no-build-extension` and `--no-install-plugin` options to gem install [#9473](https://github.com/ruby/rubygems/pull/9473)
* Update gem creation guide URL to rubygems.org [#9500](https://github.com/ruby/rubygems/pull/9500)
* Skip bundler self-checksum for unreleased bundlers [#9501](https://github.com/ruby/rubygems/pull/9501)
* Skip bundler self-checksum on ruby-core in test fixtures [#9506](https://github.com/ruby/rubygems/pull/9506)
* Replace #9506 with a targeted :ruby_repo skip [#9509](https://github.com/ruby/rubygems/pull/9509)
* Bump `rb_sys` to `>= 0.9.127` [#9516](https://github.com/ruby/rubygems/pull/9516)
* Remove cygwin from WIN_PATTERNS [#9527](https://github.com/ruby/rubygems/pull/9527)
* Deprecate parsing non-lockfile content in LockfileParser [#9502](https://github.com/ruby/rubygems/pull/9502)
* Add Gemfile `override` DSL for version constraints (Phase 1) [#9517](https://github.com/ruby/rubygems/pull/9517)
* Use Pathname#absolute? [#9529](https://github.com/ruby/rubygems/pull/9529)
* Fix bundle config gemfile unset behavior [#9514](https://github.com/ruby/rubygems/pull/9514)
* Switch bundle add to use optimistic versioning by default [#9526](https://github.com/ruby/rubygems/pull/9526)
* Extend Gemfile `override` DSL with `:all` target and metadata fields (Phase 2) [#9530](https://github.com/ruby/rubygems/pull/9530)
* Make `bundle config get` return status 1 when the value is not set [#9505](https://github.com/ruby/rubygems/pull/9505)
* Allow non-zero exit status in bundle config gemfile unset spec [#9532](https://github.com/ruby/rubygems/pull/9532)
* Use optimistic version constraints in bundle gem output [#9533](https://github.com/ruby/rubygems/pull/9533)
* Read `BUNDLE_VERSION` env var in `BundlerVersionFinder` [#9538](https://github.com/ruby/rubygems/pull/9538)
* Change Gem::Version#approximate_recommendation to be optimistic [#9537](https://github.com/ruby/rubygems/pull/9537)
* Fall back to lockfile version when `BUNDLE_VERSION` is "lockfile" [#9545](https://github.com/ruby/rubygems/pull/9545)
* Add plugin hooks for Gemfile evaluation and source fetching [#9488](https://github.com/ruby/rubygems/pull/9488)
* Skip git source exclusion when lockfile cannot backfill [#9544](https://github.com/ruby/rubygems/pull/9544)
* Gracefully handle missing checksums in Compact Index [#9492](https://github.com/ruby/rubygems/pull/9492)
* Close stdin immediately when using popen2e [#9540](https://github.com/ruby/rubygems/pull/9540)
* Remove pessimistic versioning in gem command output [#9550](https://github.com/ruby/rubygems/pull/9550)
* Prevent extraction from escaping destination_dir via pre-existing symlinks [#9493](https://github.com/ruby/rubygems/pull/9493)
* Clear gem specification cache after acquiring process lock [#9310](https://github.com/ruby/rubygems/pull/9310)
* Do not hard-code permissions for new gem directories during bundle install [#9557](https://github.com/ruby/rubygems/pull/9557)
* Bump up to rb-sys 0.9.128 [#9569](https://github.com/ruby/rubygems/pull/9569)
* Replace the rubygems-specific lockfile parser with Bundler's parser [#9564](https://github.com/ruby/rubygems/pull/9564)
* Vendor `compact_index` from rubygems.org for the artifice [#9574](https://github.com/ruby/rubygems/pull/9574)
* Document and test all available gemrc configuration keys [#9568](https://github.com/ruby/rubygems/pull/9568)
* Install compact_index on `test_setup` [#9578](https://github.com/ruby/rubygems/pull/9578)
* Lock compact_index vendoring against parallel races [#9579](https://github.com/ruby/rubygems/pull/9579)
* Write vendored compact_index files atomically [#9581](https://github.com/ruby/rubygems/pull/9581)
* Fixed flaky tests [#9580](https://github.com/ruby/rubygems/pull/9580)
* Add `cooldown` to delay newly published gem [#9576](https://github.com/ruby/rubygems/pull/9576)
* Parse `created_at` via `Time.new` instead of `Time.iso8601` [#9583](https://github.com/ruby/rubygems/pull/9583)
* Apply cooldown to locally installed gem versions [#9582](https://github.com/ruby/rubygems/pull/9582)
* Replace Molinillo with PubGrub for dependency resolution [#9402](https://github.com/ruby/rubygems/pull/9402)
* Split compact index entries on the first colon on older RubyGems [#9585](https://github.com/ruby/rubygems/pull/9585)
* Remove external tool version checks from `bundle env` [#9593](https://github.com/ruby/rubygems/pull/9593)
* Strip C1 control characters from displayed gem text [#9597](https://github.com/ruby/rubygems/pull/9597)
* Add executables and bindir validation to the gem installer [#9595](https://github.com/ruby/rubygems/pull/9595)
* Don't exclude the locked version from cooldown during bundle update [#9599](https://github.com/ruby/rubygems/pull/9599)
* Preserve per-source cooldown when converging sources from the lockfile [#9601](https://github.com/ruby/rubygems/pull/9601)
* Added Cooldown regression tests [#9602](https://github.com/ruby/rubygems/pull/9602)
* Forward security policy to old-format gems [#9611](https://github.com/ruby/rubygems/pull/9611)
* Set `Bundler.settings[:ssl_ca_cert]` to download gems [#9610](https://github.com/ruby/rubygems/pull/9610)
* Fix plugin installation from gemfile [#6957](https://github.com/ruby/rubygems/pull/6957)
* Fix ruby-core tarball detection in linked git worktrees [#9616](https://github.com/ruby/rubygems/pull/9616)
* Reduce peak memory usage of full index loading and bundle install [#9618](https://github.com/ruby/rubygems/pull/9618)
* Exempt lockfile versions from cooldown on every resolution path [#9619](https://github.com/ruby/rubygems/pull/9619)
* Fix two issues by including the ruby platform variants in the lock file [#9556](https://github.com/ruby/rubygems/pull/9556)
* Implement a make jobserver (continuation of #9210) [#9625](https://github.com/ruby/rubygems/pull/9625)
* Skip jobserver specs under a parent make jobserver [#9626](https://github.com/ruby/rubygems/pull/9626)
* Adopt the compact index for gem commands [#9606](https://github.com/ruby/rubygems/pull/9606)
* Probe socket errors via SO_ERROR in TCPSocketProbe [#9629](https://github.com/ruby/rubygems/pull/9629)
* Skip the make jobserver on Windows [#9630](https://github.com/ruby/rubygems/pull/9630)
* Suggest access issues, not only yanking, for missing locked gems [#9631](https://github.com/ruby/rubygems/pull/9631)
* Resolve Git LFS files in git sources from the real remote [#9632](https://github.com/ruby/rubygems/pull/9632)
* RubyGems: Remove unused ctx.tmp_dh_callback in start_ssl_server [#9633](https://github.com/ruby/rubygems/pull/9633)
* rubygems: Fix Gem::Request for PQC support, adding integration connection tests [#9615](https://github.com/ruby/rubygems/pull/9615)
* Reuse RubyGems' vendored tsort in Bundler [#9647](https://github.com/ruby/rubygems/pull/9647)
* Reuse RubyGems' vendored URI in Bundler [#9650](https://github.com/ruby/rubygems/pull/9650)
* Reuse RubyGems' vendored SecureRandom in Bundler [#9651](https://github.com/ruby/rubygems/pull/9651)
* Pin rdoc below 8 on JRuby in install CI [#9656](https://github.com/ruby/rubygems/pull/9656)
* bundler: Fix Bundler::Fetcher for PQC support, adding integration connection tests [#9637](https://github.com/ruby/rubygems/pull/9637)
* Fix the gemspec error snippet on Windows drive-letter paths [#9668](https://github.com/ruby/rubygems/pull/9668)
* Preserve CRLF lockfile line endings on Windows [#9669](https://github.com/ruby/rubygems/pull/9669)
* Initialize the new gem's git repo without a subshell [#9670](https://github.com/ruby/rubygems/pull/9670)
* Skip the make job server when using BSD make [#9676](https://github.com/ruby/rubygems/pull/9676)
* Disable git background maintenance in bundler specs [#9681](https://github.com/ruby/rubygems/pull/9681)
* Preserve the locked Bundler checksum when the gem isn't cached [#9658](https://github.com/ruby/rubygems/pull/9658)
* Validate spec name before writing to the spec cache [#9690](https://github.com/ruby/rubygems/pull/9690)
* Fix `bundle` binstub broken by `gem update --system` on Homebrew ruby [#9688](https://github.com/ruby/rubygems/pull/9688)
* Open compact index cache in binary mode when appending [#9679](https://github.com/ruby/rubygems/pull/9679)
* Pend on more transient network errors in TestGemBundledCA [#9705](https://github.com/ruby/rubygems/pull/9705)
* Avoid space-containing absolute path in RUBYOPT [#9696](https://github.com/ruby/rubygems/pull/9696)
* Preserve Windows paths in MAKE and rake environment variables [#9693](https://github.com/ruby/rubygems/pull/9693)
* Preserve Windows editor paths in gem open and bundle open [#9694](https://github.com/ruby/rubygems/pull/9694)
* Escape glob metacharacters in install paths when globbing [#9687](https://github.com/ruby/rubygems/pull/9687)
* Unquote Gem.ruby when spawning it as a separate argv element [#9695](https://github.com/ruby/rubygems/pull/9695)
* Skip empty checksum values in compact index metadata [#9713](https://github.com/ruby/rubygems/pull/9713)
* Call Kernel.format explicitly in Gem::Deprecate wrapper [#9714](https://github.com/ruby/rubygems/pull/9714)
* Avoid repeated base path expansion [#9712](https://github.com/ruby/rubygems/pull/9712)
* Clarify requirement marshal validation [#9711](https://github.com/ruby/rubygems/pull/9711)
* Document pessimistic operator and eval_gemfile in gemfile(5) [#9719](https://github.com/ruby/rubygems/pull/9719)
* List missing subcommands in bundle(1) UTILITIES section [#9721](https://github.com/ruby/rubygems/pull/9721)
* Clarify :path expectations and cross-link platform docs in man pages [#9724](https://github.com/ruby/rubygems/pull/9724)
* Update blog repository URL to renamed rubygems/blog [#9726](https://github.com/ruby/rubygems/pull/9726)
* Add --cooldown flag to bundle lock and bundle cache [#9725](https://github.com/ruby/rubygems/pull/9725)
* Document Bundler checksum behavior for default gems [#9735](https://github.com/ruby/rubygems/pull/9735)
* Fail `bundle check` when frozen mode needs lockfile changes [#9715](https://github.com/ruby/rubygems/pull/9715)
* Validate gem name before building compact index cache paths [#9717](https://github.com/ruby/rubygems/pull/9717)
* Redact URI userinfo from settings names in Bundler User-Agent [#9716](https://github.com/ruby/rubygems/pull/9716)
* Warn when duplicate source declarations conflict on cooldown [#9736](https://github.com/ruby/rubygems/pull/9736)
* Point bundler.io URLs at guides.rubygems.org [#9737](https://github.com/ruby/rubygems/pull/9737)
* Use RubyGems' YAML serializer in Bundler [#9751](https://github.com/ruby/rubygems/pull/9751)
* Reuse RubyGems' vendored PubGrub in Bundler [#9752](https://github.com/ruby/rubygems/pull/9752)
* Reuse RubyGems' compact index client in Bundler [#9753](https://github.com/ruby/rubygems/pull/9753)
* Don't mask install errors when no Gemfile can be located [#9757](https://github.com/ruby/rubygems/pull/9757)
* Check the resolved parent directory before extracting old format gems [#9755](https://github.com/ruby/rubygems/pull/9755)
* Prevent test git commands from mutating the checkout's own git config [#9754](https://github.com/ruby/rubygems/pull/9754)
* Summarize cooldown-skipped versions at the end of install, update, and lock [#9762](https://github.com/ruby/rubygems/pull/9762)
* Document SPDX license handling for license= and licenses= [#9766](https://github.com/ruby/rubygems/pull/9766)
* Document why rubygems.rb requires BUNDLER_SETUP at the end [#9769](https://github.com/ruby/rubygems/pull/9769)
* Filter git command output against the configured URI [#9778](https://github.com/ruby/rubygems/pull/9778)
* Restrict UserDefined handling to explicit class set for Gem::SafeMashal. [#9770](https://github.com/ruby/rubygems/pull/9770)
* Correct Bundler 5 default path documentation [#9771](https://github.com/ruby/rubygems/pull/9771)
* Validate the platform field in Gem::Installer#verify_spec [#9780](https://github.com/ruby/rubygems/pull/9780)
* Fix auto-clean default version in bundle config docs [#9783](https://github.com/ruby/rubygems/pull/9783)
* Reject SafeMarshal collection lengths longer than the remaining input [#9756](https://github.com/ruby/rubygems/pull/9756)
* Add --cooldown to gem install, update and outdated [#9734](https://github.com/ruby/rubygems/pull/9734)
* Fix gem uninstall --user-install crash when GEM_HOME does not exist [#9749](https://github.com/ruby/rubygems/pull/9749)
* Fix wrong $LOAD_PATH for gems installed in the same process [#9784](https://github.com/ruby/rubygems/pull/9784)
* Fail instead of warning when frozen mode can't update the lockfile [#9750](https://github.com/ruby/rubygems/pull/9750)
* Make repeated bundle lock options accumulate [#9748](https://github.com/ruby/rubygems/pull/9748)
* Fetch Bundler metadata through Gem::Request instead of net-http-persistent [#9786](https://github.com/ruby/rubygems/pull/9786)
* Use `delete_prefix` to strip the `subjectAltName` email tag [#9797](https://github.com/ruby/rubygems/pull/9797)
* Preserve native extensions during implicit clean [#9800](https://github.com/ruby/rubygems/pull/9800)
* Resolve globbed entries literally in Gem::Util.glob_files_in_dir [#9802](https://github.com/ruby/rubygems/pull/9802)
* Show the newest out-of-cooldown version in bundle outdated [#9803](https://github.com/ruby/rubygems/pull/9803)
* Print a release notes link instead of the whole changelog on `gem update --system` [#9794](https://github.com/ruby/rubygems/pull/9794)
* Fix release date extraction for the current changelog header format [#9767](https://github.com/ruby/rubygems/pull/9767)
* Bundler::Source::Git: avoid re-fetching the repo [#9806](https://github.com/ruby/rubygems/pull/9806)
* Add an opt-in OS credential store for gem and bundler credentials [#9671](https://github.com/ruby/rubygems/pull/9671)
* Fix gemspec evaluation under Ruby::Box [#9809](https://github.com/ruby/rubygems/pull/9809)
* Cache a shared git source only once per command [#9689](https://github.com/ruby/rubygems/pull/9689)
* Make the gem CLI work under RUBY_BOX=1 [#9810](https://github.com/ruby/rubygems/pull/9810)
* Add a `prune` setting to drop rebuildable install artifacts [#9815](https://github.com/ruby/rubygems/pull/9815)
* Fix relative gemspec paths being expanded twice [#9814](https://github.com/ruby/rubygems/pull/9814)
* Rename the no_prune setting to keep_outdated_cache [#9816](https://github.com/ruby/rubygems/pull/9816)
* Error out when `bundle init --gemspec` gets no specification [#9818](https://github.com/ruby/rubygems/pull/9818)
* Only coerce exact true and false gemrc values to booleans [#9822](https://github.com/ruby/rubygems/pull/9822)
* Load RDoc before the test sandbox in TestGemRDoc [#9828](https://github.com/ruby/rubygems/pull/9828)
* Preserve non-UTF-8 legacy gem metadata [#9835](https://github.com/ruby/rubygems/pull/9835)
* Follow renamed default branch in git sources [#9813](https://github.com/ruby/rubygems/pull/9813)
* Remove Gem::BasicSpecification#datadir and check minor-release deprecation horizons [#9842](https://github.com/ruby/rubygems/pull/9842)
* Avoid duplicate relative path prefix in bundle exec [#9596](https://github.com/ruby/rubygems/pull/9596)
* rubygems: Add PQC ML-DSA support for cryptographically signed gems workflow [#9697](https://github.com/ruby/rubygems/pull/9697)
* Expand the git source gemspec path before the chdir [#9845](https://github.com/ruby/rubygems/pull/9845)
* Let the gem and bundle cooldown settings cover each other [#9852](https://github.com/ruby/rubygems/pull/9852)
* Stop depending on `getconf` in env helper specs [#9856](https://github.com/ruby/rubygems/pull/9856)
* Add content addressable gems support [#9773](https://github.com/ruby/rubygems/pull/9773)
* Use separate Bundler download and installation workers [#9777](https://github.com/ruby/rubygems/pull/9777)
* Stop installing native extension build logs [#9700](https://github.com/ruby/rubygems/pull/9700)
* Reject Bundler redirects that downgrade https to http [#9859](https://github.com/ruby/rubygems/pull/9859)
* Normalize absolute symlink targets during gem extraction [#9860](https://github.com/ruby/rubygems/pull/9860)