### PR TITLE
Cap nesting depth in Gem::SafeMarshal::Reader

### DIFF
--- a/lib/rubygems/safe_marshal/reader.rb
+++ b/lib/rubygems/safe_marshal/reader.rb
@@ -29,10 +29,14 @@ module Gem
       class LengthTooLongError < Error
       end
 
+      class TooDeeplyNestedError < Error
+      end
+
       def initialize(io)
         @io = io
         @object_links = {}
         @symbol_links = {}
+        @depth = 0
       end
 
       def read!
@@ -46,6 +50,9 @@ module Gem
 
       MARSHAL_VERSION = [Marshal::MAJOR_VERSION, Marshal::MINOR_VERSION].map(&:chr).join.freeze
       private_constant :MARSHAL_VERSION
+
+      MAX_NESTING_DEPTH = 1_000
+      private_constant :MAX_NESTING_DEPTH
 
       def read_header
         v = @io.read(2)
@@ -109,6 +116,9 @@ module Gem
       end
 
       def read_element
+        @depth += 1
+        raise TooDeeplyNestedError, "exceeded maximum nesting depth (#{MAX_NESTING_DEPTH})" if @depth > MAX_NESTING_DEPTH
+
         type = read_byte
         case type
         when 34 then read_string # ?"
@@ -139,6 +149,8 @@ module Gem
         else
           raise Error, "Unknown marshal type discriminator #{type.chr.inspect} (#{type})"
         end
+      ensure
+        @depth -= 1
       end
 
       STRING_E_SYMBOL = Elements::Symbol.new("E").freeze

--- a/test/rubygems/test_gem_safe_marshal.rb
+++ b/test/rubygems/test_gem_safe_marshal.rb
@@ -478,6 +478,35 @@ class TestGemSafeMarshal < Gem::TestCase
     assert_equal e.message, "expected 1 bytes, got EOF"
   end
 
+  def test_nesting_depth_is_capped
+    # 2 bytes per level on the wire, so this is a small payload
+    payload = "\x04\x08".b + ("[\x06".b * 2_400) + "0".b
+
+    e = assert_raise(Gem::SafeMarshal::Reader::TooDeeplyNestedError) do
+      Gem::SafeMarshal.safe_load(payload)
+    end
+    assert_equal "exceeded maximum nesting depth (1000)", e.message
+
+    # the cap raises a StandardError, so callers that already rescue
+    # StandardError around safe_load keep working
+    assert_kind_of StandardError, e
+  end
+
+  def test_nesting_below_the_cap_still_parses
+    payload = "\x04\x08".b + ("[\x06".b * 998) + "0".b
+    # deliberately not asserting on the value itself: inspecting a 998-deep
+    # array is what blows the stack, not parsing it
+    assert_equal ::Array, Gem::SafeMarshal.safe_load(payload).class
+  end
+
+  def test_repeated_siblings_do_not_count_as_depth
+    # 5_000 elements, all at depth 2 -- must not trip the cap
+    payload = "\x04\x08[".b + "\x02\x88\x13".b + ("0".b * 5_000)
+    parsed = Gem::SafeMarshal.safe_load(payload)
+    assert_equal ::Array, parsed.class
+    assert_equal 5_000, parsed.size
+  end
+
   def test_negative_length
     assert_raise(Gem::SafeMarshal::Reader::NegativeLengthError) do
       Gem::SafeMarshal.safe_load("\004\010}\325")


### PR DESCRIPTION
Opened at your request, from the closing comment on HackerOne #4013093:

> Adding a nesting cap to `Gem::SafeMarshal::Reader` symmetric with the 1000-level cap already in `yaml_serializer.rb` is worthwhile hardening, so please open it as a pull request.

### What this does

`Reader#read_element` recurses once per nested element and counts nothing, so a stream of nested arrays runs the stack down before any other limit applies. Marshal spends two bytes per level.

This adds the symmetric cap:

```ruby
MAX_NESTING_DEPTH = 1_000
```

Past it the reader raises `Reader::TooDeeplyNestedError`, which is a `Reader::Error` and therefore a `StandardError`. That matters for callers already written to tolerate a bad spec, such as `Gem::Source#fetch_spec`:

```ruby
spec = begin
         Gem::SafeMarshal.safe_load(spec)
       rescue StandardError
         nil
       end
```

A `SystemStackError` descends from `Exception`, so that rescue never sees it and the intended "skip the bad spec" path does not run. With the cap, it does.

### Depth, not width

The counter lives in `read_element` and unwinds in an `ensure`, so sibling count is unaffected:

- 998-level nest — parses
- array of 5,000 siblings — parses
- 2,400-level nest — `TooDeeplyNestedError`

`case` is untouched; the diff is 12 lines of library code.

### Tests

Three added, covering the cap, a nest just under it, and the wide-but-shallow case.

```
test/rubygems/test_gem_safe_marshal.rb   193 tests, 2218 assertions, 0 failures, 0 errors
test/rubygems/test_gem_source.rb          40 tests,  160 assertions, 0 failures, 0 errors
```

Also checked a real `rack-3.1.8` gemspec fetched from rubygems.org still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)